### PR TITLE
Update FAQs footer to reference valid url

### DIFF
--- a/app/components/page-footer/template.hbs
+++ b/app/components/page-footer/template.hbs
@@ -2,7 +2,7 @@
 
 {{#unless settings.isPrivateLabel}}
   <a role="button" class="btn btn-sm btn-link" target="blank" href="{{docsBase}}">Documentation</a>
-  <a role="button" class="btn btn-sm btn-link" target="blank" href="{{docsBase}}/faqs/">FAQs</a>
+  <a role="button" class="btn btn-sm btn-link" target="blank" href="{{docsBase}}/faqs/server/">FAQs</a>
   <a role="button" class="btn btn-sm btn-link" target="blank" href="{{settings.issueUrl}}">File an Issue</a>
   <a role="button" class="btn btn-sm btn-link" target="blank" href="{{forumBase}}">Forums</a>
 {{/unless}}


### PR DESCRIPTION
The _FAQs_ link along the footer is currently directing to a 404 page. This updates the link to the server section of the FAQ docs.