### PR TITLE
Show bg-error when new quota exceeds limits

### DIFF
--- a/app/authenticated/cluster/projects/new-ns/controller.js
+++ b/app/authenticated/cluster/projects/new-ns/controller.js
@@ -37,6 +37,27 @@ export default Controller.extend(NewOrEdit, {
     return get(this, 'model.allProjects').filterBy('clusterId', get(this, 'scope.currentCluster.id'))
   }),
 
+  projectLimit: computed('primaryResource.resourceQuota.{limit}', 'primaryResource.projectId', function() {
+    const projectId = get(this, 'primaryResource.projectId');
+    const project   = get(this, 'allProjects').findBy('id', projectId);
+
+    return get(project, 'resourceQuota.limit');
+  }),
+
+  projectUsedLimit: computed('primaryResource.resourceQuota.{limit}', 'primaryResource.projectId', function() {
+    const projectId = get(this, 'primaryResource.projectId');
+    const project   = get(this, 'allProjects').findBy('id', projectId);
+
+    return get(project, 'resourceQuota.usedLimit');
+  }),
+
+  nsDefaultQuota: computed('primaryResource.resourceQuota.{limit}', 'primaryResource.projectId', function() {
+    const projectId = get(this, 'primaryResource.projectId');
+    const project   = get(this, 'allProjects').findBy('id', projectId);
+
+    return get(project, 'namespaceDefaultResourceQuota.limit');
+  }),
+
   nameExists: computed('primaryResource.name', 'model.namespaces.@each.name', function() {
     const name = get(this, 'primaryResource.name');
 

--- a/app/authenticated/cluster/projects/new-ns/template.hbs
+++ b/app/authenticated/cluster/projects/new-ns/template.hbs
@@ -39,9 +39,9 @@
             editing=(or editing isNew)
             expanded=expanded
             limit=primaryResource.resourceQuota.limit
-            projectLimit=primaryResource.project.resourceQuota.limit
-            usedLimit=primaryResource.project.resourceQuota.usedLimit
-            nsDefaultQuota=primaryResource.project.namespaceDefaultResourceQuota.limit
+            projectLimit=projectLimit
+            usedLimit=projectUsedLimit
+            nsDefaultQuota=nsDefaultQuota
             changed=(action "updateNsQuota")
         }}
       {{/accordion-list-item}}

--- a/app/components/namespace-quota-row/template.hbs
+++ b/app/components/namespace-quota-row/template.hbs
@@ -6,6 +6,7 @@
       values=quota.currentProjectUse
       tooltipValues=quota.totalLimits
       max=quota.max
+      minPercent=0
   }}
 </td>
 <td class="pr-10">

--- a/app/components/namespace-resource-quota/component.js
+++ b/app/components/namespace-resource-quota/component.js
@@ -66,11 +66,20 @@ export default Component.extend({
         const newUse      = get(quota, 'currentProjectUse.lastObject');
         const totalLimits = get(quota, 'totalLimits.firstObject');
         const myNewUse    = usedValue + value;
+        const remaining   = ( get(quota, 'max') - ( myNewUse ) ) > 0 ? ( get(quota, 'max') - ( myNewUse ) ) : 0;
         const translation = get(this, 'intl').t('formResourceQuota.table.resources.tooltip', {
           usedValue,
+          remaining,
           newUse:    myNewUse,
-          remaining: ( get(quota, 'max') - ( myNewUse ) ),
         });
+
+        if (remaining === 0) {
+          set(newUse, 'color', 'bg-error');
+        } else {
+          if (get(newUse, 'color') === 'bg-error') {
+            set(newUse, 'color', 'bg-warning');
+          }
+        }
 
         set(newUse, 'value', value);
         set(totalLimits, 'value', translation);
@@ -88,10 +97,11 @@ export default Component.extend({
 
     Object.keys(nsDefaultQuota).forEach((key) => {
       if ( key !== 'type' && typeof nsDefaultQuota[key] ===  'string') {
-        let value, currentProjectUse, totalLimits;
-        let usedValue         = '';
-        let max = '';
-        let newUse             = null;
+        let value, currentProjectUse, totalLimits, remaining;
+        let usedValue = '';
+        let max       = '';
+        let newUse    = null;
+        let useColorKey = 'bg-warning';
 
         if ( limit && !limit[key] ) {
           array.push({
@@ -133,6 +143,12 @@ export default Component.extend({
 
         newUse = usedValue + value;
 
+        remaining = ( max - newUse ) > 0 ? ( max - newUse ) : 0;
+
+        if (remaining === 0) {
+          useColorKey = 'bg-error';
+        }
+
         currentProjectUse = [
           {
             // current use
@@ -142,7 +158,7 @@ export default Component.extend({
           },
           {
             // only need the new value here because progress-multi-bar adds this to the previous
-            color: 'bg-warning',
+            color: useColorKey,
             label: key,
             value,
           }
@@ -153,7 +169,7 @@ export default Component.extend({
           value: intl.t('formResourceQuota.table.resources.tooltip', {
             usedValue,
             newUse,
-            remaining: ( max - newUse ),
+            remaining,
           })
         }];
 


### PR DESCRIPTION
## Proposed changes

If a user was adding a new namespace where the new NS limit exceeds the project NS limit the progress bar would not reflect this. The tool tip would show a negative value in the available space. The progress bar now shows the error color for all resources and the tooltip shows you that you have 0 available resources left. 

## Types of changes

What types of changes does your code introduce to Rancher?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Issues

rancher/rancher#15687

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
_Tip: `yarn lint` or `npm run lint`_
- [x] Any dependent issues or pr's have been linked
- [x] If updating dependencies, `yarn.lock` file has been updated and committed

## Further comments

N/A
