### PR TITLE
Dropdown positioning

### DIFF
--- a/app/components/resource-actions-menu/component.js
+++ b/app/components/resource-actions-menu/component.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import BootstrapFixes from 'ui/utils/bootstrap-fixes';
 
 export default Ember.Component.extend({
   model: null,
@@ -12,6 +13,12 @@ export default Ember.Component.extend({
   didInsertElement: function() {
     this.$().on('show.bs.dropdown', () => {
       this.set('open', true);
+    });
+
+    this.$().on('shown.bs.dropdown', (event, data) => {
+      Ember.run.next(() => {
+        BootstrapFixes.resizeDropdown(event, data);
+      });
     });
 
     this.$().on('hidden.bs.dropdown', () => {

--- a/app/initializers/extend-bootstrap.js
+++ b/app/initializers/extend-bootstrap.js
@@ -1,30 +1,8 @@
-export function initialize(/*container, application*/) {
-  // https://github.com/twbs/bootstrap/issues/10756#issuecomment-41041800
+import BootstrapFixes from 'ui/utils/bootstrap-fixes';
+
+export function initialize( /*container, application*/ ) {
   $(document).on('shown.bs.dropdown.position-calculator', function(event, data) {
-    var $item = $('.dropdown-menu', event.target);
-    var target = data.relatedTarget;
-
-    var direction = ($item.hasClass('dropdown-menu-right') ? 'right': 'left');
-
-    // reset position
-    $item.css({top:0, left:0});
-
-    // calculate new position
-    var calculator = new $.PositionCalculator({
-      item    : $item,
-      target  : target,
-      itemAt  : 'top ' + direction,
-      itemOffset: { y:3, x:0, mirror:true },
-      targetAt: 'bottom ' + direction,
-      flip    : 'both'
-    });
-    var posResult = calculator.calculate();
-
-    // set new position
-    $item.css({
-      top: posResult.moveBy.y + 'px',
-      left: posResult.moveBy.x + 'px'
-    });
+    BootstrapFixes.resizeDropdown(event, data);
   });
 }
 

--- a/app/utils/bootstrap-fixes.js
+++ b/app/utils/bootstrap-fixes.js
@@ -1,0 +1,39 @@
+export function resizeDropdown(event, data) {
+  // https://github.com/twbs/bootstrap/issues/10756#issuecomment-41041800
+  var $item = $('.dropdown-menu', event.target);
+  var target = data.relatedTarget;
+
+  var direction = ($item.hasClass('dropdown-menu-right') ? 'right' : 'left');
+
+  // reset position
+  $item.css({
+    top: 0,
+    left: 0
+  });
+
+  // calculate new position
+  var calculator = new $.PositionCalculator({
+    item: $item,
+    target: target,
+    itemAt: 'top ' + direction,
+    itemOffset: {
+      y: 3,
+      x: 0,
+      mirror: true
+    },
+    targetAt: 'bottom ' + direction,
+    flip: 'both'
+  });
+  var posResult = calculator.calculate();
+
+  // set new position
+  $item.css({
+    top: posResult.moveBy.y + 'px',
+    left: posResult.moveBy.x + 'px'
+  });
+  return null;
+}
+
+export default {
+  resizeDropdown: resizeDropdown
+};

--- a/tests/unit/utils/bootstrap-fixes-test.js
+++ b/tests/unit/utils/bootstrap-fixes-test.js
@@ -1,0 +1,10 @@
+import bootstrapFixes from '../../../utils/bootstrap-fixes';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | bootstrap fixes');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  var result = bootstrapFixes.resizeDropdown;
+  assert.ok(result);
+});


### PR DESCRIPTION
### Summary:
There was issue with drop downs that had dynamic data placed into them. The root cause comes from the size of the drop down being calculated on its inner content. The dropdown size and positioning was calculated before the content was placed inside so the dropdown showed up off screen.

### Bug Fixes/New Features
Logic was added at some point to calculate the size and position. I took this logic and made it a mixin so it could be called after the dropdown as show.

### How to Verify:
Can be verified by visiting the environments page and clicking on the active dropdown button. The drop down should appear fully on screen.

### Side Effects:
N/A

### Resolves
Fixes rancher/rancher#1923