### PR TITLE
.local TLD warning: increase severity, add link

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4117,7 +4117,7 @@ hostSettings:
       Are you sure all the hosts you will create will be able to reach <code>{activeValue}</code> ?<br/>It looks like a private IP or local network.
   badTld:
     alert: |
-      The <code>.local</code> Top-Level Domain is reserved by RFC6762 for Multicast DNS.  Using this as your Registration URL is not recommended and may cause DNS resolution issues.  Please choose a different hostname or IP.
+      The <code>.local</code> Top-Level Domain is reserved by RFC6762 for Multicast DNS.  Using this as your Registration URL is strongly discouraged since it may cause DNS resolution issues as well as problems with secrets and networked storage drivers.  Please choose a different hostname or IP. For more information, please see <a href="https://github.com/rancher/rancher/issues/9322">rancher/rancher#9322</a>.
 
 hostPod:
   supportState:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4117,7 +4117,7 @@ hostSettings:
       Are you sure all the hosts you will create will be able to reach <code>{activeValue}</code> ?<br/>It looks like a private IP or local network.
   badTld:
     alert: |
-      The <code>.local</code> Top-Level Domain is reserved by RFC6762 for Multicast DNS.  Using this as your Registration URL is strongly discouraged since it may cause DNS resolution issues as well as problems with secrets and networked storage drivers.  Please choose a different hostname or IP. For more information, please see <a href="https://github.com/rancher/rancher/issues/9322">rancher/rancher#9322</a>.
+      The <code>.local</code> Top-Level Domain is reserved by RFC6762 for Multicast DNS.  Using this as your Registration URL is strongly discouraged and may cause DNS resolution issues as well as problems with addons like secrets and networked storage drivers.  Please choose a different hostname or IP.
 
 hostPod:
   supportState:


### PR DESCRIPTION
This adds a link to https://github.com/rancher/rancher/issues/9322 and changes "not recommended" to "strongly discouraged", as well as makes mention of some of the issues that may arise when `.local` addresses are being used. See the linked issue for the full discussion.

(Sorry for the incredibly long line; I am not sure I can insert line breaks here so I'm just tagging along with the existing code style in the file.)