### PR TITLE
Add 'Service' question type to catalog

### DIFF
--- a/app/components/modal-catalog-launch/template.hbs
+++ b/app/components/modal-catalog-launch/template.hbs
@@ -77,7 +77,22 @@
                   {{#if (eq question.type "multiline")}}
                     {{textarea value=question.answer rows="5" class="form-control"}}
                   {{else}}
-                    Unknown question type: {{question.type}}
+                    {{#if (eq question.type 'service')}}
+                      {{#if loadingServices}}
+                          <i class="fa fa-spinner fa-spin" style="font-size:36px;"></i>
+                      {{else}}
+                        {{display-name-select
+                          classNames="form-control"
+                          content=services
+                          prompt="Choose a Service"
+                          optionLabelPath="content.stack"
+                          optionValuePath="content.stack"
+                          optionGroupPath="group"
+                          value=question.answer}}
+                      {{/if}}
+                    {{else}}
+                      Unknown question type: {{question.type}}
+                    {{/if}}
                   {{/if}}
                 {{/if}}
               {{/if}}

--- a/app/splash/template.hbs
+++ b/app/splash/template.hbs
@@ -17,9 +17,11 @@
     <h2>Adding your first Service</h2>
     <p>
       A service is simply a group of containers created from the same Docker image but extends Docker's &quot;link&quot; concept to leverage Rancher's lightweight distributed DNS service for service discovery.
+      Services can be added individually or by deploying an item from the Catalog.
       A service is also capable of leveraging other Rancher built-in services such as load balancers, health monitoring, upgrade support, and high-availability.
       <a href="http://docs.rancher.com/rancher/rancher-ui/applications/stacks/adding-services/" target="_blank">Learn More</a>
     </p>
     {{#link-to "service.new" (query-params environmentId=model.environmentId) class="btn btn-default"}}Add Service{{/link-to}}
+    {{#link-to "applications-tab.catalog" "all" class="btn btn-default"}}Add From Catalog{{/link-to}}
   </section>
 {{/unless}}


### PR DESCRIPTION
### Summary:
* Added logic to add a drop down in the event of a service question
* Add logic to parse services into an object containing `<stackname>/<servicename>` to send the correct data to the executor 
* Add logic to set default if the stack/service exists already
* Added a new catalog link to the welcome page for clarity 

### Side Effects:
N/A

### Resolves
