### PR TITLE
Add new tab as service access point to Rancher UI 1.6

### DIFF
--- a/app/components/page-header/component.js
+++ b/app/components/page-header/component.js
@@ -36,6 +36,7 @@ export default Ember.Component.extend(HoverDropdown, {
   swarmReady           : Ember.computed.alias('projects.orchestrationState.swarmReady'),
   mesosReady           : Ember.computed.alias('projects.orchestrationState.mesosReady'),
   stacks               : null,
+  services             : null,
 
   // Component options
   tagName              : 'header',
@@ -51,6 +52,7 @@ export default Ember.Component.extend(HoverDropdown, {
   init() {
     this._super(...arguments);
     this.set('stacks', this.get('store').all('stack'));
+    this.set('services', this.get('store').all('service'));
     this.set('hosts', this.get('store').all('host'));
     this.set('stackSchema', this.get('store').getById('schema','stack'));
     this.updateNavTree();
@@ -59,7 +61,27 @@ export default Ember.Component.extend(HoverDropdown, {
   // This computed property generates the active list of choices to display
   navTree: null,
   updateNavTree() {
-    let out = getTree().filter((item) => {
+    let services = this.get('services');
+    let servicesNav = [];
+    if(services){
+      services.forEach((ele)=>{
+        let serviceApp = ele.get('serviceApp');
+        if(serviceApp){
+          let exist = getTree().findBy('id', ele.id);
+          if(!exist){
+            servicesNav.pushObject({
+              id: ele.id,
+              label: serviceApp.label,
+              url: serviceApp.url,
+              target: '_blank',
+              ctx: [this.get('projectId')],
+            });
+          }
+        }
+      });
+    }
+
+    let out = getTree().concat(servicesNav).filter((item) => {
       if ( typeof item.condition === 'function' )
       {
         if ( !item.condition.call(this) )
@@ -109,6 +131,7 @@ export default Ember.Component.extend(HoverDropdown, {
     'projects.orchestrationState',
     'project.virtualMachine',
     'stacks.@each.group',
+    'services.@each.serviceApp',
     'catalog.catalogs.@each.{id,name}',
     `settings.${C.SETTING.CATALOG_URL}`,
     `prefs.${C.PREFS.ACCESS_WARNING}`,

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -186,6 +186,9 @@ var C = {
     LAUNCH_CONFIG: 'io.rancher.service.launch.config',
     LAUNCH_CONFIG_PRIMARY: 'io.rancher.service.primary.launch.config',
     SIDEKICK: 'io.rancher.sidekicks',
+    SERVICE_UI_PATH: 'io.rancher.service.ui_link.path',
+    SERVICE_UI_PORT: 'io.rancher.service.ui_link.port',
+    SERVICE_UI_LABEL: 'io.rancher.service.ui_link.label',
   },
 
   PREFS: {


### PR DESCRIPTION
# Implement a generic mechanism to support any service to add a new header tab as its access point

## Why do we need this?
To support Pipeline or other services's access point in the UI

## How it works?
User need to add three label to the service which need access point in page header.

1. `io.rancher.service.ui_link.label` -- This is the label show in the page header. This should be a JSON map used for i18n. it's like 
  ```JSON
  {"de-de":"Deutsch","en-us":"English","fa-ir":"فارسی","fr-fr":"Française","hu-hu":"Magyar","ja-jp":"日本語","none":"None","pt-br":"Português","ru-ru":"Русский","uk-ua":"Українська","zh-hans":"简体中文"}
  ```
	
2.  `io.rancher.service.ui_link.path` -- This is the relative router in it's own app. Default will be '/'.
	
3. `io.rancher.service.ui_link.port` -- This is the private port where the UI is hosted

All of these three label will be combined as access url for magic_proxy, as `${window.location.origin}${this.get('app.magicEndpoint')}/projects/${this.get('projectId')}/${serviceName}/${serviceAppUI}`.
The label `io.rancher.service.ui_link.label`  is the key label to detect whether this service need access point or not. The other two labels is optional.

Related issus is [here](https://github.com/rancher/rancher/issues/10332)