### PR TITLE
ember-intl

### DIFF
--- a/lib/global-admin/package.json
+++ b/lib/global-admin/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "ember-math-helpers": "*",
     "ember-truth-helpers": "*",
-    "ember-intl": "*",
     "ember-cli-htmlbars": "*",
     "ember-cli-babel": "*",
     "ember-cli-clipboard": "*",

--- a/lib/login/package.json
+++ b/lib/login/package.json
@@ -6,7 +6,6 @@
   ],
   "dependencies": {
     "ember-truth-helpers": "*",
-    "ember-intl": "*",
     "ember-cli-htmlbars": "*",
     "ember-cli-babel": "*",
     "ember-cli-clipboard": "*"

--- a/lib/shared/app/helpers/t.js
+++ b/lib/shared/app/helpers/t.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-intl/helpers/t';

--- a/lib/shared/package.json
+++ b/lib/shared/package.json
@@ -8,7 +8,6 @@
     "ember-api-store": "*",
     "ember-math-helpers": "*",
     "ember-truth-helpers": "*",
-    "ember-intl": "*",
     "ember-cli-htmlbars": "*",
     "ember-cli-pagination": "*",
     "ember-cli-babel": "*",


### PR DESCRIPTION
Fix the issue that translations got compiled 4 times

We can create a `translations` folder in each engine, so that each engine can have it's own translations.