### PR TITLE
Fix the error message cannot display when auth Github failed.

### DIFF
--- a/lib/shared/addon/github/service.js
+++ b/lib/shared/addon/github/service.js
@@ -9,6 +9,7 @@ export default Service.extend({
   session:     service(),
   globalStore: service(),
   app:         service(),
+  intl:        service(),
 
   generateState() {
     return set(this, 'session.githubState', `${ Math.random() }`);
@@ -81,7 +82,7 @@ export default Service.extend({
           responded = true;
           cb({
             type:    'error',
-            message: intl.t('authPage.github.test.authError')
+            message: intl.t('authPage.github.testAuth.authError')
           });
         }
       } else if (popup === null || typeof (popup) === 'undefined') {
@@ -92,7 +93,7 @@ export default Service.extend({
 
           cb({
             type:    'error',
-            message: intl.t('authPage.github.test.popupError')
+            message: intl.t('authPage.github.testAuth.popupError')
           });
         }
       }


### PR DESCRIPTION
## Proposed changes

The error message cannot display when auth Github failed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Lint and unit tests pass locally with my changes
_Tip: `yarn lint` or `npm run lint`_
- [ ] Any dependent issues or pr's have been linked
- [ ] If updating dependencies, `yarn.lock` file has been updated and committed