### PR TITLE
Refactor catalog item question css

### DIFF
--- a/app/admin-tab/auth/localauth/controller.js
+++ b/app/admin-tab/auth/localauth/controller.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import C from 'ui/utils/constants';
 
 export default Ember.Controller.extend({
   access            : Ember.inject.service(),
@@ -19,6 +20,10 @@ export default Ember.Controller.extend({
     var ok = this.get('adminPublicValue.length') && this.get('adminSecretValue.length') && (this.get('adminSecretValue') === this.get('adminSecretValue2'));
     return !ok;
   }.property('adminPublicValue','adminSecretValue','adminSecretValue2'),
+
+  validateDescription: Ember.computed(function() {
+    return this.get('settings').get(C.SETTING.AUTH_LOCAL_VALIDATE_DESC) || null;
+  }),
 
   actions: {
     test: function() {

--- a/app/admin-tab/auth/localauth/template.hbs
+++ b/app/admin-tab/auth/localauth/template.hbs
@@ -54,6 +54,7 @@
         <div class="form-group">
           <label>{{t 'authPage.localAuth.accessDisabled.form.password.labelText'}}*</label>
           {{input type="password" value=adminSecretValue classNames="form-control"}}
+          <div class="help-block">{{validateDescription}}</div>
         </div>
       </div>
       <div class="col-md-6">

--- a/app/admin-tab/machine/template.hbs
+++ b/app/admin-tab/machine/template.hbs
@@ -41,7 +41,13 @@
             {{/if}}
           </div>
         </div>
-        <div class="catalog-icon r-mb10 {{if (or driver.builtin driver.hasBuiltinUi) driver.iconMapFromConstants 'generic'}}"/>
+        {{#if driver.iconMapFromConstants}}
+          <div class="catalog-icon r-mb10 {{driver.iconMapFromConstants}}"/>
+        {{else if driver.machineHasIcon driver}}
+          <div class="catalog-icon r-mb10" style="background-image:url({{driver.machineHasIcon}});"/>
+        {{else}}
+          <div class="catalog-icon r-mb10 generic"/>
+        {{/if}}
       {{else if (eq section 'footer')}}
         {{#if (and driver.externalId (not-eq driver.state 'inactive'))}}
           {{upgrade-dropdown model=driver btnClass="btn-sm" currentId=driver.externalId upgradeOnly=false changeVersion=(action "upgradeDriver" driver)}}

--- a/app/authenticated/project/help/template.hbs
+++ b/app/authenticated/project/help/template.hbs
@@ -18,7 +18,7 @@
 
 <section>
   <div class="flex-wrap">
-    <div class="flex-item">
+    <div class="flex-item-third">
       <div class="flex-content well">
         <h3>{{t 'helpPage.environment.header'}}</h3>
         <hr/>
@@ -27,7 +27,7 @@
       </div>
     </div>
 
-    <div class="flex-item">
+    <div class="flex-item-third">
       <div class="flex-content well">
         <h3>{{t 'helpPage.host.header'}}</h3>
         <hr/>
@@ -36,7 +36,7 @@
       </div>
     </div>
 
-    <div class="flex-item">
+    <div class="flex-item-third">
       <div class="flex-content well">
         <h3>{{t 'helpPage.stacks.header'}}</h3>
         <hr/>

--- a/app/components/form-networking/component.js
+++ b/app/components/form-networking/component.js
@@ -4,17 +4,19 @@ import ManageLabels from 'ui/mixins/manage-labels';
 import C from 'ui/utils/constants';
 
 export default Ember.Component.extend(ManageLabels, ContainerChoices,{
-  settings      : Ember.inject.service(),
+  settings:            Ember.inject.service(),
 
   //Inputs
-  instance      : null,
-  isService     : null,
-  allHosts      : null,
-  errors        : null,
-  initialLabels : null,
+  instance:            null,
+  isService:           null,
+  allHosts:            null,
+  errors:              null,
+  initialLabels:       null,
+  isUpgrade:           false,
+  retainWasSetOnInit:  false,
+  editing:             true,
 
   classNameBindings: ['editing:component-editing:component-static'],
-  editing: true,
 
   init() {
     this._super(...arguments);
@@ -25,6 +27,9 @@ export default Ember.Component.extend(ManageLabels, ContainerChoices,{
     this.initDnsDiscovery();
     this.initDnsResolver();
     this.initDnsSearch();
+    if (this.get('service.retainIp')) {
+      this.set('retainWasSetOnInit', this.get('service.retainIp'));
+    }
   },
 
   actions: {
@@ -42,6 +47,17 @@ export default Ember.Component.extend(ManageLabels, ContainerChoices,{
       this.get('dnsSearchArray').removeObject(obj);
     },
   },
+
+  canUpdateRetainIp: Ember.computed('isUpgrade', 'service.retainIp', 'retainWasSetOnInit', function() {
+    let isUpgrade = this.get('isUpgrade');
+    let retained = this.get('service.retainIp');
+    let wasNotSet = this.get('retainWasSetOnInit');
+    if (retained && isUpgrade && wasNotSet) {
+      return true;
+    } else {
+      return false;
+    }
+  }),
 
   updateLabels(labels) {
     this.sendAction('setLabels', labels);

--- a/app/components/form-networking/template.hbs
+++ b/app/components/form-networking/template.hbs
@@ -46,7 +46,7 @@
       {{/input-or-display}}
     </div>
   </div>
-  {{#if isService}}
+  {{#if (and isService (not isSidekick))}}
     <div class="row">
       <div class="col-sm-12 col-md-2 form-label">
         <label class="form-control-static">{{t 'formNetwork.retainIp.label'}}</label>
@@ -54,7 +54,7 @@
 
       <div class="col-sm-12 col-md-8">
         {{#input-or-display editable=editing value=service.retainIp}}
-          <label class="form-control-static radio small">{{input type="checkbox" checked=service.retainIp}} {{t 'formNetwork.retainIp.reuse'}}</label>
+          <label class="form-control-static radio small">{{input type="checkbox" checked=service.retainIp disabled=isUpgrade}} {{t 'formNetwork.retainIp.reuse'}}</label>
         {{/input-or-display}}
       </div>
     </div>

--- a/app/components/new-catalog/template.hbs
+++ b/app/components/new-catalog/template.hbs
@@ -68,6 +68,7 @@
         optionLabelPath="version"
         optionValuePath="link"
         value=selectedTemplateUrl
+        disabled=loading
       }}
       <p class="help-block">{{t (if editing selectVersionUpgrade selectVersionAdd)}}</p>
     </div>
@@ -99,24 +100,26 @@
       <h4>{{t 'newCatalog.config'}}</h4>
       <hr/>
 
-      <div class="row"><div class="col-sm-12"><div class="row">
+      <div class="container-flex">
         {{#each selectedTemplateModel.questions as |question|}}
-          <div class="col-sm-12 {{if (eq selectedTemplateModel.questions.length 1) 'col-md-12' 'col-md-6'}} form-label r-mb10">
-            <label class="form-label form-control-static">{{question.label}}{{if question.required "*"}}</label>
+          <div class="flex-item-half">
+            <div class="col-sm-12 form-label r-mb10">
+              <label class="form-label form-control-static">{{question.label}}{{if question.required "*"}}</label>
 
-            {{#if question.supported}}
-              {{component question.inputComponent field=question value=question.answer}}
-            {{else}}
-              {{input type="text" value=question.answer class="form-control"}}
-              <p>{{t 'newCatalog.unknownType'}} {{question.type}}</p>
-            {{/if}}
+              {{#if question.supported}}
+                {{component question.inputComponent field=question value=question.answer}}
+              {{else}}
+                {{input type="text" value=question.answer class="form-control"}}
+                <p>{{t 'newCatalog.unknownType'}} {{question.type}}</p>
+              {{/if}}
 
-            <p class="help-block">{{question.description}}</p>
+              <p class="help-block">{{question.description}}</p>
+            </div>
           </div>
         {{else}}
           <span class="text-muted">{{t 'newCatalog.noConfig'}}</span>
         {{/each}}
-      </div></div></div>
+      </div>
       {{#if (and (not editing) (eq templateBase ""))}}
         <div class="row r-mt20">
           <div class="col-md-12">

--- a/app/components/new-container/template.hbs
+++ b/app/components/new-container/template.hbs
@@ -142,7 +142,9 @@
           allHosts=allHosts
           service=service
           isService=isService
+          isSidekick=isSidekick
           initialLabels=launchConfig.labels
+          isUpgrade=isUpgrade
           setLabels=(action 'setLabels' 'networking')
         }}
       </div>

--- a/app/components/new-select/component.js
+++ b/app/components/new-select/component.js
@@ -12,6 +12,8 @@ export default Ember.Component.extend({
   action: Ember.K, // action to fire on change
   value: null,
   localizedLabel: false,
+  disabled: false,
+  attributeBindings: ['disabled'],
 
   ungroupedContent: null,
   groupedContent: null,

--- a/app/models/template.js
+++ b/app/models/template.js
@@ -42,6 +42,15 @@ export default Resource.extend({
     return name;
   }),
 
+  machineHasIcon: Ember.computed('templateBase', function(){
+    if (this.get('templateBase') === 'machine') {
+      if (this.get('links.icon')) {
+        return this.get('links.icon');
+      }
+    }
+    return false;
+  }),
+
   supportsOrchestration(orch) {
     orch = orch.replace(/.*\*/,'');
     if ( orch === 'k8s' ) {

--- a/app/service/controller.js
+++ b/app/service/controller.js
@@ -7,7 +7,13 @@ export default Ember.Controller.extend({
 
   actions: {
     changeService(service) {
-      this.transitionToRoute(this.get('application.currentRouteName'), service.get('id'));
+      var transitionTo = this.get('application.currentRouteName');
+
+      if (service.type === 'dnsService') {
+        transitionTo = 'service.links';
+      }
+
+      this.transitionToRoute(transitionTo, service.get('id'));
     }
   }
 });

--- a/app/service/template.hbs
+++ b/app/service/template.hbs
@@ -44,8 +44,8 @@
             {{if service.isGlobalScale (t 'servicePage.multistat.global') (t 'generic.na')}}
           {{/if}}
         </div>
-        <hr>
         {{#if service.hasImage}}
+        <hr>
 
             <div>
               <label class="block">{{t 'servicePage.multistat.image'}}</label>

--- a/app/styles/layout/_flex-box.scss
+++ b/app/styles/layout/_flex-box.scss
@@ -32,7 +32,12 @@
   flex-wrap: wrap;
   margin: -10px -0.5em 0 -0.5em;
 }
-.flex-item {
+.flex-item-half {
+  flex-grow: 1;
+  display: flex;
+  width: 50%;
+}
+.flex-item-third {
   flex-grow: 1;
   display: flex;
   padding: 0 0.5em 0 0.5em;

--- a/app/styles/layout/_sm-screen.scss
+++ b/app/styles/layout/_sm-screen.scss
@@ -70,6 +70,11 @@
 
 /*695-959*/
 @media (max-width: $screen-sm-max) {
+
+  .flex-item-half {
+    width: 100%;
+  }
+
   .stack-section {
     .header-right {
       width: 20%;

--- a/app/templates/ldap-config.hbs
+++ b/app/templates/ldap-config.hbs
@@ -153,42 +153,50 @@
         <h4>{{t 'ldap.customizeSchema.users.header'}}</h4>
         <div class="form-group">
           <label>{{t 'ldap.customizeSchema.users.objectClass.labelText'}}</label>
-          {{input type="text" value=model.userObjectClass type="text" classNames="form-control"}}
+          {{input type="text" value=model.userObjectClass classNames="form-control"}}
         </div>
         <div class="form-group">
           <label>{{t 'ldap.customizeSchema.users.login.labelText'}}</label>
-          {{input type="text" value=model.userLoginField type="text" classNames="form-control"}}
+          {{input type="text" value=model.userLoginField classNames="form-control"}}
         </div>
         <div class="form-group">
           <label>{{t 'ldap.customizeSchema.users.name.labelText'}}</label>
-          {{input type="text" value=model.userNameField type="text" classNames="form-control"}}
+          {{input type="text" value=model.userNameField classNames="form-control"}}
         </div>
         <div class="form-group">
           <label>{{t 'ldap.customizeSchema.users.search.labelText'}}</label>
-          {{input type="text" value=model.userSearchField type="text" classNames="form-control"}}
+          {{input type="text" value=model.userSearchField classNames="form-control"}}
         </div>
         <div class="form-group">
           <label>{{t 'ldap.customizeSchema.users.status.labelText'}}</label>
-          {{input type="text" value=model.userEnabledAttribute type="text" classNames="form-control"}}
+          {{input type="text" value=model.userEnabledAttribute classNames="form-control"}}
         </div>
         <div class="form-group">
           <label>{{t 'ldap.customizeSchema.users.disabledBitMask.labelText'}}</label>
-          {{input type="text" value=model.userDisabledBitMask type="number" min=1 classNames="form-control"}}
+          {{input type="number" value=model.userDisabledBitMask min=1 classNames="form-control"}}
         </div>
       </div>
       <div class="col-md-6">
         <h3>{{t 'ldap.customizeSchema.groups.header'}}</h3>
         <div class="form-group">
           <label>{{t 'ldap.customizeSchema.groups.objectClass.labelText'}}</label>
-          {{input type="text" value=model.groupObjectClass type="text" classNames="form-control"}}
+          {{input type="text" value=model.groupObjectClass classNames="form-control"}}
         </div>
         <div class="form-group">
           <label>{{t 'ldap.customizeSchema.groups.name.labelText'}}</label>
-          {{input type="text" value=model.groupNameField type="text" classNames="form-control"}}
+          {{input type="text" value=model.groupNameField classNames="form-control"}}
         </div>
         <div class="form-group">
           <label>{{t 'ldap.customizeSchema.groups.search.labelText'}}</label>
-          {{input type="text" value=model.groupSearchField type="text" classNames="form-control"}}
+          {{input type="text" value=model.groupSearchField classNames="form-control"}}
+        </div>
+        <div class="form-group">
+          <label>{{t 'ldap.customizeSchema.groups.groupMemberUser.labelText'}}</label>
+          {{input type="text" value=model.groupMemberUserAttribute classNames="form-control" placeholder=(t 'ldap.customizeSchema.groups.groupMemberUser.placeholder')}}
+        </div>
+        <div class="form-group">
+          <label>{{t 'ldap.customizeSchema.groups.groupDN.labelText'}}</label>
+          {{input type="text" value=model.groupDNField classNames="form-control" placeholder=(t 'ldap.customizeSchema.groups.groupDN.placeholder')}}
         </div>
       </div>
     </div>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1368,6 +1368,12 @@ ldap:
         labelText: Name Field
       search:
         labelText: Search Field
+      groupMemberUser:
+        labelText: Group Member User Attribute
+        placeholder: uid
+      groupDN:
+        labelText: Group DN Field
+        placeholder: distinguishedName
   testAuth:
     header: "3. Test and enable authentication"
     helpText: "Check that everything is configured correctly by testing authentication with your {providerName} account:"


### PR DESCRIPTION
rancher/rancher#6364

Change logic around retain ip on upgrade

rancher/rancher#5410

Refactor retainIp prop on services

@vincent99 and I had a discussion. Since retainIp is a service level
setting it does not make sense (nor did it ever work) to have retainIp
on sidekicks. So the setting has been removed from that screen. Additionally
since an upgrade does not modify the service but rather the launch config
turning Retain IP on/off during the upgrade does not work. The new requirement
is to disable the checkbox during an upgrade. The upgrade should retain the
origianl value.

rancher/rancher#5410

add password validate desc to local auth config page

rancher/rancher#6362

Change the way stack graph handles route transitions

rancher/rancher#6343

Prevent user from selecting a new catalog template

until the previous one loads

rancher/rancher#6166

Ensure ext service only shows the label outlet

rancher/rancher#5927

Remove double hr element when service doesnt have image

rancher/rancher#5850

Refactor how machine driver icons are displayed

rancher/rancher#5738

Add new fields to ldap config

rancher/rancher#3875