### PR TITLE
Filter driver `forwardPost` of webhook-service in UI

### DIFF
--- a/app/authenticated/project/api/hooks/index/controller.js
+++ b/app/authenticated/project/api/hooks/index/controller.js
@@ -4,7 +4,10 @@ import Sortable from 'ui/mixins/sortable';
 export default Ember.Controller.extend(Sortable, {
   settings: Ember.inject.service(),
 
-  sortableContent: Ember.computed.alias('model.receivers'),
+  sortableContent: function() {
+    let receivers = this.get('model.receivers');
+    return receivers.filter(ele => ele.driver !== 'forwardPost');
+  }.property('model.receivers.@each.driver'),
   sortBy: 'name',
   sorts: {
     state:        ['stateSort','name','id'],


### PR DESCRIPTION
Since the [PR](https://github.com/rancher/webhook-service/pull/66) to add new driver `forwardPost` is merged.

We currently just keep `forwardPost` for internal usage. So, users should not be able to see it.

Related Issue is [here](https://github.com/rancher/rancher/issues/10479)