### PR TITLE
Removed the showdown markdown processor in favor of Commonmark.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,7 +16,8 @@
     "Identicon",
     "md5",
     "_",
-    "NoVNC"
+    "NoVNC",
+    "commonmark"
   ],
   "browser" : true,
   "boss" : true,

--- a/app/components/common-mark/component.js
+++ b/app/components/common-mark/component.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+
+  markdown: null,
+
+  cmReader: new commonmark.Parser(),
+  cmWriter: new commonmark.HtmlRenderer(),
+
+  parsedMarkdown: function() {
+
+      var parsed = this.cmReader.parse(this.get('markdown'));
+
+      return this.cmWriter.render(parsed);
+  }.property('markdown')
+});

--- a/app/components/common-mark/template.hbs
+++ b/app/components/common-mark/template.hbs
@@ -1,0 +1,1 @@
+{{{parsedMarkdown}}}

--- a/app/components/new-catalog/template.hbs
+++ b/app/components/new-catalog/template.hbs
@@ -53,7 +53,7 @@
             </span>
           </div>
           {{#liquid-if showReadme}}
-            {{markdown-to-html markdown=readmeContent}}
+            {{common-mark markdown=readmeContent}}
           {{/liquid-if}}
         </div>
       {{/if}}

--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
     "bootstrap-multiselect": "~0.9.10",
     "bootstrap-sass-official": "~3.3.1",
     "c3": "~0.4.10",
+    "commonmark": "~0.22.1",
     "dagre": "~0.7.1",
     "ember": "1.13.8",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
@@ -25,7 +26,6 @@
     "position-calculator": "~1.1.2",
     "prism": "gh-pages",
     "qunit": "~1.18.0",
-    "zeroclipboard": "~2.2.0",
-    "showdown": "~1.3.0"
+    "zeroclipboard": "~2.2.0"
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -71,6 +71,7 @@ module.exports = function(defaults) {
   app.import('bower_components/md5-jkmyers/md5.js');
   app.import('vendor/dagre-d3/dagre-d3.core.js');
   app.import('vendor/novnc.js');
+  app.import('bower_components/commonmark/dist/commonmark.js');
 
 
   app.import('vendor/icons/style.css');

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "ember-cli-qunit": "^1.0.0",
     "ember-cli-release": "0.2.3",
     "ember-cli-sass": "^5.1.0",
-    "ember-cli-showdown": "2.5.0",
     "ember-cli-sri": "^1.0.3",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-proxy-controllers": "^1.0.0",

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -21,7 +21,9 @@
     "andThen",
     "currentURL",
     "currentPath",
-    "currentRouteName"
+    "currentRouteName",
+    "NoVNC",
+    "commonmark"
   ],
   "node": false,
   "browser": false,


### PR DESCRIPTION
* Showdown had an issue with a node dependency that would break sourcemaps on require so we got rid of that.