### PR TITLE
Fix bug with error page from Up to date button

### DIFF
--- a/app/components/upgrade-dropdown/template.hbs
+++ b/app/components/upgrade-dropdown/template.hbs
@@ -1,9 +1,6 @@
-<button type="button" class="btn {{color}} {{btnClass}}" {{action "doUpgrade"}}>
-  {{t (concat-str 'upgradeBtn.status.' upgradeStatus character='')}}
-</button>
 {{~#if showDropdown~}}
   <button type="button" class="btn {{color}} {{btnClass}} dropdown-toggle" data-toggle="dropdown" aria-expanded="true">
-    <i class="icon icon-fw icon-chevron-down"></i>
+    {{t (concat-str 'upgradeBtn.status.' upgradeStatus character='')}}
     <span class="sr-only">{{t 'nav.srToggleDropdown'}}</span>
   </button>
   <ul class="dropdown-menu dropdown-menu-right" role="menu">
@@ -15,4 +12,8 @@
       </li>
     {{/each-in}}
   </ul>
+{{else}}
+  <button type="button" class="btn {{color}} {{btnClass}}">
+    {{t (concat-str 'upgradeBtn.status.' upgradeStatus character='')}}
+  </button>
 {{/if}}


### PR DESCRIPTION
I replace the `icon` with `button`, so that it look like the follow picture

![image](https://user-images.githubusercontent.com/18737885/31374641-614f6788-ad64-11e7-83b4-57ff349a2f6f.png)
![image](https://user-images.githubusercontent.com/18737885/31374645-65ef477c-ad64-11e7-848f-c77188f2be72.png)
