### PR TITLE
Fix save button issue

### DIFF
--- a/lib/shared/addon/components/save-cancel/component.js
+++ b/lib/shared/addon/components/save-cancel/component.js
@@ -42,6 +42,9 @@ export default Component.extend({
 
     cancel() {
       this.sendAction('cancel');
+    },
+
+    doNothing() {
     }
   },
 

--- a/lib/shared/addon/components/save-cancel/template.hbs
+++ b/lib/shared/addon/components/save-cancel/template.hbs
@@ -1,6 +1,6 @@
 {{yield}}
 {{#if saving}}
-  <button class="btn bg-primary btn-disabled"><i class="icon icon-spinner icon-spin"></i> {{t savingLabel}}</button>
+  <button class="btn bg-primary btn-disabled" {{action "doNothing"}}><i class="icon icon-spinner icon-spin"></i> {{t savingLabel}}</button>
 {{else}}
   <button type="submit" {{action "save"}} disabled={{saveDisabled}} class="btn {{if saved savedColor saveColor}}">
     {{t btnLabel}}


### PR DESCRIPTION
## Proposed changes

In add node template page, even the save button sate is `saving`. It is still clickable. Clicking the save button will trigger the `submit` method [source code link](https://github.com/rancher/ui/blob/master/lib/shared/addon/mixins/new-or-edit.js#L37) 

We can add `disabled=true` to the button, but it will change the color of the button. So I added a `doNothing` action for it.

## Types of changes

What types of changes does your code introduce to Rancher?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Issues

n/a

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
_Tip: `yarn lint` or `npm run lint`_
- [ ] Any dependent issues or pr's have been linked
- [ ] If updating dependencies, `yarn.lock` file has been updated and committed

## Further comments

n/a