### PR TITLE
[1.6]Enhance Windows Environment Experience

### DIFF
--- a/app/components/edit-host/component.js
+++ b/app/components/edit-host/component.js
@@ -15,7 +15,7 @@ export default ModalBase.extend(NewOrEdit, ManageLabels, {
   ips: null,
   requireAny: null,
   requiredIfAny: {[C.LABEL.SYSTEM_TYPE]: ''},
-  readonlyLabels: [C.LABEL.PER_HOST_SUBNET],
+  readonlyLabels: [C.LABEL.PER_HOST_SUBNET,C.LABEL.PER_HOST_SUBNET_ROUTING_IP],
   systemLabels: null,
   userLabels: null,
 

--- a/app/components/form-networking/component.js
+++ b/app/components/form-networking/component.js
@@ -78,7 +78,7 @@ export default Ember.Component.extend(ManageLabels, ContainerChoices,{
     if ( this.get('projects.current.isWindows') ) {
       choices = ['nat','transparent'];
       if ( mode === 'managed' ) {
-        this.set('instance.networkMode','nat');
+        this.set('instance.networkMode','transparent');
       }
     }
 

--- a/app/components/machine/driver-custom/template.hbs
+++ b/app/components/machine/driver-custom/template.hbs
@@ -6,38 +6,66 @@
         <ul class="list-circles list-circles-clear">
           <li>
             <i>1</i>
-            {{format-html-message 'machine.driverCustom.windows.step1'}}
+            {{format-html-message 'machine.driverCustom.windowsSteps.step1'}}
           </li>
           <li>
             <i>2</i>
-            {{format-html-message 'machine.driverCustom.windows.step2'}}
+            {{format-html-message 'machine.driverCustom.windowsSteps.step2'}}
             <div class="copy-pre">
-              <pre id="network-command">{{t 'machine.driverCustom.windows.step2Copy'}}</pre>
-              {{copy-to-clipboard clipboardText=(t 'machine.driverCustom.windows.step2Copy')}}
+              <pre id="network-command">{{t 'machine.driverCustom.windowsSteps.step2Copy'}}</pre>
+              {{copy-to-clipboard clipboardText=(t 'machine.driverCustom.windowsSteps.step2Copy')}}
             </div>
           </li>
           <li>
             <i>3</i>
-            {{t 'machine.driverCustom.windows.step3' appName=settings.appName}}
+            {{format-html-message 'machine.driverCustom.windowsSteps.step3' rancherImage=settings.rancherImage}}
+            <div class="checkbox r-mt10">
+              {{input type="text" value=subnet classNames="form-control" input=(action 'subnetOnChange') placeholder=(t 'machine.driverCustom.windowsSteps.subnet.placeholder')}}
+            </div>
+          </li>
+          <li>
+            <i>4</i>
+            {{format-html-message 'machine.driverCustom.windowsSteps.step4' rancherImage=settings.rancherImage}}
+            <div class="checkbox r-mt10">
+              {{input type="text" value=routerIp classNames="form-control" input=(action 'subnetOnChange') placeholder=(t 'machine.driverCustom.windowsSteps.routerIp.placeholder')}}
+            </div>
+          </li>
+          <li>
+            <i>5</i>
+            {{format-html-message 'machine.driverCustom.windowsSteps.step5' rancherImage=settings.rancherImage}}
+            <div class="checkbox r-mt10">
+              {{input type="text" value=cattleAgentIp classNames="form-control" placeholder=(t 'machine.driverCustom.agentIp.placeholder')}}
+            </div>
+          </li>
+          <li>
+            <i>6</i>
+            {{t 'machine.driverCustom.windowsSteps.step6'}}
+            <div class="r-mt10">
+              {{form-user-labels setLabels=(action 'setLabels')}}
+            </div>
+          </li>
+          <li>
+            <i>7</i>
+            {{t 'machine.driverCustom.windowsSteps.step7' appName=settings.appName}}
             <div class="copy-pre">
               <pre id="registration-command">{{registrationCommandWindows}}</pre>
               {{copy-to-clipboard clipboardText=registrationCommandWindows}}
             </div>
           </li>
           <li>
-            <i>3</i>
+            <i>8</i>
             {{t 'machine.driverCustom.step5Close.part1'}} {{#link-to "hosts"}}{{t 'machine.driverCustom.step5Close.link'}}{{/link-to}} {{t 'machine.driverCustom.step5Close.part2'}}
           </li>
         </ul>
       </div>
     </div>
+  <div class="footer-actions">
+    <button {{action "cancel"}} class="btn btn-primary">{{t 'machine.driverCustom.close'}}</button>
+  </div>
   </section>
-{{/if}}
+{{else}}
 
 <section>
-  {{#if projects.current.isWindows}}
-    <h3>{{t 'machine.driverCustom.windows.linuxHeader'}}</h3>
-  {{/if}}
   <div class="row form-group">
     <div class="col-md-8 col-md-offset-2">
       <ul class="list-circles list-circles-clear">
@@ -85,8 +113,8 @@
       </ul>
     </div>
   </div>
-
   <div class="footer-actions">
     <button {{action "cancel"}} class="btn btn-primary">{{t 'machine.driverCustom.close'}}</button>
   </div>
 </section>
+{{/if}}

--- a/app/components/stack-header/template.hbs
+++ b/app/components/stack-header/template.hbs
@@ -22,20 +22,20 @@
 
     <div class="btn-group r-ml10">
       {{#link-to "service.new" (query-params stackId=model.id) classNames="btn btn-primary btn-sm"}}{{t 'stackHeader.add.service'}}{{/link-to}}
-      {{#unless projects.current.isWindows}}
         <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
           <i class="icon icon-chevron-down"></i>
           <span class="sr-only">{{t 'nav.srToggleNav'}}</span>
         </button>
         <ul class="dropdown-menu dropdown-menu-right" role="menu">
+          {{#unless projects.current.isWindows}}
           <li>{{#link-to "service.new-balancer" (query-params stackId=model.id)}}{{t 'stackHeader.add.balancer'}}{{/link-to}}</li>
+          {{/unless}}
           <li>{{#link-to "service.new-alias" (query-params stackId=model.id)}}{{t 'stackHeader.add.alias'}}{{/link-to}}</li>
           <li>{{#link-to "service.new-external" (query-params stackId=model.id)}}{{t 'stackHeader.add.external'}}{{/link-to}}</li>
-          {{#if hasVm}}
+          {{#if (and hasVm (not projects.current.isWindows))}}
             <li>{{#link-to "service.new-virtualmachine" (query-params stackId=model.id)}}{{t 'stackHeader.add.vm'}}{{/link-to}}</li>
           {{/if}}
         </ul>
-      {{/unless}}
     </div>
 
     {{action-menu model=model classNames="r-ml10 pull-right" size="sm"}}

--- a/app/components/stack-section/template.hbs
+++ b/app/components/stack-section/template.hbs
@@ -53,20 +53,22 @@
       {{#if showAddService}}
         <div class="btn-group">
           {{#link-to "service.new" (query-params stackId=model.id) classNames="btn btn-default btn-sm"}}{{t 'stackSection.add.service'}}{{/link-to}}
-          {{#unless projects.current.isWindows}}
+
             <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="true">
               <i class="icon icon-fw icon-chevron-down"></i>
               <span class="sr-only">{{t 'nav.srToggleDropdown'}}</span>
             </button>
             <ul class="dropdown-menu dropdown-menu-right" role="menu">
+              {{#unless projects.current.isWindows}}
               <li>{{#link-to "service.new-balancer" (query-params stackId=model.id)}}{{t 'stackSection.add.loadBalancer'}}{{/link-to}}</li>
+              {{/unless}}
               <li>{{#link-to "service.new-alias" (query-params stackId=model.id)}}{{t 'stackSection.add.serviceAlias'}}{{/link-to}}</li>
               <li>{{#link-to "service.new-external" (query-params stackId=model.id)}}{{t 'stackSection.add.externalService'}}{{/link-to}}</li>
-              {{#if hasVm}}
+              {{#if (and hasVm (not projects.current.isWindows))}}
                 <li>{{#link-to "service.new-virtualmachine" (query-params stackId=model.id)}}{{t 'stackSection.add.virtualMachine'}}{{/link-to}}</li>
               {{/if}}
             </ul>
-          {{/unless}}
+
         </div>
       {{/if}}
     </div>

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -151,6 +151,7 @@ var C = {
     STACK_UUID: 'io.rancher.stack.uuid',
     SYSTEM_TYPE: 'io.rancher.container.system',
     PER_HOST_SUBNET: 'io.rancher.network.per_host_subnet.subnet',
+    PER_HOST_SUBNET_ROUTING_IP: 'io.rancher.network.per_host_subnet.router_ip',
 
     // Catalog
     CERTIFIED: 'io.rancher.certified',

--- a/app/utils/navigation-tree.js
+++ b/app/utils/navigation-tree.js
@@ -341,6 +341,7 @@ const navTree = [
         localizedLabel: 'nav.api.hooks',
         icon: 'icon icon-link',
         route: 'authenticated.project.api.hooks',
+        condition: function() { return !this.get('projects.current.isWindows'); },
         ctx: [getProjectId],
       },
     ],

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -2502,6 +2502,19 @@ machine:
       step2: "Create a transparent Docker Network:"
       step2Copy: docker network create -d transparent transparent
       step3: Copy, paste, and run the command below in PowerShell to start the {appName} agent.
+    windowsSteps:
+      step1: Start up a Windows Server 2016 machine somewhere and install the latest version of <a href="https://docs.docker.com/engine/installation/windows/docker-ee/" target="_blank" rel="noreferrer nofollow">Docker</a> on it.
+      step2: "Check and install RemoteAccess and Routing in Windows features:"
+      step2Copy: Get-WindowsFeature -Name "RemoteAccess","Routing" | Install-WindowsFeature
+      step3: Please set the subnet for Windows host. In Windows environment, only the per-host-subnet network model is supported.
+      step4: Please set the router IP for host's subnet. This IP is used to forward network traffic between containers on different hosts。
+      routerIp:
+          placeholder: e.g. 1.2.3.4
+      subnet:
+          placeholder: e.g. 192.168.0.0/24
+      step5: "Specify the public IP that should be registered for this host.  If left empty, Rancher will auto-detect the IP to use.  This generally works for machines with unique public IPs, but will not work if the machine is behind a firewall/NAT or if it is the same machine that is running the <code>{rancherImage}</code> container."
+      step6: "Optional: Add labels to be applied to the host."
+      step7: Copy, paste, and run the command below in PowerShell to start the {appName} agent.
 
   driverDigitalocean:
     sizeLabel: |

--- a/translations/zh-hans.yaml
+++ b/translations/zh-hans.yaml
@@ -2414,10 +2414,23 @@ machine:
     windows:
       windowsHeader: Windows主机
       linuxHeader: Linux主机
-      step1: 运行一台Windows 2016主机并安装最新版本的 <a href="https://msdn.microsoft.com/en-us/virtualization/windowscontainers/quick_start/quick_start_windows_server" target="_blank" rel="noreferrer nofollow">Docker</a> on it.
+      step1: 运行一台Windows 2016主机并安装最新版本的 <a href="https://msdn.microsoft.com/en-us/virtualization/windowscontainers/quick_start/quick_start_windows_server" target="_blank" rel="noreferrer nofollow">Docker</a>
       step2: "创建一个 transparent Docker 网络:"
       step2Copy: docker network create -d transparent transparent
       step3: '复制粘贴下面的命令到Powershell命令行中运行以启动 {appName} agent'
+    windowsSteps:
+      step1: 运行一台Windows 2016主机并安装最新版本的 <a href="https://docs.docker.com/engine/installation/windows/docker-ee/" target="_blank" rel="noreferrer nofollow">Docker</a> on it.
+      step2: "检查并安装Windoes功能 RemoteAccess, Routing:"
+      step2Copy: Get-WindowsFeature -Name "RemoteAccess","Routing" | Install-WindowsFeature
+      step3: 请设置Windows主机的子网. 在Windows环境中，只支持 per-host-subnet网络模型
+      step4: 请设置子网的路由IP，此IP用于转发不同主机上容器之间的网络流量
+      routerIp:
+          placeholder: e.g. 1.2.3.4
+      subnet:
+          placeholder: e.g. 192.168.0.0/24
+      step5: "指定用于注册这台主机的公网IP。如果留空，Rancher会自动检测IP注册。通常在主机有唯一公网IP 的情况下这是可以的。如果主机位于防火墙/NAT设备之后，或者主机同时也是运行<code>{rancherImage}</code>容器的主机时，则必须设置此IP。"
+      step6: "可选项: 在主机上增加标签"
+      step7: 制粘贴下面的命令到Powershell命令行中运行以启动 {appName} agent
 
   driverDigitalocean:
     sizeLabel: |


### PR DESCRIPTION
refer to https://github.com/rancher/rancher/issues/10442
and https://github.com/rancher/rancher/issues/10448

1. Change the add host step for windows environment. Add setting
subnet labels logic.
2. Run command in Windows environment is fetched from rancher
server.
3. Block the webhook link on windows. Because the webhook is not
fully supported in Windows environment.
4. Because the metadata and DNS services are supported, service
alias and external service can be use in Windows environment.