### PR TITLE
Lock eslint-scope to pre-hacked package

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "stripe": "^4.15.0"
   },
   "resolutions": {
-    "ember-cli-babel": "^6.12.0"
+    "ember-cli-babel": "^6.12.0",
+    "eslint-scope": "3.7.1"
   },
   "ember-addon": {
     "paths": [


### PR DESCRIPTION
Something, probably ember-cli-eslint or babel, depends on eslint-scope so lets lock it to 3.7.1 

https://github.com/eslint/eslint-scope/issues/39