### PR TITLE
Remove pre populated namespace

### DIFF
--- a/app/containers/run/route.js
+++ b/app/containers/run/route.js
@@ -175,7 +175,12 @@ export default Route.extend({
     }
 
     if (!ns) {
-      ns = clusterStore.getById('namespace', get(this, `prefs.${C.PREFS.LAST_NAMESPACE}`));
+      const project = window.l('route:application').modelFor('authenticated.project').get('project');
+      const projectId = project.get('id');
+      const lastNamespace = clusterStore.getById('namespace', get(this, `prefs.${C.PREFS.LAST_NAMESPACE}`));
+      if ( lastNamespace && get(lastNamespace, 'projectId') === projectId ) {
+        ns = lastNamespace;
+      }
     }
 
     let namespaceId = null;

--- a/lib/shared/addon/components/form-namespace/component.js
+++ b/lib/shared/addon/components/form-namespace/component.js
@@ -61,7 +61,6 @@ export default Component.extend({
       } else {
         next(() => {
           set(this, 'mode', CREATE);
-          set(this, 'createNamespace.name', 'default')
         });
       }
 


### PR DESCRIPTION
If there is no namespace in a project. UI will not pre populate a `default` namespace as it might already exists in other project. 