### PR TITLE
[1.6] Support Alibaba Cloud Docker Hub webhook

### DIFF
--- a/app/components/webhook/new-receiver/component.js
+++ b/app/components/webhook/new-receiver/component.js
@@ -41,13 +41,16 @@ export default Ember.Component.extend(NewOrEdit, {
       });
       break;
     case 'serviceUpgrade':
+      const serviceUpgradeSchema = this.get('webhookStore').getById('schema','serviceupgrade');
+      const resourceFields = serviceUpgradeSchema.resourceFields;
       def = store.createRecord({
         type: 'serviceUpgrade',
         tag: '',
         serviceSelector: '',
-        batchSize: 1,
-        interval: 2,
-        startFirst: false,
+        batchSize: resourceFields.batchSize.default,
+        interval: resourceFields.intervalMillis.default,
+        payloadFormat: resourceFields.payloadFormat.default,
+        startFirst: resourceFields.startFirst.default
       });
       break;
     }

--- a/app/components/webhook/new-receiver/template.hbs
+++ b/app/components/webhook/new-receiver/template.hbs
@@ -19,9 +19,9 @@
       </div>
       <div>
         <select class="form-control" onchange={{action "changeDriver"}}>
-          <option value="scaleService">{{t 'hookPage.scaleService.label'}}</option>
-          <option value="scaleHost">{{t 'hookPage.scaleHost.label'}}</option>
-          <option value="serviceUpgrade">{{t 'hookPage.serviceUpgrade.label'}}</option>
+          <option value="scaleService" selected={{eq model.driver 'scaleService'}} >{{t 'hookPage.scaleService.label'}}</option>
+          <option value="scaleHost" selected={{eq model.driver 'scaleHost'}} >{{t 'hookPage.scaleHost.label'}}</option>
+          <option value="serviceUpgrade" selected={{eq model.driver 'serviceUpgrade'}} >{{t 'hookPage.serviceUpgrade.label'}}</option>
         </select>
       </div>
     </div>

--- a/app/components/webhook/service-upgrade-config/component.js
+++ b/app/components/webhook/service-upgrade-config/component.js
@@ -2,9 +2,24 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   tagName: '',
+  payloadFormatChoices: null,
+
+  init() {
+    this._super(...arguments);
+    this.initPayloadFormatChoices();
+  },
+
+  initPayloadFormatChoices() {
+    const serviceUpgradeSchema = this.get('webhookStore').getById('schema', 'serviceupgrade');
+    const payloadFormatSchema = serviceUpgradeSchema.resourceFields.payloadFormat;
+    const choices = payloadFormatSchema.options.map(option => {
+      return { label: `newReceiver.payloadFormat.${option}`, value: option };
+    });
+    this.set('payloadFormatChoices', choices);
+  },
 
   actions: {
-    optionsChanged: function(opt) {
+    optionsChanged: function (opt) {
       this.get('model').setProperties(opt);
     }
   }

--- a/app/components/webhook/service-upgrade-config/template.hbs
+++ b/app/components/webhook/service-upgrade-config/template.hbs
@@ -1,6 +1,22 @@
 <div class="row form-group">
   <div class="col-md-6 col-md-offset-3">
     <div class="form-label form-control-static">
+      <label>{{t 'newReceiver.payloadFormat.label'}}</label>
+    </div>
+    <div>
+      {{new-select
+        classNames="form-control"
+        content=payloadFormatChoices
+        localizedLabel=true
+        value=model.payloadFormat
+      }}
+    </div>
+  </div>
+</div>
+
+<div class="row form-group">
+  <div class="col-md-6 col-md-offset-3">
+    <div class="form-label form-control-static">
       <label>{{t 'newReceiver.tag.label'}}*</label>
     </div>
     <div>
@@ -44,7 +60,7 @@
       <label>{{t 'formUpgrade.interval'}}</label>
     </div>
     <div class="input-group">
-      {{input-integer class="form-control" value=model.interval}}
+      {{input-integer class="form-control" value=model.intervalMillis}}
       <span class="input-group-addon">{{t 'formUpgrade.sec'}}</span>
     </div>
   </div>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -2993,6 +2993,10 @@ newReceiver:
   max:
     label: Maximum Scale
     placeholder: e.g. 20
+  payloadFormat:
+    label: Webhook Payload Format
+    alicloud: Alibaba Cloud Docker Hub
+    dockerhub: Docker Hub
   tag:
     label: Image Tag
     placeholder: "e.g. latest"

--- a/translations/zh-hans.yaml
+++ b/translations/zh-hans.yaml
@@ -2911,6 +2911,10 @@ newReceiver:
   max:
     label: 最大数量
     placeholder: '例如: 20'
+  payloadFormat:
+    label: 镜像仓库Webhook参数格式
+    alicloud: 阿里云
+    dockerhub: Docker Hub
   tag:
     label: 镜像标签
     placeholder: "例如: latest"


### PR DESCRIPTION
payload of Alibaba Cloud Docker Hub's webhook is slightly different from Docker Hub.
PR for webhook-service change is [here](https://github.com/rancher/webhook-service/pull/60)
So I have added an option in UI for it [#9175](https://github.com/rancher/rancher/issues/9175)
Also fixed the issues [#7996](https://github.com/rancher/rancher/issues/7996) and [#9022](https://github.com/rancher/rancher/issues/9022)

![image](https://user-images.githubusercontent.com/21168270/29991798-4954fc68-8fc0-11e7-895e-cbbf6b8b87e2.png)

![image](https://user-images.githubusercontent.com/21168270/29991802-5974fa9e-8fc0-11e7-9dd0-507df08d4f88.png)
