### PR TITLE
tweak rke cluster creation to handle the new cluster-defaults

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -196,45 +196,14 @@ export default InputTextFile.extend(ClusterDriver, {
 
       const rkeConfig = globalStore.createRecord({
         type:                'rancherKubernetesEngineConfig',
-        ignoreDockerVersion: true,
         kubernetesVersion:   get(this, `settings.${ C.SETTING.VERSION_K8S_DEFAULT }`),
-        authentication:      globalStore.createRecord({
-          type:     'authnConfig',
-          strategy: 'x509',
-        }),
-        network: globalStore.createRecord({
-          type:    'networkConfig',
-          plugin:  'canal',
-          options: { flannel_backend_type: null, },
-        }),
-        ingress: globalStore.createRecord({
-          type:     'ingressConfig',
-          provider: 'nginx',
-        }),
-        monitoring: globalStore.createRecord({
-          type:     'monitoringConfig',
-          provider: 'metrics-server',
-        }),
-        services: globalStore.createRecord({
-          type:    'rkeConfigServices',
-          kubeApi: globalStore.createRecord({
-            type:                  'kubeAPIService',
-            podSecurityPolicy:     false,
-            serviceNodePortRange: '30000-32767',
-          }),
-          etcd: globalStore.createRecord({
-            type:      'etcdService',
-            extraArgs: {
-              'heartbeat-interval': 500,
-              'election-timeout':   5000
-            },
-          }),
-        }),
       });
 
       scheduleOnce('afterRender', () => {
-        set(this, 'cluster.rancherKubernetesEngineConfig', rkeConfig);
-        set(this, 'cluster.enableNetworkPolicy', false);
+        setProperties(get(this, 'cluster'), {
+          rancherKubernetesEngineConfig: rkeConfig,
+          enableNetworkPolicy:           false,
+        });
       });
     }
   }),
@@ -256,16 +225,24 @@ export default InputTextFile.extend(ClusterDriver, {
       let res = NETWORKCHOICES.filter((n) => n.value === FLANNEL)
 
       setProperties(this, {
-        networkContent:                                res,
-        'config.network.plugin':                       FLANNEL,
-        'config.network.options.flannel_backend_type': HOST_GW,
-      })
+        networkContent: res,
+        config:         {
+          network: {
+            plugin:  FLANNEL,
+            options: { flannel_backend_type: HOST_GW }
+          }
+        },
+      });
     } else {
       setProperties(this, {
-        networkContent:                                NETWORKCHOICES,
-        'config.network.options.flannel_backend_type': null,
-        'config.network.plugin':                       CANAL,
-      })
+        networkContent: NETWORKCHOICES,
+        config:         {
+          network: {
+            plugin:  CANAL,
+            options: { flannel_backend_type: null }
+          }
+        },
+      });
     }
   }),
 
@@ -282,6 +259,64 @@ export default InputTextFile.extend(ClusterDriver, {
         etcd:         false,
         worker:       true,
       })
+    }
+  }),
+
+  kubeApiPodSecurityPolicy: computed('config.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy', {
+    get() {
+      let pspConfig = get(this, 'config.rancherKubernetesEngineConfig.services.kubeApi');
+
+      if (typeof  pspConfig === 'undefined') {
+        return false;
+      }
+
+      return get(pspConfig, 'podSecurityPolicy');
+    },
+    set(key, value) {
+      set(this.config, 'rancherKubernetesEngineConfig', {
+        services: { kubeApi: { podSecurityPolicy: value } }
+      });
+
+      return value;
+    }
+  }),
+
+  monitoringProvider: computed('config.rancherKubernetesEngineConfig.monitoring', {
+    get() {
+      let monitoringConfig = get(this, 'config.rancherKubernetesEngineConfig.monitoring');
+
+      if (typeof  monitoringConfig === 'undefined') {
+        return null;
+      }
+
+      return get(monitoringConfig, 'provider');
+    },
+    set(key, value) {
+      set(this.config, 'rancherKubernetesEngineConfig', {
+        monitoring: { provider: value }
+      });
+
+      return value;
+    }
+  }),
+
+  nginxIngressProvider: computed('config.rancherKubernetesEngineConfig.ingress', {
+    get() {
+      let ingressConfig = get(this, 'config.rancherKubernetesEngineConfig.ingress');
+
+      if (typeof  ingressConfig === 'undefined') {
+        return null;
+      }
+
+      return get(ingressConfig, 'provider');
+    },
+    set(key, value) {
+
+      set(this.config, 'rancherKubernetesEngineConfig', {
+        ingress: { provider: value }
+      })
+
+      return value;
     }
   }),
 

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -273,9 +273,7 @@ export default InputTextFile.extend(ClusterDriver, {
       return get(pspConfig, 'podSecurityPolicy');
     },
     set(key, value) {
-      set(this.config, 'rancherKubernetesEngineConfig', {
-        services: { kubeApi: { podSecurityPolicy: value } }
-      });
+      set(this.config, 'rancherKubernetesEngineConfig', { services: { kubeApi: { podSecurityPolicy: value } } });
 
       return value;
     }
@@ -292,9 +290,7 @@ export default InputTextFile.extend(ClusterDriver, {
       return get(monitoringConfig, 'provider');
     },
     set(key, value) {
-      set(this.config, 'rancherKubernetesEngineConfig', {
-        monitoring: { provider: value }
-      });
+      set(this.config, 'rancherKubernetesEngineConfig', { monitoring: { provider: value } });
 
       return value;
     }
@@ -311,10 +307,7 @@ export default InputTextFile.extend(ClusterDriver, {
       return get(ingressConfig, 'provider');
     },
     set(key, value) {
-
-      set(this.config, 'rancherKubernetesEngineConfig', {
-        ingress: { provider: value }
-      })
+      set(this.config, 'rancherKubernetesEngineConfig', { ingress: { provider: value } })
 
       return value;
     }

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -94,13 +94,13 @@
             <label class="acc-label">{{t 'clusterNew.rke.ingress.label'}}</label>
             <div class="radio">
               <label>
-                {{radio-button selection=cluster.rancherKubernetesEngineConfig.ingress.provider value="nginx"}}
+                {{radio-button selection=nginxIngressProvider value="nginx"}}
                 {{t 'generic.enabled'}}
               </label>
             </div>
             <div class="radio">
               <label>
-                {{radio-button selection=cluster.rancherKubernetesEngineConfig.ingress.provider value="none"}}
+                {{radio-button selection=nginxIngressProvider value=null}}
                 {{t 'generic.disabled'}}
               </label>
             </div>
@@ -109,13 +109,13 @@
             <label class="acc-label">{{t 'clusterNew.rke.monitoring.label'}}</label>
             <div class="radio">
               <label>
-                {{radio-button selection=cluster.rancherKubernetesEngineConfig.monitoring.provider value="metrics-server"}}
+                {{radio-button selection=monitoringProvider value="metrics-server"}}
                 {{t 'generic.enabled'}}
               </label>
             </div>
             <div class="radio">
               <label>
-                {{radio-button selection=cluster.rancherKubernetesEngineConfig.monitoring.provider value="none"}}
+                {{radio-button selection=monitoringProvider value=null}}
                 {{t 'generic.disabled'}}
               </label>
             </div>
@@ -124,13 +124,13 @@
             <label class="acc-label">{{t 'clusterNew.rke.podSecurityPolicy.label'}}</label>
             <div class="radio">
               <label>
-                {{radio-button selection=cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy value=false disabled=(not model.psps.length)}}
+                {{radio-button selection=kubeApiPodSecurityPolicy value=false disabled=(not model.psps.length)}}
                 {{t 'generic.disabled'}}
               </label>
             </div>
             <div class="radio">
               <label class={{unless model.psps.length 'text-muted'}}>
-                {{radio-button selection=cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy value=true disabled=(not model.psps.length)}}
+                {{radio-button selection=kubeApiPodSecurityPolicy value=true disabled=(not model.psps.length)}}
                 {{t 'generic.enabled'}}
                 {{#unless model.psps.length}}
                   &mdash; {{t 'clusterNew.psp.none'}}


### PR DESCRIPTION
## Proposed changes
The cluster creation ui for RKE was adding its own defaults. We added the new editor for these defaults to the settings pages but we were defaulting some of the props on the config so the new defaults were not coming through. 

## Types of changes

What types of changes does your code introduce to Rancher?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Issues

rancher/rancher#15111

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
_Tip: `yarn lint` or `npm run lint`_
- [x] Any dependent issues or pr's have been linked
- [x] If updating dependencies, `yarn.lock` file has been updated and committed

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
