### PR TITLE
Updating AWS EC2 Driver to add new eu-west-3 region

### DIFF
--- a/lib/shared/addon/components/machine/driver-amazonec2/component.js
+++ b/lib/shared/addon/components/machine/driver-amazonec2/component.js
@@ -101,6 +101,7 @@ let REGIONS = [
   "cn-north-1",
   "eu-west-1",
   "eu-west-2",
+  "eu-west-3",
   "eu-central-1",
   "sa-east-1",
   "us-east-1",


### PR DESCRIPTION
This adds the new AWS EC2 eu-west-3 region (Paris) in Rancher UI