### PR TITLE
Show the image name of first container

### DIFF
--- a/lib/shared/addon/mixins/display-image.js
+++ b/lib/shared/addon/mixins/display-image.js
@@ -10,9 +10,9 @@ export default Mixin.create({
     const count = get(containers, 'length');
 
     if ( count > 1  ) {
-      return get(this, 'intl').t('pagination.image', {
-        pages: 1,
-        count
+      return get(this, 'intl').t('podPage.displayImage', {
+        image:   get(containers, 'firstObject.image'),
+        sidecar: count - 1
       });
     } else if ( count ) {
       return get(containers, 'firstObject.image');

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -804,7 +804,7 @@ podPage:
   podIp: Pod IP
   containerImage: 'Image of {container}'
   image: Image
-
+  displayImage: '{image} + {sidecar, plural, =1 {1 image} other {# images}}'
 containersPage:
   table:
     sparkPrefixCpu: "CPU: "


### PR DESCRIPTION
## Proposed changes

In workload list page, if there are workloads with sidecars. The image column will not show the image name. It only shows the count like `3 Images`.

If we are using istio, all of the workloads has at least two sidecars. It will be good if we can show the image name of first container in the pod.
![image](https://user-images.githubusercontent.com/21168270/45248958-87143380-b34a-11e8-8147-1c7405536aa7.png)

## Types of changes

What types of changes does your code introduce to Rancher?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Issues

n/a

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
_Tip: `yarn lint` or `npm run lint`_
- [ ] Any dependent issues or pr's have been linked
- [ ] If updating dependencies, `yarn.lock` file has been updated and committed

## Further comments

n/a