### PR TITLE
load locale polyfills for non-intl supporting browsers

### DIFF
--- a/app/admin-tab/audit-logs/template.hbs
+++ b/app/admin-tab/audit-logs/template.hbs
@@ -53,7 +53,7 @@
       <tbody>
         {{#each model.auditLog as |log|}}
           <tr>
-            <td data-title="{{t 'auditLogsPage.table.time'}}:">{{format-relative log.created interval=C.LANGUAGE.FORMAT_RELATIVE_TIMEOUT}}</td>
+            <td data-title="{{t 'auditLogsPage.table.time'}}:">{{date-from-now log.created}}</td>
             <td data-title="{{t 'auditLogsPage.table.eventType'}}:" class="force-wrap" title="{{log.eventType}}">
               {{log.eventType}} <i class="icon icon-info addtl-info-trigger" {{action 'showResponseObjects' log.requestObject log.responseObject }}></i>
             </td>

--- a/config/ember-intl.js
+++ b/config/ember-intl.js
@@ -2,7 +2,7 @@
 
 module.exports = function(environment) {
   return {
-    locales: null,
+    locales: ['en-us'],
     baseLocale: 'en-us',
     disablePolyfill: false,
     publicOnly: true,

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -106,7 +106,7 @@ auditLogsPage:
       placeholder: "Auth Type:"
       dropdownPlaceholder: 'Select an Auth Type:'
       dropdownList:
-    clearButtonText: Clear All
+    clearButtonText: Clear Filters
     searchButtonText: Search
   table:
     time: Time


### PR DESCRIPTION
This should resolve the admin pages not loading but does not fix the root problem. Polyfills for english are now loaded by default but there seems to be a bug in the ember add on. I will be opening an issue there as well. (rancher/rancher#4954)

Additionally I changed the clear all to clear filters on audit logs search.