### PR TITLE
Fix Active Directory UI using groupDomain key instead of groupSearchBase

### DIFF
--- a/lib/global-admin/addon/templates/-ldap-config.hbs
+++ b/lib/global-admin/addon/templates/-ldap-config.hbs
@@ -65,7 +65,7 @@
           </div>
           <div class="col span-4">
             <h3>{{t 'ldap.accessEnabled.group.header'}}</h3>
-            <div><b>{{t 'ldap.accessEnabled.general.searchBase'}} </b> <span class="text-muted">{{adConfig.groupDomain}}</span></div>
+            <div><b>{{t 'ldap.accessEnabled.general.searchBase'}} </b> <span class="text-muted">{{adConfig.groupSearchBase}}</span></div>
             <div><b>{{t 'ldap.accessEnabled.group.objectClass'}} </b> <span class="text-muted">{{adConfig.groupObjectClass}}</span></div>
             <div><b>{{t 'ldap.accessEnabled.group.name'}} </b> <span class="text-muted">{{adConfig.groupNameAttribute}}</span></div>
             <div><b>{{t 'ldap.accessEnabled.group.search'}} </b> <span class="text-muted">{{adConfig.groupSearchAttribute}}</span></div>
@@ -174,7 +174,7 @@
           <div class="col span-6">
             <div class="inline-form">
               <label class="acc-label pb-5">{{t 'ldap.accessConfig.groupSearchBase.labelText'}}</label>
-              {{input value=adConfig.groupDomain classNames="form-control" placeholder=(t 'ldap.accessConfig.groupSearchBase.placeholder')}}
+              {{input value=adConfig.groupSearchBase classNames="form-control" placeholder=(t 'ldap.accessConfig.groupSearchBase.placeholder')}}
               <p class="help-block">{{t 'ldap.accessConfig.groupSearchBase.helpText'}}</p>
             </div>
           </div>


### PR DESCRIPTION
As seen here:

https://github.com/rancher/types/blob/master/apis/management.cattle.io/v3/authn_types.go#L138

There is no `groupDomain` field. The UI should reference the group search base field by its name `groupSearchBase` instead. Without this fix the setting is currently silently dropped when setting up the Active Directory authentication provider.