### PR TITLE
Fixed variable mismatch for Packet cloud facility

### DIFF
--- a/app/components/machine/driver-packet/template.hbs
+++ b/app/components/machine/driver-packet/template.hbs
@@ -62,9 +62,9 @@
         <label class="form-control-static">{{t 'machine.driverPacket.region.label'}}</label>
       </div>
       <div class="col-md-10">
-        <select class="form-control" onchange={{action (mut packetConfig.facility) value="target.value"}}>
+        <select class="form-control" onchange={{action (mut packetConfig.facilityCode) value="target.value"}}>
           {{#each facilityChoices as |choice|}}
-            <option value={{choice.code}} selected={{eq packetConfig.facility choice.code}}>{{choice.name}}</option>
+            <option value={{choice.code}} selected={{eq packetConfig.facilityCode choice.code}}>{{choice.name}}</option>
           {{/each}}
         </select>
       </div>


### PR DESCRIPTION
On v1.2.0GA, Packet ui-skelton included variable mismatch between component.js and template.hbs and this PR will enable to deploy machines on several Packet clouds regions.