### PR TITLE
Support kube-api and kube-controller in cluster options

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -262,7 +262,23 @@ export default InputTextFile.extend(ClusterDriver, {
 
         if ( validFields[underlineToCamel(key)] ) {
 
-          set(this, `cluster.rancherKubernetesEngineConfig.${ underlineToCamel(key) }`, keysToCamel(configs[key]));
+          const obj = keysToCamel(configs[key]);
+
+          if ( key === 'services' && obj['kube-api'] ) {
+
+            set(obj, 'kubeApi', obj['kube-api']);
+            delete obj['kube-api'];
+
+          }
+
+          if ( key === 'services' && obj['kube-controller'] ) {
+
+            set(obj, 'kubeController', obj['kube-controller']);
+            delete obj['kube-controller'];
+
+          }
+
+          set(this, `cluster.rancherKubernetesEngineConfig.${ underlineToCamel(key) }`, obj);
 
         }
 
@@ -569,7 +585,7 @@ export default InputTextFile.extend(ClusterDriver, {
 
           if ( !isEmpty(field) && (typeof field !== 'object' || Object.keys(field).length ) ) {
 
-            out[camelToUnderline(key)] = this.getFieldValue(field[key], resourceFields[key].type);
+            out[camelToUnderline(key, type !== 'rkeConfigServices')] = this.getFieldValue(field[key], resourceFields[key].type);
 
           }
 

--- a/lib/shared/addon/utils/util.js
+++ b/lib/shared/addon/utils/util.js
@@ -386,12 +386,14 @@ export function removeEmpty(obj){
     {});
 }
 
-export function camelToUnderline(str) {
+export function camelToUnderline(str, split = true) {
   str = (str || '');
   if ( str.indexOf('-') > -1 ) {
     return str;
-  } else {
+  } else if ( split ) {
     return (str || '').dasherize().split('-').join('_');
+  } else {
+    return (str || '').dasherize();
   }
 }
 


### PR DESCRIPTION
support `kube-api` and `kube-controller` in cluster yaml to keep them consistent with RKE cluster yaml.

User can use `kube-api` or `kube_api` in advanced cluster yaml.