### PR TITLE
Fix remove pod issue

### DIFF
--- a/app/container/controller.js
+++ b/app/container/controller.js
@@ -1,3 +1,4 @@
+import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import {
   get, set, observer, computed
@@ -5,6 +6,8 @@ import {
 import { once } from '@ember/runloop';
 
 export default Controller.extend({
+  router: service(),
+
   selectedContainer: null,
 
   displayEnvironmentVars: computed('selectedContainer', function() {
@@ -33,7 +36,7 @@ export default Controller.extend({
 
   podStateDidChange: observer('model.state', function() {
 
-    if ( get(this, 'model.state') === 'removed') {
+    if ( get(this, 'model.state') === 'removed' && get(this, 'router.currentRouteName') === 'container' ) {
 
       this.transitionToRoute('authenticated.project.index');
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/14572

If user goes to pod detail page first and go back to workload detail page, page will be redirected to workload list page when pod get removed