### PR TITLE
Use the legacy incoming webhooks to support overriding channel

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1457,7 +1457,7 @@ notifierPage:
     defaultRecipient: Default Recipient (Channel)
     defaultRecipientPlaceholder: 'e.g. #example'
     helpText: |
-        Here's how you <a href="https://get.slack.help/hc/en-us/articles/115005265063-Incoming-WebHooks-for-Slack" target="_blank" rel="nofollow noopener noreferrer">create incoming WebHooks</a> for slack.
+        Here's how you <a href="https://slack.com/apps/A0F7XDUAZ-incoming-webhooks" target="_blank" rel="nofollow noopener noreferrer">create Incoming WebHooks</a> for Slack.
 
   smtp:
     server: Smtp Server


### PR DESCRIPTION
## Proposed changes

The current link takes you to Slack Apps, which has Incoming WebHooks functionality but lacks overriding params. This points the user to the legacy Incoming WebHooks to make sure they create the correct one. Filed https://github.com/rancher/rancher/issues/15569 to make sure this is being investigated/handled.

## Types of changes

What types of changes does your code introduce to Rancher?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Issues

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
_Tip: `yarn lint` or `npm run lint`_
- [ ] Any dependent issues or pr's have been linked
- [ ] If updating dependencies, `yarn.lock` file has been updated and committed

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
