### PR TITLE
Control -> Control Plane

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -2105,7 +2105,7 @@ clusterNew:
       detail: Choose what roles the node will have in the cluster
       header:
         etcd: etcd
-        controlplane: Control
+        controlplane: Control Plane
         worker: Worker
       requirements:
         label: "Number of nodes required:"
@@ -5715,7 +5715,7 @@ model:
     role:
       worker: Worker
       etcd: etcd
-      controlPlane: Control
+      controlPlane: Control Plane
   openldapconfig:
     server:
       label: Hostname or IP Address


### PR DESCRIPTION
- K8s docs uses Control Plane
- Our docs uses Control Plane
- kubectl shows `controlplane`
- Our agent command uses `--controlplane`

I think it makes sense to keep naming the same across everything.