### PR TITLE
Alert Users of Remaining Project Resource Quotas

### DIFF
--- a/app/authenticated/cluster/projects/new-ns/template.hbs
+++ b/app/authenticated/cluster/projects/new-ns/template.hbs
@@ -39,6 +39,8 @@
             editing=(or editing isNew)
             expanded=expanded
             limit=primaryResource.resourceQuota.limit
+            projectLimit=primaryResource.project.resourceQuota.limit
+            usedLimit=primaryResource.project.resourceQuota.usedLimit
             nsDefaultQuota=primaryResource.project.namespaceDefaultResourceQuota.limit
             changed=(action "updateNsQuota")
         }}

--- a/app/components/namespace-quota-row/template.hbs
+++ b/app/components/namespace-quota-row/template.hbs
@@ -2,5 +2,12 @@
   {{resource-quota-select editing=false quota=quota}}
 </td>
 <td class="pr-10">
+  {{progress-bar-multi
+      values=quota.projectLimits
+      tooltipValues=quota.totalLimits
+      max=quota.max
+  }}
+</td>
+<td class="pr-10">
   {{input-resource-quota editing=editing quota=quota key='value'}}
 </td>

--- a/app/components/namespace-quota-row/template.hbs
+++ b/app/components/namespace-quota-row/template.hbs
@@ -3,7 +3,7 @@
 </td>
 <td class="pr-10">
   {{progress-bar-multi
-      values=quota.projectLimits
+      values=quota.currentProjectUse
       tooltipValues=quota.totalLimits
       max=quota.max
   }}

--- a/app/components/namespace-resource-quota/component.js
+++ b/app/components/namespace-resource-quota/component.js
@@ -55,26 +55,49 @@ export default Component.extend({
     });
 
     this.sendAction('changed', Object.keys(out).length ? out : null);
+    this.updateLimits();
   }),
 
+  updateLimits() {
+    ( get(this, 'quotaArray') || [] ).forEach((quota) => {
+      if ( quota.key ) {
+        const value       = parseInt(get(quota, 'value'), 10) || 0;
+        const usedValue   = get(quota, 'currentProjectUse.firstObject.value');
+        const newUse      = get(quota, 'currentProjectUse.lastObject');
+        const totalLimits = get(quota, 'totalLimits.firstObject');
+        const myNewUse    = usedValue + value;
+        const translation = get(this, 'intl').t('formResourceQuota.table.resources.tooltip', {
+          usedValue,
+          newUse:    myNewUse,
+          remaining: ( get(quota, 'max') - ( myNewUse ) ),
+        });
+
+        set(newUse, 'value', value);
+        set(totalLimits, 'value', translation);
+      }
+    });
+  },
+
   initQuotaArray() {
-    let limit                 = get(this, 'limit');
+    const limit               = get(this, 'limit');
     const nsDefaultQuota      = get(this, 'nsDefaultQuota');
     const array               = [];
     const used                = get(this, 'usedLimit');
     const currentProjectLimit = get(this, 'projectLimit')
+    const intl = get(this, 'intl');
 
     Object.keys(nsDefaultQuota).forEach((key) => {
       if ( key !== 'type' && typeof nsDefaultQuota[key] ===  'string') {
-        let value;
-        let usedValue = '';
-        let projectLimitValue = '';
+        let value, currentProjectUse, totalLimits;
+        let usedValue         = '';
+        let max = '';
+        let newUse             = null;
 
         if ( limit && !limit[key] ) {
           array.push({
             key,
-            value:         '',
-            projectLimits: [],
+            value:             '',
+            currentProjectUse: [],
           });
 
           return;
@@ -82,33 +105,61 @@ export default Component.extend({
 
         value = limit && limit[key] ? limit[key] : nsDefaultQuota[key];
 
-        if ( key === 'limitsCpu' || key === 'requestsCpu' ) {
-          value = convertToMillis(value);
+        switch (key) {
+        case 'limitsCpu':
+        case 'requestsCpu':
+          value     = convertToMillis(value);
           usedValue = convertToMillis(get(used, key));
-          projectLimitValue = convertToMillis(get(currentProjectLimit, key));
-        } else if ( key === 'limitsMemory' || key === 'requestsMemory' ) {
-          value = parseSi(value, 1024) / 1048576;
+          max       = convertToMillis(get(currentProjectLimit, key));
+          break;
+        case 'limitsMemory':
+        case 'requestsMemory':
+          value     = parseSi(value, 1024) / 1048576;
           usedValue = parseSi(get(used, key), 1024) / 1048576;
-          projectLimitValue = parseSi(get(currentProjectLimit, key), 1024) / 1048576;
-        } else if ( key === 'requestsStorage' ) {
-          value = parseSi(value) / (1024 ** 3);
+          max       = parseSi(get(currentProjectLimit, key), 1024) / 1048576;
+          break;
+        case 'requestsStorage':
+          value     = parseSi(value) / (1024 ** 3);
           usedValue = parseSi(get(used, key)) / (1024 ** 3);
-          projectLimitValue = parseSi(get(currentProjectLimit, key)) / (1024 ** 3);
+          max       = parseSi(get(currentProjectLimit, key)) / (1024 ** 3);
+          break;
+        default:
+          break;
         }
 
-        array.push({
-          key,
-          value,
-          max:           projectLimitValue,
-          projectLimits: [{
+
+        newUse = usedValue + value;
+
+        currentProjectUse = [
+          {
+            // current use
             color: 'bg-error',
             label: key,
             value: usedValue,
-          }],
-          totalLimits: [{
-            label: get(this, 'intl').t(`formResourceQuota.resources.${ key }`),
-            value: `${ projectLimitValue - usedValue } of ${ projectLimitValue } remaining`,
-          }],
+          },
+          {
+            // only need the new value here because progress-multi-bar adds this to the previous
+            color: 'bg-warning',
+            label: key,
+            value,
+          }
+        ];
+
+        totalLimits = [{
+          label: get(this, 'intl').t(`formResourceQuota.resources.${ key }`),
+          value: intl.t('formResourceQuota.table.resources.tooltip', {
+            usedValue,
+            newUse,
+            remaining: ( max - newUse ),
+          })
+        }];
+
+        array.push({
+          currentProjectUse,
+          key,
+          max,
+          totalLimits,
+          value,
         });
       }
     });

--- a/app/components/namespace-resource-quota/template.hbs
+++ b/app/components/namespace-resource-quota/template.hbs
@@ -3,12 +3,13 @@
     <thead>
       <tr>
         <th>{{t 'formResourceQuota.table.type.label'}}</th>
+        <th width="200px">{{t 'formResourceQuota.table.resources.label'}}</th>
         <th>{{t 'formResourceQuota.table.value.label'}}</th>
       </tr>
     </thead>
     <tbody>
       {{#each quotaArray as |quota|}}
-        {{namespace-quota-row 
+        {{namespace-quota-row
             quota=quota
             editing=editing
         }}

--- a/app/components/namespace-table/template.hbs
+++ b/app/components/namespace-table/template.hbs
@@ -15,9 +15,13 @@
 }}
   {{#if (eq kind "row")}}
     <tr class="main-row">
-        <td valign="middle" class="row-check" style="padding-top: 2px;">
-          {{check-box nodeId=ns.id}}
-        </td>
+      <td valign="middle" class="row-check" style="padding-top: 2px;">
+        {{#if (and projectsWithoutNamespace.length (not model.length))}}
+            &nbsp;
+          {{else}}
+            {{check-box nodeId=ns.id}}
+          {{/if}}
+      </td>
       <td>
         {{badge-state model=ns}}
       </td>

--- a/app/components/namespace-table/template.hbs
+++ b/app/components/namespace-table/template.hbs
@@ -16,12 +16,7 @@
   {{#if (eq kind "row")}}
     <tr class="main-row">
         <td valign="middle" class="row-check" style="padding-top: 2px;">
-          {{#if projectsWithoutNamespace.length}}
-            &nbsp;
-          {{else}}
-            {{check-box nodeId=ns.id}}
-          {{/if}}
-
+          {{check-box nodeId=ns.id}}
         </td>
       <td>
         {{badge-state model=ns}}

--- a/app/components/pod-row/template.hbs
+++ b/app/components/pod-row/template.hbs
@@ -32,7 +32,6 @@
         {{#copy-inline clipboardText=model.displayIp}}{{format-ip model.displayIp}}{{/copy-inline}} /
       {{/if}}
       {{#if (and showNode model.node)}}
-        {{log model.node}}
         <a href="{{href-to "node" scope.currentCluster.id model.node.id}}">{{model.node.displayName}}</a> /
       {{/if}}
       {{t 'generic.createdDate' date=(date-from-now model.created) htmlSafe=true}}

--- a/app/components/progress-bar-multi/component.js
+++ b/app/components/progress-bar-multi/component.js
@@ -1,4 +1,4 @@
-import { defineProperty, computed, get } from '@ember/object';
+import { defineProperty, computed, get, observer } from '@ember/object';
 import Component from '@ember/component';
 import layout from './template';
 
@@ -28,19 +28,19 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    let colorKey = this.get('colorKey');
-    let labelKey = this.get('labelKey');
-    let valueKey = this.get('valueKey');
+    let colorKey = get(this, 'colorKey');
+    let labelKey = get(this, 'labelKey');
+    let valueKey = get(this, 'valueKey');
 
     let valueDep = `values.@each.{${ colorKey },${ labelKey },${ valueKey }}`;
 
     defineProperty(this, 'pieces', computed('min', 'max', valueDep, () => {
-      let min = this.get('min');
-      let max = this.get('max');
+      let min = get(this, 'min');
+      let max = get(this, 'max');
 
       var out = [];
 
-      (this.get('values') || []).forEach((obj) => {
+      (get(this, 'values') || []).forEach((obj) => {
         out.push({
           color: get(obj, colorKey),
           label: get(obj, labelKey),
@@ -56,7 +56,7 @@ export default Component.extend({
       }
 
       let sum = 0;
-      let minPercent = this.get('minPercent');
+      let minPercent = get(this, 'minPercent');
 
       out.forEach((obj) => {
         let per = Math.max(minPercent, toPercent(obj.value, min, max));
@@ -79,12 +79,12 @@ export default Component.extend({
 
     valueDep = `tooltipValues.@each.{${ labelKey },${ valueKey }}`;
     defineProperty(this, 'tooltipContent', computed(valueDep, () => {
-      let labelKey = this.get('labelKey');
-      let valueKey = this.get('valueKey');
+      let labelKey = get(this, 'labelKey');
+      let valueKey = get(this, 'valueKey');
 
       var out = [];
 
-      (this.get('tooltipValues') || []).forEach((obj) => {
+      (get(this, 'tooltipValues') || []).forEach((obj) => {
         out.push(`${ get(obj, labelKey) }: ${  get(obj, valueKey) }`);
       });
 
@@ -95,8 +95,9 @@ export default Component.extend({
   didInsertElement() {
     this.zIndexDidChange();
   },
-  zIndexDidChange: function() {
-    this.$().css('zIndex', this.get('zIndex') || 'inherit');
-  }.observes('zIndex'),
+
+  zIndexDidChange: observer('zIndex', function() {
+    this.$().css('zIndex', get(this, 'zIndex') || 'inherit');
+  }),
 
 });

--- a/app/components/progress-bar-multi/template.hbs
+++ b/app/components/progress-bar-multi/template.hbs
@@ -1,4 +1,12 @@
-{{#tooltip-element type="tooltip-basic" model=tooltipContent tooltipTemplate='tooltip-static' aria-describedby="tooltip-base" tooltipFor="progress-bar" inlineBlock=false}}
+{{#tooltip-element
+     type="tooltip-basic"
+     model=tooltipContent
+     tooltipTemplate='tooltip-static'
+     aria-describedby="tooltip-base"
+     tooltipFor="progress-bar"
+     inlineBlock=true
+     classNames="full-width"
+}}
   <div class="progress">
     {{~#each pieces as |obj|~}}
       <div class="progress-bar {{obj.color}}" style={{obj.css}}></div>

--- a/app/components/workload-row/template.hbs
+++ b/app/components/workload-row/template.hbs
@@ -39,8 +39,6 @@
   {{/if}}
 
   <td data-title="{{dt.scale}}" class="text-center">
-    {{log 'pg vals' model.podStates.byColor}}
-    {{log 'pg tt vals' model.podStates.byName}}
     {{progress-bar-multi
         classNames="mt-5"
         labelKey="state"

--- a/app/components/workload-row/template.hbs
+++ b/app/components/workload-row/template.hbs
@@ -39,12 +39,14 @@
   {{/if}}
 
   <td data-title="{{dt.scale}}" class="text-center">
+    {{log 'pg vals' model.podStates.byColor}}
+    {{log 'pg tt vals' model.podStates.byName}}
     {{progress-bar-multi
-      classNames="mt-5"
-      labelKey="state"
-      valueKey="count"
-      values=model.podStates.byColor
-      tooltipValues=model.podStates.byName
+        classNames="mt-5"
+        labelKey="state"
+        valueKey="count"
+        values=model.podStates.byColor
+        tooltipValues=model.podStates.byName
     }}
     <small class="text-muted">
       {{model.displayScale}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3381,7 +3381,7 @@ formResourceQuota:
       memoryPlaceholder: e.g. 1Gi
     resources:
       label: Project Resource Availability
-      tooltip: "Current: { usedValue }, New: { newUse }, Limit Remaining: { remaining }"
+      tooltip: "Reserved - { usedValue }, This Namespace - { newUse }, Available - { remaining }"
     projectLimit:
       label: Project Limit
       placeholder: e.g. 50

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3381,6 +3381,7 @@ formResourceQuota:
       memoryPlaceholder: e.g. 1Gi
     resources:
       label: Project Resource Availability
+      tooltip: "Current: { usedValue }, New: { newUse }, Limit Remaining: { remaining }"
     projectLimit:
       label: Project Limit
       placeholder: e.g. 50

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3379,6 +3379,8 @@ formResourceQuota:
       placeholder: e.g. 10
       milliCpuPlaceholder: e.g. 500
       memoryPlaceholder: e.g. 1Gi
+    resources:
+      label: Project Resource Availability
     projectLimit:
       label: Project Limit
       placeholder: e.g. 50


### PR DESCRIPTION
## Proposed changes

Added a progress bar to the Namespace creation page that shows the remaining/total resources for a project if it has quotas enabled. Additionally if you had any Projects without namespaces in the Projects/Namespaces table at the cluster level you would not see the bulk action checkboxes, that has been fixed. 

## Types of changes

What types of changes does your code introduce to Rancher?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Issues

rancher/rancher#15522
rancher/rancher#15646

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
_Tip: `yarn lint` or `npm run lint`_
- [x] Any dependent issues or pr's have been linked
- [x] If updating dependencies, `yarn.lock` file has been updated and committed

## Further comments
N/A
