### PR TITLE
Fix view log performance issue

### DIFF
--- a/app/components/container-logs/template.hbs
+++ b/app/components/container-logs/template.hbs
@@ -34,7 +34,7 @@
     </label>
   </div>
   <button {{action "scrollToTop"}} class="btn bg-default">{{t 'containerLogs.scrollTop'}}</button>
-  <button {{action "scrollToBottom"}} class="btn bg-default scroll-bottom">{{t 'containerLogs.scrollBottom'}}</button>
+  <button {{action "followLog"}} class="btn bg-default scroll-bottom">{{t 'containerLogs.scrollBottom'}}</button>
   <button {{action "clear"}} class="btn bg-default">{{t 'containerLogs.clear'}}</button>
   <button {{action "cancel"}} class="btn bg-primary">{{t 'generic.closeModal'}}</button>
 </div>


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/14535


UI will get stuck if server sends a lot of frames in a very short time. The reason is we are using `$body.scrollTop() + $body.outerHeight()` inside `onmessage` callback.