### PR TITLE
Fix restart policy issue

### DIFF
--- a/app/components/container/form-command/component.js
+++ b/app/components/container/form-command/component.js
@@ -1,5 +1,5 @@
 import {
-  get, set, observer
+  get, set, observer, computed
 } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
@@ -22,6 +22,11 @@ export default Component.extend({
   terminal:          null,
   statusClass:       null,
   status:            null,
+
+  isJob: computed('scaleMode', function() {
+    return get(this, 'scaleMode') === 'job' || get(this, 'scaleMode') === 'cronJob';
+  }),
+
   terminalDidChange: observer('terminal.type', function() {
 
     var val = get(this, 'terminal.type');
@@ -35,12 +40,17 @@ export default Component.extend({
 
   scaleModeDidChange: observer('scaleMode', function() {
 
-    const scaleMode = get(this, 'scaleMode');
     const restartPolicy = get(this, 'service.restartPolicy');
 
-    if ( (scaleMode === 'job' || scaleMode === 'cronJob') && restartPolicy === 'Always' ) {
+    if ( get(this, 'isJob') ) {
 
-      set(this, 'service.restartPolicy', 'Never');
+      if ( restartPolicy === 'Always' ) {
+        set(this, 'service.restartPolicy', 'Never');
+      }
+
+    } else {
+
+      set(this, 'service.restartPolicy', 'Always');
 
     }
 

--- a/app/components/container/form-command/template.hbs
+++ b/app/components/container/form-command/template.hbs
@@ -64,19 +64,23 @@
         <label class="acc-label">{{t 'formCommand.autoRestart.label'}}</label>
         <div class="row {{unless editing 'inline-form'}}">
           {{#if editing}}
-            <div class="radio">
-              <label>{{radio-button selection=service.restartPolicy value="Never"}} {{t 'formCommand.autoRestart.no'}}</label>
-            </div>
+            {{#if isJob}}
+              <div class="radio">
+                <label>{{radio-button selection=service.restartPolicy value="Never"}} {{t 'formCommand.autoRestart.no'}}</label>
+              </div>
+            {{/if}}
 
-            {{#unless (or (eq scaleMode 'job') (eq scaleMode 'cronJob'))}}
+            {{#unless isJob}}
               <div class="radio">
                 <label>{{radio-button selection=service.restartPolicy value="Always"}} {{t 'formCommand.autoRestart.always'}}</label>
               </div>
             {{/unless}}
 
-            <div class="radio">
-              <label>{{radio-button selection=service.restartPolicy value="OnFailure"}} {{t 'formCommand.autoRestart.onFailure' htmlSafe=true}}</label>
-            </div>
+            {{#if isJob}}
+              <div class="radio">
+                <label>{{radio-button selection=service.restartPolicy value="OnFailure"}} {{t 'formCommand.autoRestart.onFailure' htmlSafe=true}}</label>
+              </div>
+            {{/if}}
           {{else if (eq service.restartPolicy "OnFailure")}}
             <div>
               {{t 'formCommand.autoRestart.onFailure' htmlSafe=true}}


### PR DESCRIPTION
Only a `.spec.template.spec.restartPolicy` equal to` Always` is allowed for deployment, daemonset and statefulset

https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/