### PR TITLE
Replace kubernetes with swarm in compose waiting template

### DIFF
--- a/app/applications-tab/compose-waiting/template.hbs
+++ b/app/applications-tab/compose-waiting/template.hbs
@@ -25,7 +25,7 @@
     <i class="icon icon-host"></i>
     <h2>Adding your first Host</h2>
     <p>
-      Before launching Kubernetes, you must first add at least one Linux host that supports Docker 1.9.1+ and be able to reach the {{settings.appName}} server via HTTP.
+      Before launching Swarm, you must first add at least one Linux host that supports Docker 1.9.1+ and be able to reach the {{settings.appName}} server via HTTP.
       {{settings.appName}} supports adding Linux hosts in the form of a virtual or physical machine from any public cloud providers, privately hosted clouds, or even bare metal servers.
       {{#unless settings.isPrivateLabel}}<a href="{{docsBase}}/rancher-ui/infrastructure/hosts/" target="_blank">Learn More</a>{{/unless}}
     </p>


### PR DESCRIPTION
Currently seeing Kubernetes show up in the swarm section when no hosts have been added. If this isn't a typo, then you can go ahead and close this.

<img width="685" alt="screen shot 2016-03-29 at 6 47 37 pm" src="https://cloud.githubusercontent.com/assets/2991219/14126402/c409aa8a-f5de-11e5-88dc-afef6f84a225.png">
