### PR TITLE
Improve readability of code blocks

### DIFF
--- a/app/styles/vendors/_prism-theme.scss
+++ b/app/styles/vendors/_prism-theme.scss
@@ -6,8 +6,7 @@
 
 code[class*="language-"],
 pre[class*="language-"] {
-  color: #a3cfbb;
-  text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+  color: #236f2b;
   font-family: Consolas, Monaco, 'Andale Mono', monospace;
   direction: ltr;
   text-align: left;


### PR DESCRIPTION
Before:

<img width="887" alt="screen shot 2016-11-23 at 2 46 16 pm" src="https://cloud.githubusercontent.com/assets/1197375/20576427/ed335f82-b18b-11e6-813d-bbc9b4a09afe.png">

After:

<img width="889" alt="screen shot 2016-11-23 at 2 48 28 pm" src="https://cloud.githubusercontent.com/assets/1197375/20576432/f00915da-b18b-11e6-819e-50117d96ee08.png">
