### PR TITLE
 show container logs with ansi colors

### DIFF
--- a/app/components/container-logs/component.js
+++ b/app/components/container-logs/component.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import ThrottledResize from 'ui/mixins/throttled-resize';
 import Util from 'ui/utils/util';
 import { alternateLabel } from 'ui/utils/platform';
+import AnsiUp from 'npm:ansi_up';
 
 var typeClass = {
   0: 'log-combined',
@@ -118,7 +119,7 @@ export default Ember.Component.extend(ThrottledResize, {
         body.insertAdjacentHTML('beforeend',
           '<div class="log-msg '+ typeClass[type]  +'">' +
             dateStr +
-            Util.escapeHtml(msg) +
+            AnsiUp.ansi_to_html(Util.escapeHtml(msg)) +
           '</div>'
         );
       });

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Rancher Labs, Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
+    "ansi_up": "^1.3.0",
     "broccoli-asset-rev": "^2.4.2",
     "ember-api-store": "^1.3.1",
     "ember-browserify": "^1.0.1",


### PR DESCRIPTION
This PR turns this
![image](https://cloud.githubusercontent.com/assets/3680556/18031475/ef038b88-6cb8-11e6-9cd6-9d49ce0614bb.png)
into this
![image](https://cloud.githubusercontent.com/assets/3680556/18031479/fe8529d6-6cb8-11e6-921c-cdc4b94528d1.png)
Related to https://github.com/rancher/rancher/issues/2768