### PR TITLE
Warning message in ports section for workload not created by Rancher

### DIFF
--- a/app/components/container/form-ports/component.js
+++ b/app/components/container/form-ports/component.js
@@ -18,12 +18,14 @@ const protocolOptions = [
 ];
 
 export default Component.extend({
-  intl:  service(),
-  scope: service(),
+  intl:     service(),
+  scope:    service(),
+  settings: service(),
 
   layout,
   initialPorts: null,
   editing:      false,
+  showWarning:  false,
   kindChoices:  null,
 
   ports:               null,

--- a/app/components/container/form-ports/template.hbs
+++ b/app/components/container/form-ports/template.hbs
@@ -1,5 +1,8 @@
 <div class="clearfix {{unless editing 'box'}}">
   <label class="{{if editing 'acc-label'}}">{{t 'formPorts.header'}}</label>
+  {{#if showWarning}}
+    {{banner-message icon='icon-alert' color='bg-warning mb-10' message=(t 'formPorts.warning' appName=settings.appName)}}
+  {{/if}}
   {{#if ports.length}}
     <table class="table fixed no-lines small mb-10">
       <thead>

--- a/app/components/container/new-edit/template.hbs
+++ b/app/components/container/new-edit/template.hbs
@@ -66,6 +66,7 @@
 <div class="row">
   {{container/form-ports
     initialPorts=launchConfig.ports
+    showWarning=(and isUpgrade (not service.isCreatedByRancher))
     changed=(action (mut launchConfig.ports))
     errors=portErrors
     editing=true

--- a/app/models/workload.js
+++ b/app/models/workload.js
@@ -9,6 +9,7 @@ import StateCounts from 'ui/mixins/state-counts';
 import EndpointPorts from 'ui/mixins/endpoint-ports';
 import { inject as service } from '@ember/service';
 import DisplayImage from 'shared/mixins/display-image';
+import C from 'shared/utils/constants';
 
 var Workload = Resource.extend(DisplayImage, StateCounts, EndpointPorts, {
   intl:          service(),
@@ -176,6 +177,12 @@ var Workload = Resource.extend(DisplayImage, StateCounts, EndpointPorts, {
 
   secondaryLaunchConfigs: computed('containers.[]', function() {
     return (get(this, 'containers') || []).slice(1);
+  }),
+
+  isCreatedByRancher: computed('workloadAnnotations', function() {
+    const workloadAnnotations = get(this, 'workloadAnnotations') || {};
+
+    return !!workloadAnnotations[C.LABEL.CREATOR_ID];
   }),
 
   actions: {

--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -150,6 +150,8 @@ var C = {
     BALANCER_TARGET:       'io.rancher.lb_service.target',
 
     DEPLOYMENT_REVISION: 'deployment.kubernetes.io/revision',
+
+    CREATOR_ID: 'field.cattle.io/creatorId'
   },
 
   LANGUAGE: {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3656,6 +3656,7 @@ formNetwork:
 formPorts:
   header: Port Mapping
   addAction: Add Port
+  warning: This workload is not created by {appName} UI or {appName} API. {appName} will not automatically create related services for port mapping. 
   kind:
     label: As a
     NodePort: NodePort (On every node)


### PR DESCRIPTION
## Proposed changes

Given a deployment created by `kubectl`.

If you edit it in Rancher UI and update the port mapping, Rancher server will not created related nodePort service or clusterIP service automatically.

A warning message  can help user to notice that when users update a workload created by kubectl.

## Types of changes

What types of changes does your code introduce to Rancher?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Issues

n/a

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
_Tip: `yarn lint` or `npm run lint`_
- [ ] Any dependent issues or pr's have been linked
- [ ] If updating dependencies, `yarn.lock` file has been updated and committed

## Further comments

n/a
