### PR TITLE
Display slug for digitalocean in node template creation

### DIFF
--- a/translations/ja-jp.yaml
+++ b/translations/ja-jp.yaml
@@ -4436,7 +4436,7 @@ nodeDriver:
       {highMem, select, true {高メモリ: } other {}}{memoryGb} GB RAM, {disk} GB ディスク, {vcpus, plural,
         =1 {# vCPU}
         other {# vCPUs}
-      }
+      } ({slug})
     authAccountButton: '次へ: ドロップレットの設定'
     accessToken:
       label: アクセストークン

--- a/translations/zh-hans.yaml
+++ b/translations/zh-hans.yaml
@@ -4850,7 +4850,7 @@ nodeDriver:
       {highMem, select, true{High Memory:}other{}}{memoryGb}GB RAM,{disk}GB Disk,{vcpus, plural,
       =1{#vCPU}
       other{#vCPUs}
-      }
+      } ({slug})
     authAccountButton: '下一步: 配置Droplet'
     accessToken:
       label: 访问令牌

--- a/translations/zh-hant.yaml
+++ b/translations/zh-hant.yaml
@@ -4853,7 +4853,7 @@ nodeDriver:
       {highMem, select, true{High Memory:}other{}}{memoryGb}GB RAM,{disk}GB Disk,{vcpus, plural,
       =1{#vCPU}
       other{#vCPUs}
-      }
+      } ({slug})
     authAccountButton: '下一步: 配置Droplet'
     accessToken:
       label: 訪問令牌


### PR DESCRIPTION
## Proposed changes

Small change to make it super obvious what each of the droplets are. With DigitalOcean there are a few variants since the latest slug updates and sometimes it's not obvious which droplet you have selected. Some even have the same CPU + RAM but slightly varying disk size for a different cost.

## Types of changes

What types of changes does your code introduce to Rancher?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Issues

N/A


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
_Tip: `yarn lint` or `npm run lint`_
- [x] Any dependent issues or pr's have been linked
- [x] If updating dependencies, `yarn.lock` file has been updated and committed


## Further comments

I am unable to get this running locally to provide a screenshot due to an openssl issue.
