### PR TITLE
fixed typo in en-us.yaml translation

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -2509,7 +2509,7 @@ action:
   stop: Stop
   stopServices: Stop Services
   switchNamespace: Switch to this Namespace
-  switchEnvironment: Switch to this Envrionment
+  switchEnvironment: Switch to this Environment
   upgrade: Upgrade
   viewConfig: View Config
   viewGraph: View Graph


### PR DESCRIPTION
Typo in action: switchEnvironment fixed