### PR TITLE
Rework NS Quota Progress Bar

### DIFF
--- a/app/authenticated/cluster/projects/new-ns/controller.js
+++ b/app/authenticated/cluster/projects/new-ns/controller.js
@@ -37,6 +37,27 @@ export default Controller.extend(NewOrEdit, {
     return get(this, 'model.allProjects').filterBy('clusterId', get(this, 'scope.currentCluster.id'))
   }),
 
+  projectLimit: computed('primaryResource.resourceQuota.{limit}', 'primaryResource.projectId', function() {
+    const projectId = get(this, 'primaryResource.projectId');
+    const project   = get(this, 'allProjects').findBy('id', projectId);
+
+    return get(project, 'resourceQuota.limit');
+  }),
+
+  projectUsedLimit: computed('primaryResource.resourceQuota.{limit}', 'primaryResource.projectId', function() {
+    const projectId = get(this, 'primaryResource.projectId');
+    const project   = get(this, 'allProjects').findBy('id', projectId);
+
+    return get(project, 'resourceQuota.usedLimit');
+  }),
+
+  nsDefaultQuota: computed('primaryResource.resourceQuota.{limit}', 'primaryResource.projectId', function() {
+    const projectId = get(this, 'primaryResource.projectId');
+    const project   = get(this, 'allProjects').findBy('id', projectId);
+
+    return get(project, 'namespaceDefaultResourceQuota.limit');
+  }),
+
   nameExists: computed('primaryResource.name', 'model.namespaces.@each.name', function() {
     const name = get(this, 'primaryResource.name');
 

--- a/app/authenticated/cluster/projects/new-ns/template.hbs
+++ b/app/authenticated/cluster/projects/new-ns/template.hbs
@@ -39,9 +39,9 @@
             editing=(or editing isNew)
             expanded=expanded
             limit=primaryResource.resourceQuota.limit
-            projectLimit=primaryResource.project.resourceQuota.limit
-            usedLimit=primaryResource.project.resourceQuota.usedLimit
-            nsDefaultQuota=primaryResource.project.namespaceDefaultResourceQuota.limit
+            projectLimit=projectLimit
+            usedLimit=projectUsedLimit
+            nsDefaultQuota=nsDefaultQuota
             changed=(action "updateNsQuota")
         }}
       {{/accordion-list-item}}

--- a/app/components/namespace-quota-row/template.hbs
+++ b/app/components/namespace-quota-row/template.hbs
@@ -5,6 +5,8 @@
   {{progress-bar-multi
       values=quota.currentProjectUse
       tooltipValues=quota.totalLimits
+      tooltipArrayOrString="array"
+      tooltipTemplate="-ns-quota-progressbar"
       max=quota.max
       minPercent=0
   }}

--- a/app/components/namespace-quota-row/template.hbs
+++ b/app/components/namespace-quota-row/template.hbs
@@ -6,6 +6,7 @@
       values=quota.currentProjectUse
       tooltipValues=quota.totalLimits
       max=quota.max
+      minPercent=0
   }}
 </td>
 <td class="pr-10">

--- a/app/components/namespace-quota-row/template.hbs
+++ b/app/components/namespace-quota-row/template.hbs
@@ -9,6 +9,6 @@
       minPercent=0
   }}
 </td>
-<td class="pr-10">
+<td>
   {{input-resource-quota editing=editing quota=quota key='value'}}
 </td>

--- a/app/components/namespace-resource-quota/component.js
+++ b/app/components/namespace-resource-quota/component.js
@@ -50,8 +50,6 @@ export default Component.extend({
         }
 
         if (value > max || (( currentUse + value ) > max)) {
-          console.log('over max!')
-
           value = set(quota, 'value', max - currentUse);
         }
 

--- a/app/components/namespace-resource-quota/component.js
+++ b/app/components/namespace-resource-quota/component.js
@@ -66,11 +66,20 @@ export default Component.extend({
         const newUse      = get(quota, 'currentProjectUse.lastObject');
         const totalLimits = get(quota, 'totalLimits.firstObject');
         const myNewUse    = usedValue + value;
+        const remaining   = ( get(quota, 'max') - ( myNewUse ) ) > 0 ? ( get(quota, 'max') - ( myNewUse ) ) : 0;
         const translation = get(this, 'intl').t('formResourceQuota.table.resources.tooltip', {
           usedValue,
+          remaining,
           newUse:    myNewUse,
-          remaining: ( get(quota, 'max') - ( myNewUse ) ),
         });
+
+        if (remaining === 0) {
+          set(newUse, 'color', 'bg-error');
+        } else {
+          if (get(newUse, 'color') === 'bg-error') {
+            set(newUse, 'color', 'bg-warning');
+          }
+        }
 
         set(newUse, 'value', value);
         set(totalLimits, 'value', translation);
@@ -88,10 +97,11 @@ export default Component.extend({
 
     Object.keys(nsDefaultQuota).forEach((key) => {
       if ( key !== 'type' && typeof nsDefaultQuota[key] ===  'string') {
-        let value, currentProjectUse, totalLimits;
-        let usedValue         = '';
-        let max = '';
-        let newUse             = null;
+        let value, currentProjectUse, totalLimits, remaining;
+        let usedValue = '';
+        let max       = '';
+        let newUse    = null;
+        let useColorKey = 'bg-warning';
 
         if ( limit && !limit[key] ) {
           array.push({
@@ -133,6 +143,12 @@ export default Component.extend({
 
         newUse = usedValue + value;
 
+        remaining = ( max - newUse ) > 0 ? ( max - newUse ) : 0;
+
+        if (remaining === 0) {
+          useColorKey = 'bg-error';
+        }
+
         currentProjectUse = [
           {
             // current use
@@ -142,7 +158,7 @@ export default Component.extend({
           },
           {
             // only need the new value here because progress-multi-bar adds this to the previous
-            color: 'bg-warning',
+            color: useColorKey,
             label: key,
             value,
           }
@@ -153,7 +169,7 @@ export default Component.extend({
           value: intl.t('formResourceQuota.table.resources.tooltip', {
             usedValue,
             newUse,
-            remaining: ( max - newUse ),
+            remaining,
           })
         }];
 

--- a/app/components/namespace-resource-quota/component.js
+++ b/app/components/namespace-resource-quota/component.js
@@ -100,6 +100,10 @@ export default Component.extend({
           {
             label: intl.t('formResourceQuota.table.resources.available'),
             value: this.quotaWithUnits(quota, remaining, true),
+          },
+          {
+            label: intl.t('formResourceQuota.table.resources.max'),
+            value: this.quotaWithUnits(quota, get(quota, 'max'), true),
           }
         ];
 
@@ -208,6 +212,10 @@ export default Component.extend({
           {
             label: intl.t('formResourceQuota.table.resources.available'),
             value: this.quotaWithUnits(nsDefaultQuota[key], remaining, true),
+          },
+          {
+            label: intl.t('formResourceQuota.table.resources.max'),
+            value: this.quotaWithUnits(nsDefaultQuota[key], max, true),
           }
         ];
 

--- a/app/components/namespace-resource-quota/component.js
+++ b/app/components/namespace-resource-quota/component.js
@@ -6,6 +6,11 @@ import { parseSi } from 'shared/utils/parse-unit';
 import layout from './template';
 import { inject as service } from '@ember/service';
 
+const defaultRadix      = 10;
+const defaultIncrement  = 1024;
+const defaultDivisor    = 1048576;
+const defaultMultiplier = 3;
+
 export default Component.extend({
   intl: service(),
 
@@ -34,7 +39,9 @@ export default Component.extend({
 
     (get(this, 'quotaArray') || []).forEach((quota) => {
       if ( quota.key ) {
-        let value = quota.value;
+        let value      = parseInt(get(quota, 'value'), defaultRadix);
+        let max        = get(quota, 'max');
+        let currentUse = get(quota, 'currentProjectUse.firstObject.value');
 
         if ( !value ) {
           out[quota.key] = '';
@@ -42,15 +49,13 @@ export default Component.extend({
           return;
         }
 
-        if ( quota.key === 'limitsCpu' || quota.key === 'requestsCpu' ) {
-          value = `${ value }m`;
-        } else if ( quota.key === 'limitsMemory' || quota.key === 'requestsMemory' ) {
-          value = `${ value }Mi`;
-        } else if ( quota.key === 'requestsStorage' ) {
-          value = `${ value }Gi`;
+        if (value > max || (( currentUse + value ) > max)) {
+          console.log('over max!')
+
+          value = set(quota, 'value', max - currentUse);
         }
 
-        out[quota.key] = value;
+        out[quota.key] = this.quotaWithUnits(quota, value);
       }
     });
 
@@ -58,20 +63,45 @@ export default Component.extend({
     this.updateLimits();
   }),
 
+  quotaWithUnits(quota, value, readable = false) {
+    let cpuNotation     = readable ? 'milli CPUs' : 'm';
+    let memNotation     = readable ? 'MiB' : 'Mi';
+    let storageNotation = readable ? 'GB' : 'Gi';
+
+    if ( quota.key === 'limitsCpu' || quota.key === 'requestsCpu' ) {
+      return `${ value }${ cpuNotation }`;
+    } else if ( quota.key === 'limitsMemory' || quota.key === 'requestsMemory' ) {
+      return `${ value }${ memNotation }`;
+    } else if ( quota.key === 'requestsStorage' ) {
+      return `${ value }${ storageNotation }`;
+    } else {
+      return value;
+    }
+  },
+
   updateLimits() {
     ( get(this, 'quotaArray') || [] ).forEach((quota) => {
       if ( quota.key ) {
-        const value       = parseInt(get(quota, 'value'), 10) || 0;
+        const intl        = get(this, 'intl');
+        const value       = parseInt(get(quota, 'value'), defaultRadix) || 0;
         const usedValue   = get(quota, 'currentProjectUse.firstObject.value');
         const newUse      = get(quota, 'currentProjectUse.lastObject');
-        const totalLimits = get(quota, 'totalLimits.firstObject');
         const myNewUse    = usedValue + value;
         const remaining   = ( get(quota, 'max') - ( myNewUse ) ) > 0 ? ( get(quota, 'max') - ( myNewUse ) ) : 0;
-        const translation = get(this, 'intl').t('formResourceQuota.table.resources.tooltip', {
-          usedValue,
-          remaining,
-          newUse:    myNewUse,
-        });
+        const newTotals   = [
+          {
+            label: intl.t('formResourceQuota.table.resources.reserved'),
+            value: this.quotaWithUnits(quota, usedValue, true),
+          },
+          {
+            label: intl.t('formResourceQuota.table.resources.namespace'),
+            value: this.quotaWithUnits(quota, value, true),
+          },
+          {
+            label: intl.t('formResourceQuota.table.resources.available'),
+            value: this.quotaWithUnits(quota, remaining, true),
+          }
+        ];
 
         if (remaining === 0) {
           set(newUse, 'color', 'bg-error');
@@ -82,18 +112,20 @@ export default Component.extend({
         }
 
         set(newUse, 'value', value);
-        set(totalLimits, 'value', translation);
+        set(quota, 'totalLimits', newTotals);
       }
     });
   },
 
   initQuotaArray() {
-    const limit               = get(this, 'limit');
-    const nsDefaultQuota      = get(this, 'nsDefaultQuota');
-    const array               = [];
+    const {
+      limit,
+      nsDefaultQuota,
+      intl
+    }                         = this;
     const used                = get(this, 'usedLimit');
     const currentProjectLimit = get(this, 'projectLimit')
-    const intl = get(this, 'intl');
+    const array               = [];
 
     Object.keys(nsDefaultQuota).forEach((key) => {
       if ( key !== 'type' && typeof nsDefaultQuota[key] ===  'string') {
@@ -124,19 +156,19 @@ export default Component.extend({
           break;
         case 'limitsMemory':
         case 'requestsMemory':
-          value     = parseSi(value, 1024) / 1048576;
-          usedValue = parseSi(get(used, key), 1024) / 1048576;
-          max       = parseSi(get(currentProjectLimit, key), 1024) / 1048576;
+          value     = parseSi(value, defaultIncrement) / defaultDivisor;
+          usedValue = parseSi(get(used, key), defaultIncrement) / defaultDivisor;
+          max       = parseSi(get(currentProjectLimit, key), defaultIncrement) / defaultDivisor;
           break;
         case 'requestsStorage':
-          value     = parseSi(value) / (1024 ** 3);
-          usedValue = parseSi(get(used, key)) / (1024 ** 3);
-          max       = parseSi(get(currentProjectLimit, key)) / (1024 ** 3);
+          value     = parseSi(value) / (defaultIncrement ** defaultMultiplier);
+          usedValue = parseSi(get(used, key)) / (defaultIncrement ** defaultMultiplier);
+          max       = parseSi(get(currentProjectLimit, key)) / (defaultIncrement ** defaultMultiplier);
           break;
         default:
-          value     = parseInt(value, 10);
-          usedValue = parseInt(( get(used, key) || 0 ), 10);
-          max       = parseInt(get(currentProjectLimit, key), 10);
+          value     = parseInt(value, defaultRadix);
+          usedValue = parseInt(( get(used, key) || 0 ), defaultRadix);
+          max       = parseInt(get(currentProjectLimit, key), defaultRadix);
           break;
         }
 
@@ -152,7 +184,7 @@ export default Component.extend({
         currentProjectUse = [
           {
             // current use
-            color: 'bg-error',
+            color: 'bg-info',
             label: key,
             value: usedValue,
           },
@@ -164,14 +196,20 @@ export default Component.extend({
           }
         ];
 
-        totalLimits = [{
-          label: get(this, 'intl').t(`formResourceQuota.resources.${ key }`),
-          value: intl.t('formResourceQuota.table.resources.tooltip', {
-            usedValue,
-            newUse,
-            remaining,
-          })
-        }];
+        totalLimits = [
+          {
+            label: intl.t('formResourceQuota.table.resources.reserved'),
+            value: this.quotaWithUnits(nsDefaultQuota[key], usedValue, true),
+          },
+          {
+            label: intl.t('formResourceQuota.table.resources.namespace'),
+            value: this.quotaWithUnits(nsDefaultQuota[key], value, true),
+          },
+          {
+            label: intl.t('formResourceQuota.table.resources.available'),
+            value: this.quotaWithUnits(nsDefaultQuota[key], remaining, true),
+          }
+        ];
 
         array.push({
           currentProjectUse,

--- a/app/components/namespace-resource-quota/template.hbs
+++ b/app/components/namespace-resource-quota/template.hbs
@@ -3,7 +3,7 @@
     <thead>
       <tr>
         <th>{{t 'formResourceQuota.table.type.label'}}</th>
-        <th width="200px">{{t 'formResourceQuota.table.resources.label'}}</th>
+        <th>{{t 'formResourceQuota.table.resources.label'}}</th>
         <th>{{t 'formResourceQuota.table.value.label'}}</th>
       </tr>
     </thead>

--- a/app/components/progress-bar-multi/component.js
+++ b/app/components/progress-bar-multi/component.js
@@ -99,7 +99,6 @@ export default Component.extend({
 
 
       return get(this, 'tooltipArrayOrString') === 'string' ?  out.join('\n') : out;
-
     }));
   },
 

--- a/app/components/progress-bar-multi/component.js
+++ b/app/components/progress-bar-multi/component.js
@@ -13,18 +13,20 @@ function toPercent(value, min, max) {
 
 export default Component.extend({
   layout,
-  tagName:    'div',
-  classNames: ['progress-bar-multi'],
+  tagName:              'div',
+  classNames:           ['progress-bar-multi'],
 
-  values:        null,
-  colorKey:      'color',
-  labelKey:      'label',
-  valueKey:      'value',
-  tooltipValues: null,
-  min:           0,
-  max:           null,
-  minPercent:    10,
-  zIndex:        null,
+  values:               null,
+  colorKey:             'color',
+  labelKey:             'label',
+  valueKey:             'value',
+  tooltipValues:        null,
+  min:                  0,
+  max:                  null,
+  minPercent:           10,
+  zIndex:               null,
+  tooltipTemplate:      'tooltip-static',
+  tooltipArrayOrString: 'string',
 
   init() {
     this._super(...arguments);
@@ -85,10 +87,19 @@ export default Component.extend({
       var out = [];
 
       (get(this, 'tooltipValues') || []).forEach((obj) => {
-        out.push(`${ get(obj, labelKey) }: ${  get(obj, valueKey) }`);
+        if (get(this, 'tooltipArrayOrString') === 'string') {
+          out.push(`${ get(obj, labelKey) }: ${  get(obj, valueKey) }`);
+        } else {
+          out.push({
+            label: get(obj, labelKey),
+            value: get(obj, valueKey),
+          });
+        }
       });
 
-      return out.join('\n');
+
+      return get(this, 'tooltipArrayOrString') === 'string' ?  out.join('\n') : out;
+
     }));
   },
 

--- a/app/components/progress-bar-multi/template.hbs
+++ b/app/components/progress-bar-multi/template.hbs
@@ -1,7 +1,7 @@
 {{#tooltip-element
      type="tooltip-basic"
      model=tooltipContent
-     tooltipTemplate='tooltip-static'
+     tooltipTemplate=tooltipTemplate
      aria-describedby="tooltip-base"
      tooltipFor="progress-bar"
      inlineBlock=true

--- a/app/styles/components/_tables.scss
+++ b/app/styles/components/_tables.scss
@@ -420,6 +420,29 @@ TABLE {
   &.solid {
     @include solid;
   }
+
+
+  &.tooltip-table {
+    > TBODY {
+      background: transparent;
+      > TR {
+        background-color: transparent;
+        &:last-of-type {
+          border-top: #41484d solid 2px;
+
+        }
+        td {
+          height: 25px;
+          margin: 0;
+          max-height: 25px;
+          padding-left: 10px;
+          &:first-of-type {
+            text-align:left;
+          }
+        }
+      }
+    }
+  }
 }
 
 .box > div > table.striped {

--- a/app/templates/-ns-quota-progressbar.hbs
+++ b/app/templates/-ns-quota-progressbar.hbs
@@ -1,0 +1,10 @@
+<table class="table fixed" style="max-width: 300px;">
+  <tbody>
+    {{#each model as |tt|}}
+      <tr>
+        <td class="pl-10 m-0" style="max-height: 25px;height: 25px;text-align:left;">{{tt.label}}</td>
+        <td class="pl-10 m-0" style="max-height: 25px;height: 25px;">{{tt.value}}</td>
+      </tr>
+    {{/each}}
+  </tbody>
+</table>

--- a/app/templates/-ns-quota-progressbar.hbs
+++ b/app/templates/-ns-quota-progressbar.hbs
@@ -1,9 +1,9 @@
-<table class="table fixed" style="max-width: 300px;">
+<table class="table fixed tooltip-table" style="max-width: 300px;">
   <tbody>
     {{#each model as |tt|}}
       <tr>
-        <td class="pl-10 m-0" style="max-height: 25px;height: 25px;text-align:left;">{{tt.label}}</td>
-        <td class="pl-10 m-0" style="max-height: 25px;height: 25px;">{{tt.value}}</td>
+        <td>{{tt.label}}:</td>
+        <td>{{tt.value}}</td>
       </tr>
     {{/each}}
   </tbody>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3384,9 +3384,10 @@ formResourceQuota:
       memoryPlaceholder: e.g. 1Gi
     resources:
       label: Project Resource Availability
-      reserved: Reserved
+      reserved: Other Namespaces
       namespace: This Namespace
       available: Available
+      max: Total
     projectLimit:
       label: Project Limit
       placeholder: e.g. 50

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3384,7 +3384,9 @@ formResourceQuota:
       memoryPlaceholder: e.g. 1Gi
     resources:
       label: Project Resource Availability
-      tooltip: "Reserved - { usedValue }, This Namespace - { newUse }, Available - { remaining }"
+      reserved: Reserved
+      namespace: This Namespace
+      available: Available
     projectLimit:
       label: Project Limit
       placeholder: e.g. 50


### PR DESCRIPTION
## Proposed changes

Based on feedback from review I've tweaked the way the progress bar works when creating a NS for a project with quotas. 

## Types of changes

What types of changes does your code introduce to Rancher?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Issues

rancher/rancher#15522
rancher/rancher#15687

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
_Tip: `yarn lint` or `npm run lint`_
- [x] Any dependent issues or pr's have been linked
- [x] If updating dependencies, `yarn.lock` file has been updated and committed

## Further comments
- [x] "Reserved" color shouldn't stand out... bg-info
- [x] "This namespace" number should be the same as the input on the right (=5), not (reserved+this=11)
- [x] The math is wrong somehow, if you put in a 0 quota there's still a yellow bar, sometimes @tfiduccia gets NaNs for all the numbers, etc
- [x] You shouldn't be able to type in a number higher than is available, or negative numbers in the first place.. set min/max on the input
- [x] Use colons instead of hyphens, and newlines, and drop the field name ("Pods") from the tooltip
- [x] Show units on the numbers when appropriate (500 MiB)
- [x] Trying again on the labels with @tfiduccia (below)
- [x] And +1 internet points if it could be an actual HTML table so they line up nicely (ignore the first row, GitHub markdown...):
