### PR TITLE
Disable Resource Quota Templates route & resources

### DIFF
--- a/app/authenticated/cluster/projects/new-ns/controller.js
+++ b/app/authenticated/cluster/projects/new-ns/controller.js
@@ -26,19 +26,19 @@ export default Controller.extend(NewOrEdit, {
     },
   },
 
-  projectDidChange: observer('model.namespace.projectId', function() {
-    if ( !get(this, 'model.namespace.project.resourceQuota') ) {
-      set(this, 'model.namespace.resourceQuotaTemplateId', null);
-    }
-  }),
+  // projectDidChange: observer('model.namespace.projectId', function() {
+  //   if ( !get(this, 'model.namespace.project.resourceQuota') ) {
+  //     set(this, 'model.namespace.resourceQuotaTemplateId', null);
+  //   }
+  // }),
 
   allProjects:     computed('model.allProjects', 'scope.currentCluster.id', function() {
     return get(this, 'model.allProjects').filterBy('clusterId', get(this, 'scope.currentCluster.id'))
   }),
 
-  allQuotaTemplates: computed('model.allQuotaTemplates', 'scope.currentCluster.id', function() {
-    return get(this, 'model.allQuotaTemplates').filterBy('clusterId', get(this, 'scope.currentCluster.id'))
-  }),
+  // allQuotaTemplates: computed('model.allQuotaTemplates', 'scope.currentCluster.id', function() {
+  //   return get(this, 'model.allQuotaTemplates').filterBy('clusterId', get(this, 'scope.currentCluster.id'))
+  // }),
 
   nameExists: computed('primaryResource.name', 'model.namespaces.@each.name', function() {
     const name = get(this, 'primaryResource.name');

--- a/app/authenticated/cluster/projects/new-ns/controller.js
+++ b/app/authenticated/cluster/projects/new-ns/controller.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller'
 import NewOrEdit from 'ui/mixins/new-or-edit';
 import { alias } from '@ember/object/computed';
-import { computed, get, set, observer } from '@ember/object';
+import { computed, get/* , set, observer */ } from '@ember/object';
 import { inject as service } from '@ember/service';
 import C from 'ui/utils/constants';
 

--- a/app/authenticated/cluster/projects/new-ns/route.js
+++ b/app/authenticated/cluster/projects/new-ns/route.js
@@ -25,7 +25,7 @@ export default Route.extend({
       namespace,
       namespaces:        get(this, 'clusterStore').findAll('namespace'),
       allProjects:       get(this, 'globalStore').findAll('project'),
-      allQuotaTemplates: get(this, 'globalStore').findAll('resourceQuotaTemplate'),
+      // allQuotaTemplates: get(this, 'globalStore').findAll('resourceQuotaTemplate'),
     });
   },
 

--- a/app/authenticated/cluster/projects/new-ns/template.hbs
+++ b/app/authenticated/cluster/projects/new-ns/template.hbs
@@ -24,19 +24,19 @@
       localizedPrompt=true
   }}
 {{/unless}}
-
-{{#if model.namespace.project.resourceQuota}}
-  <label class="pt-20 pb-5 acc-label">{{t 'editStack.quota.label'}}</label>
-  {{new-select
-      classNames="form-control"
-      optionValuePath="id"
-      optionLabelPath="displayName"
-      content=allQuotaTemplates
-      value=model.namespace.resourceQuotaTemplateId
-      prompt="editStack.quota.prompt"
-      localizedPrompt=true
-  }}
-{{/if}}
-
+{{!--
+    {{#if model.namespace.project.resourceQuota}}
+    <label class="pt-20 pb-5 acc-label">{{t 'editStack.quota.label'}}</label>
+    {{new-select
+    classNames="form-control"
+    optionValuePath="id"
+    optionLabelPath="displayName"
+    content=allQuotaTemplates
+    value=model.namespace.resourceQuotaTemplateId
+    prompt="editStack.quota.prompt"
+    localizedPrompt=true
+    }}
+    {{/if}}
+    --}}
 {{top-errors errors=errors}}
 {{save-cancel editing=false save="save" cancel="cancel"}}

--- a/app/authenticated/route.js
+++ b/app/authenticated/route.js
@@ -116,7 +116,7 @@ export default Route.extend(Preload, {
             this.preload('authConfig', 'globalStore', { url: 'authConfigs' }),
             this.preload('globalRoleBinding', 'globalStore', { url: 'globalRoleBinding' }),
             this.preload('user', 'globalStore', { url: 'user' }),
-            this.preload('resourceQuotaTemplate', 'globalStore', { url: 'resourceQuotaTemplates' }),
+            // this.preload('resourceQuotaTemplate', 'globalStore', { url: 'resourceQuotaTemplates' }),
 
             globalStore.findAll('principal').then((principals) => {
               const me = principals.filter((p) => p.me === true);

--- a/app/components/modal-edit-namespace/template.hbs
+++ b/app/components/modal-edit-namespace/template.hbs
@@ -16,19 +16,20 @@
     prompt="editStack.project.prompt"
     localizedPrompt=true
   }}
-
-  {{#if primaryResource.project.resourceQuota}}
+  {{!--
+    {{#if primaryResource.project.resourceQuota}}
     <label class="pt-20 pb-5">{{t 'editStack.quota.label'}}</label>
     {{new-select
-        classNames="form-control"
-        optionValuePath="id"
-        optionLabelPath="displayName"
-        content=allQuotaTemplates
-        value=primaryResource.resourceQuotaTemplateId
-        prompt="editStack.quota.prompt"
-        localizedPrompt=true
+    classNames="form-control"
+    optionValuePath="id"
+    optionLabelPath="displayName"
+    content=allQuotaTemplates
+    value=primaryResource.resourceQuotaTemplateId
+    prompt="editStack.quota.prompt"
+    localizedPrompt=true
     }}
-  {{/if}}
+    {{/if}}
+    --}}
 </section>
 
 {{top-errors errors=errors}}

--- a/app/models/namespace.js
+++ b/app/models/namespace.js
@@ -54,7 +54,7 @@ var Namespace = Resource.extend(StateCounts, {
   volumes:               hasMany('id', 'persistentVolumeClaim', 'namespaceId', 'projectStore', null, 'clusterStore'),
   type:                  'namespace',
   project:               reference('projectId', 'project', 'globalStore'),
-  resourceQuotaTemplate: reference('resourceQuotaTemplateId', 'resourceQuotaTemplate', 'globalStore'),
+  // resourceQuotaTemplate: reference('resourceQuotaTemplateId', 'resourceQuotaTemplate', 'globalStore'),
 
   init() {
     this._super(...arguments);

--- a/app/router.js
+++ b/app/router.js
@@ -72,13 +72,13 @@ Router.map(function() {
         this.route('new-ns', { path: '/ns/add' });
       });
 
-      this.route('quotas', { path: '/quota-templates' }, function() {
-        this.route('index', { path: '/' });
-        this.route('new', { path: '/quota-template/add' });
-        this.route('detail', { path: '/quota-template/:quota_template_id' }, function() {
-          this.route('edit');
-        });
-      });
+      // this.route('quotas', { path: '/quota-templates' }, function() {
+      //   this.route('index', { path: '/' });
+      //   this.route('new', { path: '/quota-template/add' });
+      //   this.route('detail', { path: '/quota-template/:quota_template_id' }, function() {
+      //     this.route('edit');
+      //   });
+      // });
 
       this.route('security', function() {
         this.route('index', { path: '/' });


### PR DESCRIPTION
This is the first of 2 prs for the new Resource Quotas work
This PR removes all refs to that resource. we will add these
back in when the backend is merged and the ui can be updated

rancher/rancher#14620

remove all references to loading `resourceQuotaTemplate`