### PR TITLE
[1.6] Reset userIdentity in local storage if it doesn't exist

### DIFF
--- a/app/components/machine/driver-azure/component.js
+++ b/app/components/machine/driver-azure/component.js
@@ -7,7 +7,6 @@ export default Ember.Component.extend(Driver, {
   azureConfig      : Ember.computed.alias('model.azureConfig'),
   environments     : environments.sortBy('value'),
   vmTypeChoices    : sizes,
-  vmSizeChoices    : null,
   driverName       : 'azure',
   model            : null,
   openPorts        : null,

--- a/app/services/access.js
+++ b/app/services/access.js
@@ -60,8 +60,19 @@ export default Ember.Service.extend({
       url: 'token',
     })
     .then((xhr) => {
+      var session = this.get('session');
       // If we get a good response back, the API supports authentication
       var token = xhr.body.data[0];
+
+      var interesting = {};
+      C.TOKEN_TO_SESSION_KEYS.forEach((key) => {
+        if (  typeof token[key] !== 'undefined' && typeof session.get(key) === 'undefined' )
+        {
+          interesting[key] = token[key];
+        }
+      });
+
+      session.setProperties(interesting);
 
       this.setProperties({
         'enabled': token.security,


### PR DESCRIPTION
Sometimes if admin users clean their local storage and refresh the browser.
The admin menu in UI will not display.

Some customer is logging in Rancher without using `login` method of `access` service.