### PR TITLE
Fixed wrong displayed endpoints

### DIFF
--- a/app/components/namespace-app/template.hbs
+++ b/app/components/namespace-app/template.hbs
@@ -35,7 +35,7 @@
           {{model.pods.length}}
         </small>
       </div>
-      <div class="col span-7 clip text-small">
+      <div class="col span-7 text-small">
         {{model.displayEndpoints}}
       </div>
     </div>


### PR DESCRIPTION
[#14485](https://github.com/rancher/rancher/issues/14485)

Allow wrap in endpoints text, so all endpoints are shown and div expands to bottom instead of sidewards (where text is cliped, but div expands anyway).