### PR TITLE
prevent attempt to upload on PR with new merge behavior

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,8 @@ pipeline:
       - ENABLE_DOCKER=true UPLOAD_LATEST=true ./scripts/ci
     when:
       branch: "master"
+      event:
+        exclude: [pull_request]
 
   build:
     privileged: true


### PR DESCRIPTION
Add an exclude to 'master' build def such that it does not execute with Drone's non-default merge behavior. I suspect with the non-default merge behavior we have uncommitted changes in the work directory but git still thinks we are on unadulterated master/HEAD?

@cloudnautique @vincent99 