### PR TITLE
Remove anchor tags for action menu items

### DIFF
--- a/app/components/action-menu-item/component.js
+++ b/app/components/action-menu-item/component.js
@@ -11,8 +11,6 @@ export default Ember.Component.extend({
 
   tagName           : 'a',
   classNameBindings : ['enabled::hide'],
-  attributeBindings: ['href'],
-  href: "#",
 
   click : function(event) {
 


### PR DESCRIPTION
* Anchors were causing the page to refresh. This will remove the accessabilty on these links so we need to find another way