### PR TITLE
Fix rbac helper recompute issue

### DIFF
--- a/lib/shared/addon/helpers/rbac-allows.js
+++ b/lib/shared/addon/helpers/rbac-allows.js
@@ -1,11 +1,16 @@
 import { inject as service } from '@ember/service';
-import { get } from '@ember/object';
+import { get, observer } from '@ember/object';
 import Helper from '@ember/component/helper';
 
 export default Helper.extend({
   access: service(),
+  scope: service(),
+
+  scopeChanged: observer('scope.currentProject.id', 'scope.currentCluster.id', function() {
+    this.recompute();
+  }),
 
   compute(params, options) {
-    return get(this, 'access').allows(options.resource, options.permission, options.scope);
+    return get(this, 'access').allows(options.resource, options.permission, options.scope, get(this, 'scope'));
   }
 });

--- a/lib/shared/addon/helpers/rbac-prevents.js
+++ b/lib/shared/addon/helpers/rbac-prevents.js
@@ -1,11 +1,16 @@
 import { inject as service } from '@ember/service';
-import { get } from '@ember/object';
+import { get, observer } from '@ember/object';
 import Helper from '@ember/component/helper';
 
 export default Helper.extend({
   access: service(),
+  scope: service(),
+
+  scopeChanged: observer('scope.currentProject.id', 'scope.currentCluster.id', function() {
+    this.recompute();
+  }),
 
   compute(params, options) {
-    return !get(this, 'access').allows(options.resource, options.permission, options.scope);
+     return !get(this, 'access').allows(options.resource, options.permission, options.scope, get(this, 'scope'));
   }
 });


### PR DESCRIPTION
`rbac-allows` and `rbac-prevents` do not re-compute when user switch project or cluster.