### PR TITLE
Fixed: In grouping mode searchable-select takes two click to select a…

### DIFF
--- a/lib/shared/addon/components/searchable-select/template.hbs
+++ b/lib/shared/addon/components/searchable-select/template.hbs
@@ -28,7 +28,7 @@
       {{#each unGroupedContent as |item idx|}}
         <div
           class="searchable-option"
-          {{action 'selectUnGroupedItem' idx}}
+          {{action 'selectUnGroupedItem' idx on="mouseDown"}}
           onmouseenter={{action 'mouseEnter'}}
           onmouseleave={{action 'mouseLeave'}}
         >
@@ -48,7 +48,7 @@
           {{#each group.options as |item idx|}}
             <div
               class="searchable-option"
-              {{action 'selectGroupedItem' group.options idx}}
+              {{action 'selectGroupedItem' group.options idx on="mouseDown"}}
               onmouseenter={{action 'mouseEnter'}}
               onmouseleave={{action 'mouseLeave'}}
             >


### PR DESCRIPTION
In grouping mode, it takes two clicks to select a searchable-select option.

Here's the related link:
https://stackoverflow.com/questions/9335325/blur-event-stops-click-event-from-working