### PR TITLE
Display Unschedulable label on controlplane nodes

### DIFF
--- a/app/models/node.js
+++ b/app/models/node.js
@@ -158,7 +158,9 @@ var Node = Resource.extend(StateCounts, ResourceUsage, {
 
   isUnschedulable: computed('taints.@each.{effect,key}', function(){
     const taints = get(this, 'taints') || [];
-    return taints.some(taint=> taint.effect === 'NoExecute' && taint.key === 'node-role.kubernetes.io/etcd');
+    return taints.some(taint => taint.effect === 'NoExecute' && (
+      taint.key === 'node-role.kubernetes.io/etcd' || taint.key === 'node-role.kubernetes.io/controlplane'
+    ));
   }),
 
   osBlurb: computed('info.os.operatingSystem', function() {


### PR DESCRIPTION
Before this PR, the Unschedulable label only appears for etcd nodes, after this PR it appears for both etcd nodes and controlplane nodes.

This is probably related to rancher/rke#665 which also made controlplane nodes unschedulable.