### PR TITLE
better catalogIcon display

### DIFF
--- a/app/applications-tab/catalog/template.hbs
+++ b/app/applications-tab/catalog/template.hbs
@@ -21,7 +21,7 @@
     <div class="col-md-12 r-pl15 r-pr15">
       {{#each arrangedContent as |catalogItem|}}
         <div class="container-catalog text-center">
-          <img src={{catalogItem.iconLink}} alt={{catalogItem.name}} class="center-block r-mt20" style="height:75px;">
+          <img src={{catalogItem.iconLink}} alt={{catalogItem.name}} class="center-block r-mt20" style="height:75px;max-width:150px">
           <div class="r-mt15">{{catalogItem.name}}</div>
           <div class="r-mt10 description">{{catalogItem.description}}</div>
           <button class="btn btn-sm btn-primary" {{action 'launch' catalogItem}}><i class="fa fa-upload"></i> Launch</button>


### PR DESCRIPTION
minor css changes. I added max-width so logos like Kibana looks better. Moreover certan svg ratio went out of the box, e.g. the logo for Plone I am adding in https://github.com/eea/rancher-catalog/tree/master/templates/plone