### PR TITLE
Display Project row only correctly (namespace-table)

### DIFF
--- a/app/authenticated/cluster/projects/index/controller.js
+++ b/app/authenticated/cluster/projects/index/controller.js
@@ -13,12 +13,12 @@ export default Controller.extend({
     },
   },
 
-  rows: computed('model.namespaces.@each.displayName', 'scope.currentCluster.id', function() {
+  rows: computed('model.namespaces.@each.displayName', 'model.projects.@each.clusterId', 'scope.currentCluster.id', function() {
     return get(this, 'model.namespaces')
       .filterBy('displayName');
   }),
 
-  projects: computed('model.projects.@each.clusterId', 'scope.currentCluster.id', function() {
+  projects: computed('model.namespaces.@each.displayName', 'model.projects.@each.clusterId', 'scope.currentCluster.id', function() {
     return get(this, 'model.projects').filterBy('clusterId', get(this, 'scope.currentCluster.id'));
   }),
 

--- a/app/authenticated/cluster/projects/index/template.hbs
+++ b/app/authenticated/cluster/projects/index/template.hbs
@@ -23,7 +23,7 @@
 </section>
 
 {{#if (eq group 'project')}}
-  {{namespace-table model=rows prns=projectsWithoutNamespaces}}
+  {{namespace-table model=rows projectsWithoutNamespace=projectsWithoutNamespaces}}
 {{else}}
   {{namespace-list model=rows}}
 {{/if}}

--- a/app/components/namespace-table/template.hbs
+++ b/app/components/namespace-table/template.hbs
@@ -1,15 +1,15 @@
 {{#sortable-table
      body=model
+     descending=descending
      groupByKey="projectId"
      groupByRef="project"
      groupedSortBy="displayName"
      headers=headers
      paging=paging
-     descending=descending
-     sortGroupedFirst=true
      pagingLabel="pagination.project"
      searchText=searchText
      sortBy=sortBy
+     sortGroupedFirst=true
      subRows=subRows
      suffix=suffix
      tableClassNames="bordered"
@@ -17,9 +17,14 @@
 }}
   {{#if (eq kind "row")}}
     <tr class="main-row">
-      <td valign="middle" class="row-check" style="padding-top: 2px;">
-        {{check-box nodeId=ns.id}}
-      </td>
+        <td valign="middle" class="row-check" style="padding-top: 2px;">
+          {{#if projectsWithoutNamespace.length}}
+            &nbsp;
+          {{else}}
+            {{check-box nodeId=ns.id}}
+          {{/if}}
+
+        </td>
       <td>
         {{badge-state model=ns}}
       </td>
@@ -58,18 +63,21 @@
       <td colspan="{{sortable.fullColspan}}" class="text-center text-muted lacsso pt-20 pb-20">{{t 'projectsPage.noMatch'}}</td>
     </tr>
   {{else if (eq kind "norows")}}
-    <tr>
-      <td colspan="{{sortable.fullColspan}}" class="text-center text-muted lacsso pt-20 pb-20">{{t 'projectsPage.noData'}}</td>
-    </tr>
+    {{#unless projectsWithoutNamespace.length}}
+      <tr>
+        <td colspan="{{sortable.fullColspan}}" class="text-center text-muted lacsso pt-20 pb-20">{{t 'projectsPage.noData'}}</td>
+      </tr>
+    {{/unless}}
   {{else if (eq kind "suffix")}}
-    {{#if prns.length}}
-      <tbody class="group">
-        {{#each prns as |project|}}
+    {{#if (and projectsWithoutNamespace.length (not searchText.length))}}
+      <tbody class="fixed grid group">
+        {{#each projectsWithoutNamespace as |project|}}
           {{project-group
               model=project
               noGroup="namespaceGroup.project"
               fullColspan=sortable.fullColspan
               noNamespace=true
+              projectsWithoutNamespaces=projectsWithoutNamespace
           }}
         {{/each}}
       </tbody>

--- a/app/components/project-group/component.js
+++ b/app/components/project-group/component.js
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
 import layout from './template';
-import { computed } from '@ember/object';
 
 export default Component.extend({
   layout,
@@ -11,15 +10,5 @@ export default Component.extend({
   alignState:   'text-center',
   showActions:  true,
   noGroup:      'namespaceGroup.none',
-
   tagName:      '',
-
-  nameSpan: computed('fullColspan', 'afterName', 'showState', 'afterState', 'showActions', function() {
-    let span = this.get('fullColspan') -
-        (this.get('showActions') ? 2 : 0);
-
-    return Math.max(span, 1);
-  }),
-
-
 });

--- a/app/components/project-group/template.hbs
+++ b/app/components/project-group/template.hbs
@@ -1,5 +1,5 @@
 <tr class="group-row">
-  <td colspan=3 class="pl-10">
+  <td colspan={{if (eq projectsWithoutNamespaces.length 1) 2 3}} class="pl-10">
     {{#if model}}
       <a href="{{href-to 'authenticated.project' model.id}}">{{t 'projectGroup.label' name=model.displayName}}</a>
     {{else}}
@@ -22,7 +22,7 @@
 </tr>
 {{#if noNamespace}}
   <tr class="main-row">
-    <td colspan="{{fullColspan}}" class="text-center p-20">
+    <td colspan="{{if (eq projectsWithoutNamespaces.length 1) 4 fullColspan}}" class="text-center p-20">
       <div class="text-muted">{{t 'projectGroup.noNS'}}</div>
     </td>
   </tr>


### PR DESCRIPTION
When a new user had a single project without a namespace we'd fall into branch where we'd see a duplicate no-data row.

The resulting table, a single project row, had incorrect col-span's due to the missing checkbox in the `sortable-table` headers.

rancher/rancher#15296