### PR TITLE
Fix the issue that xip.io can not be set in catalog

### DIFF
--- a/lib/shared/addon/components/schema/input-hostname/component.js
+++ b/lib/shared/addon/components/schema/input-hostname/component.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { next } from '@ember/runloop';
 import { get, set, observer } from '@ember/object'
 import layout from './template';
 import { inject as service } from '@ember/service';
@@ -24,7 +25,9 @@ export default Component.extend({
       set(this, 'mode', 'manual');
     }
 
-    this.modeChanged();
+    next(() => {
+      this.modeChanged();
+    });
   },
 
   modeChanged: observer('mode', function() {


### PR DESCRIPTION
We have applied a workaround in https://github.com/rancher/charts/pull/2
But it's better to fix it in UI.