### PR TITLE
Remove the interval check for child processes

### DIFF
--- a/app/admin-tab/processes/process/route.js
+++ b/app/admin-tab/processes/process/route.js
@@ -16,24 +16,5 @@ export default Ember.Route.extend({
         //do some errors
       });
     });
-  },
-  intervalId: null,
-  setupController: function(controller, model) {
-    this._super(controller, model);
-    const intervalCount = 2000;
-    if (!this.get('intervalId')) {
-      this.set('intervalId', setInterval(() => {
-        this.get('store').find('processInstance', this.get('params').process_id).then((processInstance) => {
-          processInstance.followLink('processExecutions').then((processExecutions) => {
-            var sorted = processExecutions.get('content').reverse();
-            processExecutions.set('content', sorted);
-            this.controller.get('model.processExecutions').replaceWith(processExecutions);
-          });
-        });
-      }, intervalCount));
-    }
-  },
-  deactivate: function() {
-    clearInterval(this.get('intervalId'));
   }
 });


### PR DESCRIPTION
### Summary:
Child processes do not need to be refreshed and doing so while keeping collapse opens its problematic. Removed the logic to refresh child processes on an interval.

### Resolves
rancher/rancher#2242