### PR TITLE
Fix pagination issue for grouped resources

### DIFF
--- a/app/authenticated/project/ns/index/template.hbs
+++ b/app/authenticated/project/ns/index/template.hbs
@@ -13,9 +13,7 @@
        pagingLabel="pagination.namespace"
        groupByKey="projectId"
        groupByRef="project"
-       groupedSortBy="displayName"
        headers=headers
-       sortGroupedFirst=true
        bulkActions=true
        body=allNamespace
        descending=descending

--- a/app/components/namespace-table/template.hbs
+++ b/app/components/namespace-table/template.hbs
@@ -3,13 +3,11 @@
      descending=descending
      groupByKey="projectId"
      groupByRef="project"
-     groupedSortBy="displayName"
      headers=headers
      paging=paging
      pagingLabel="pagination.project"
      searchText=searchText
      sortBy=sortBy
-     sortGroupedFirst=true
      subRows=subRows
      suffix=suffix
      tableClassNames="bordered"

--- a/app/containers/index/controller.js
+++ b/app/containers/index/controller.js
@@ -84,9 +84,9 @@ export default Controller.extend({
     const group = this.get('group');
 
     if (group === 'node') {
-      return 'nodeId';
-    } else {
-      return group
+      return 'node';
+    } else if (group === 'namespace') {
+      return 'namespace'
     }
   }.property('group'),
 });

--- a/app/containers/index/template.hbs
+++ b/app/containers/index/template.hbs
@@ -45,7 +45,7 @@
           }}
         {{/if}}
       {{else if (and (eq kind "group") (eq groupTableBy 'nodeId'))}}
-        {{node-group nodes=model.nodes nodeId=inst.ref fullColspan=sortable.fullColspan}}
+        {{node-group nodes=model.nodes nodeId=inst.ref.id fullColspan=sortable.fullColspan}}
       {{else if (eq kind "group")}}
         {{namespace-group model=inst.ref fullColspan=sortable.fullColspan}}
       {{else if (eq kind "nomatch")}}

--- a/lib/shared/addon/components/sortable-table/component.js
+++ b/lib/shared/addon/components/sortable-table/component.js
@@ -1,5 +1,4 @@
 import { or, alias } from '@ember/object/computed';
-import { compare } from '@ember/utils';
 import Component from '@ember/component';
 import Sortable from 'shared/mixins/sortable-base';
 import StickyHeader from 'shared/mixins/sticky-table-header';
@@ -105,7 +104,6 @@ export default Component.extend(Sortable, StickyHeader, {
   body:                 null,
   groupByKey:           null,
   groupByRef:           null,
-  groupedSortBy:        null,
   preSorts:             null,
   sortBy:               null,
   descending:           false,
@@ -122,7 +120,6 @@ export default Component.extend(Sortable, StickyHeader, {
   subRows:              false,
   checkWidth:           40,
   actionsWidth:         40,
-  sortGroupedFirst:     false,
 
   availableActions:  null,
   selectedNodes:     null,
@@ -196,18 +193,6 @@ export default Component.extend(Sortable, StickyHeader, {
           });
         }
       });
-
-      if (get(this, 'sortGroupedFirst')) {
-        const groupedSortBy = get(this, 'groupedSortBy');
-        const sortBy = groupedSortBy ? `ref.${ groupedSortBy }` : 'group';
-
-        ary = ary.sort((a, b) => {
-          const aValue = get(a, sortBy);
-          const bValue = get(b, sortBy);
-
-          return ( !aValue - !bValue ) || compare(aValue, bValue);
-        });
-      }
 
       return ary;
     }));

--- a/lib/shared/addon/mixins/sortable-base.js
+++ b/lib/shared/addon/mixins/sortable-base.js
@@ -7,6 +7,7 @@ export default Mixin.create({
   headers:         null,
   preSorts:        null,
   sortBy:          null,
+  groupByRef:      null,
   descending:      false,
 
   actions: {
@@ -30,10 +31,20 @@ export default Mixin.create({
     },
   },
 
-  currentSort: computed('sortBy', 'headers.@each.{sortBy}', 'descending', function() {
+  currentSort: computed('sortBy', 'groupByRef', 'headers.@each.{sortBy}', 'descending', function() {
     var headers = this.get('headers');
     var desc = this.get('descending');
     let sort = this.get('preSorts') || [];
+
+    if ( get(this, 'groupByRef') ) {
+      const groupSortBy = `${ get(this, 'groupByRef') }.displayName`;
+
+      if ( desc ) {
+        sort.push(`${ groupSortBy }:desc`);
+      } else {
+        sort.push(groupSortBy);
+      }
+    }
 
     if ( headers ) {
       var header = headers.findBy('name', this.get('sortBy'));


### PR DESCRIPTION
## Proposed changes

Given 70 workloads under namespace `A`.
We need to show 50 workloads of `A` in page 1 and show the left 20 workloads of `A` in page 2 first then we can show the workloads of other namespaces in page 2.

But now, it shows 30 workloads of namespace `A` first and 20 workloads of namespace `B` in page 1. And 40 workloads of `A` in page 2 .

## Types of changes

What types of changes does your code introduce to Rancher?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Issues

https://github.com/rancher/rancher/issues/15515

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
_Tip: `yarn lint` or `npm run lint`_
- [ ] Any dependent issues or pr's have been linked
- [ ] If updating dependencies, `yarn.lock` file has been updated and committed

## Further comments

n/a
