### PR TITLE
Fix the select render issue in Firefox

### DIFF
--- a/app/components/new-select/component.js
+++ b/app/components/new-select/component.js
@@ -67,6 +67,21 @@ export default Ember.Component.extend({
     this.on('change', this, this._change);
   },
 
+  didRender: function () {
+    const selectEl = this.$()[0];
+    const value = this.get('value');
+    for (let i = 0; i < selectEl.options.length; i++) {
+      if(selectEl.options[i].value === value) {
+        selectEl.value = value;
+        break;
+      }
+    }
+
+    if (value !== selectEl.value) {
+      this._change();
+    }
+  },
+
   willDestroyElement() {
     this.off('change', this, this._change);
   },


### PR DESCRIPTION
If there is a matching value in options,  set the value manually to avoid the Firefox issue emberjs/ember.js#15484

In chrome and Firefox, the first option will be selected automatically when the value is not in the content array. But we need to trigger the change event, otherwise the value in the model will not be updated.

https://github.com/rancher/rancher/issues/10242
https://github.com/rancher/rancher/issues/10241