### PR TITLE
Fix %MISSING% text in the change password button

### DIFF
--- a/lib/shared/addon/components/modal-edit-password/template.hbs
+++ b/lib/shared/addon/components/modal-edit-password/template.hbs
@@ -8,5 +8,6 @@
     complete=(action "complete")
     showCurrent=true
     cancel=(action "cancel")
+    editButton='modalEditPassword.actionButton'
     user=user
 }}


### PR DESCRIPTION
In the password change popup, the confirmation button with the text %MISSING%. I tried to fix it.