### PR TITLE
Fixed a spelling error in the workload template.

### DIFF
--- a/app/workload/template.hbs
+++ b/app/workload/template.hbs
@@ -29,7 +29,7 @@
 <section>
   <div class="row banner bg-info basics">
     <div class="vertical-middle">
-      <label class="acc-label vertical-middle p-0">{{t 'servicePage.multistat.namesapce'}}</label>
+      <label class="acc-label vertical-middle p-0">{{t 'servicePage.multistat.namespace'}}</label>
       {{service.namespace.displayName}}
     </div>
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1219,7 +1219,7 @@ servicePage:
     fqdn: 'FQDN:'
     scale: 'Scale:'
     image: 'Image:'
-    namesapce: 'Namesapce:'
+    namespace: 'Namespace:'
     created: 'Created:'
     daemonSetScale: '1 per node'
   serviceType:

--- a/translations/ja-jp.yaml
+++ b/translations/ja-jp.yaml
@@ -1107,7 +1107,7 @@ servicePage:
     fqdn: 'FQDN:'
     scale: 'スケール:'
     image: 'イメージ:'
-    namesapce: '名前空間:'
+    namespace: '名前空間:'
     created: '作成日:'
     daemonSetScale: 'ノード毎に 1 つ'
   serviceType:
@@ -2807,7 +2807,7 @@ moveNamespace:
     {count, plural,
     =1 {個の名前空間: {name}}
     other {# 個の名前空間}
-    }の移動: 
+    }の移動:
   to: "移動先のプロジェクト:"
 
 stackHeader:

--- a/translations/ru-ru.yaml
+++ b/translations/ru-ru.yaml
@@ -925,7 +925,7 @@ servicePage:
     fqdn: 'Полное доменное имя:'
     scale: 'Масштаб:'
     image: 'Образ:'
-    namesapce: 'Пространство имен:'
+    namespace: 'Пространство имен:'
     created: 'Создан:'
     daemonSetScale: '1 на узел'
   serviceType:

--- a/translations/zh-hans.yaml
+++ b/translations/zh-hans.yaml
@@ -518,7 +518,7 @@ authPage:
       header: '危险区域&trade;'
       reallyDisable: '确认? 再次点击将关闭访问控制'
       promptDisable: 关闭访问控制
-      warning: '<b class="text-danger">警告:</b>禁用访问控制将导致任何能够访问此页面或API的用户拥有对{appName}的完全控制权限' 
+      warning: '<b class="text-danger">警告:</b>禁用访问控制将导致任何能够访问此页面或API的用户拥有对{appName}的完全控制权限'
       general:
         header: 常规
     configure:
@@ -1224,7 +1224,7 @@ servicePage:
     fqdn: 'FQDN:'
     scale: '数量:'
     image: '镜像:'
-    namesapce: '命名空间:'
+    namespace: '命名空间:'
     created: '创建时间:'
     daemonSetScale: '每主机1个'
   serviceType:


### PR DESCRIPTION
This PR fixes a spelling error that shows up in the workload view. 

NOTE! There were some ending blankspaces in the file that got removed automatically by the projects .editorconfig. I hope this is not an issue.