### PR TITLE
Exclude unschedulable nodes from cluster dashboard

### DIFF
--- a/app/authenticated/cluster/index/controller.js
+++ b/app/authenticated/cluster/index/controller.js
@@ -11,11 +11,11 @@ export default Controller.extend({
 
   tags:              alias('projectController.tags'),
 
-  currentClusterNodes: computed('model.nodes.@each.{capacity,allocatable,state}', function() {
+  currentClusterNodes: computed('model.nodes.@each.{capacity,allocatable,state,isUnschedulable}', function() {
 
     const clusterId = get(this, 'scope.currentCluster.id');
 
-    return get(this, 'model.nodes').filter((n) => n.clusterId === clusterId);
+    return get(this, 'model.nodes').filter((n) => n.clusterId === clusterId && !n.isUnschedulable);
 
   }),
   actions: {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/14459

As we need to show the max and min nodes in cluster dashboard, it is easier to just exclude unschedulable nodes.