### PR TITLE
Fix health check cannot update initialDelaySeconds

### DIFF
--- a/app/components/form-healthcheck/component.js
+++ b/app/components/form-healthcheck/component.js
@@ -3,6 +3,7 @@ import { observer, get, set, setProperties } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import layout from './template';
+import { scheduleOnce } from '@ember/runloop';
 
 const NONE = 'none';
 const TCP = 'tcp';
@@ -93,6 +94,10 @@ export default Component.extend({
     set(this, 'healthCheck', check);
     set(this, 'checkType', type);
     this.validate();
+
+    scheduleOnce('afterRender', () => {
+      this.checkChanged()
+    });
   },
 
   checkChanged: observer('path', 'host', 'headers', 'checkType', 'command', function() {


### PR DESCRIPTION
## Proposed changes

![image](https://user-images.githubusercontent.com/18737885/45354590-8d2b3e00-b5f0-11e8-8f18-0d04f08681cd.png)

Input 20 but requested field `initialDelaySeconds` is 110. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Lint and unit tests pass locally with my changes
_Tip: `yarn lint` or `npm run lint`_
- [ ] Any dependent issues or pr's have been linked
- [ ] If updating dependencies, `yarn.lock` file has been updated and committed

## Further comments

Change can not pass to parent component. 