### PR TITLE
add transplation for ecl machine catalog

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -2725,6 +2725,21 @@ machine:
       label: SSH Password
       placeholder: Set Instance SSH Password, Blank for Auto set
 
+  driverEcl:
+    accountAccess:
+      apiEndpoint: Keystone API Endpoint*
+      tenantId: Tenant ID*
+      username: Username*
+      password: Password*
+    instance:
+      flavorName: Flavor Name*
+      imageId: Image ID*
+      sshPort: SSH Port
+      sshUser: SSH User
+      networkId: Network ID*
+      availabilityZone: Availability Zone
+      userDataFile: User Data File
+
 modalAboutComponent:
   component: Component
   version: Version

--- a/translations/ja-jp.yaml
+++ b/translations/ja-jp.yaml
@@ -2398,6 +2398,20 @@ machine:
     sshPassword:
       label: SSH のパスワード
       placeholder: インスタンスの SSH パスワードを設定してください。自動設定するには空白を指定してください。
+  driverEcl:
+    accountAccess:
+      apiEndpoint: Keystone API エンドポイント*
+      tenantId: テナント ID*
+      username: ユーザー名*
+      password: パスワード*
+    instance:
+      flavorName: フレーバー名*
+      imageId: イメージID*
+      sshPort: SSH ポート
+      sshUser: SSH ユーザー
+      networkId: ネットワーク ID*
+      availabilityZone: アベイラビリティゾーン
+      userDataFile: ユーザーデータファイル
 modalAboutComponent:
   component: コンポーネント
   version: バージョン


### PR DESCRIPTION
Add translation parameter for ECL machine driver catalog.

[template.hbs](https://github.com/mittz/ui-driver-ecl/blob/v1.1.0/component/template.hbs) will be applied to machine driver in community catalog after this pr is merged.