### PR TITLE
Managed network option should not be seen in windows

### DIFF
--- a/app/components/form-networking/component.js
+++ b/app/components/form-networking/component.js
@@ -92,7 +92,7 @@ export default Ember.Component.extend(ManageLabels, ContainerChoices,{
       out.push({label: intl.t('formNetwork.networkMode.'+option), value: option});
     });
 
-    if ( !out.findBy('value', mode) ) {
+    if ( !out.findBy('value', mode) && !this.get('projects.current.isWindows')) {
       out.push({label: mode, value: mode});
     }
 


### PR DESCRIPTION
refer to https://github.com/rancher/rancher/issues/10571,
https://github.com/rancher/rancher/issues/10576 and
https://github.com/rancher/rancher/issues/10570

Manged network option will cause unexpect error when creating service in windows environment. Deprecate it for now.