### PR TITLE
[1.6]Webhook for Windows environment

### DIFF
--- a/app/components/webhook/new-receiver/component.js
+++ b/app/components/webhook/new-receiver/component.js
@@ -4,6 +4,7 @@ import NewOrEdit from 'ui/mixins/new-or-edit';
 const DRIVERS = ['scaleService','scaleHost','serviceUpgrade'];
 
 export default Ember.Component.extend(NewOrEdit, {
+  projects: Ember.inject.service(),
   model: null,
 
   init() {

--- a/app/components/webhook/new-receiver/template.hbs
+++ b/app/components/webhook/new-receiver/template.hbs
@@ -20,7 +20,9 @@
       <div>
         <select class="form-control" onchange={{action "changeDriver"}}>
           <option value="scaleService" selected={{eq model.driver 'scaleService'}} >{{t 'hookPage.scaleService.label'}}</option>
+          {{#if (not projects.current.isWindows)}}
           <option value="scaleHost" selected={{eq model.driver 'scaleHost'}} >{{t 'hookPage.scaleHost.label'}}</option>
+          {{/if}}
           <option value="serviceUpgrade" selected={{eq model.driver 'serviceUpgrade'}} >{{t 'hookPage.serviceUpgrade.label'}}</option>
         </select>
       </div>

--- a/app/utils/navigation-tree.js
+++ b/app/utils/navigation-tree.js
@@ -341,7 +341,6 @@ const navTree = [
         localizedLabel: 'nav.api.hooks',
         icon: 'icon icon-link',
         route: 'authenticated.project.api.hooks',
-        condition: function() { return !this.get('projects.current.isWindows'); },
         ctx: [getProjectId],
       },
     ],


### PR DESCRIPTION
Related issue https://github.com/rancher/rancher/issues/10663
Webhook is enable for Windows.
Webhook only can be scale service or upgrade a service in Windows environment because there is no any machine driver for windows.