### PR TITLE
If Editing Saml will no longer reset the allowedPrincipalIds on save

### DIFF
--- a/lib/global-admin/addon/mixins/saml-auth.js
+++ b/lib/global-admin/addon/mixins/saml-auth.js
@@ -43,9 +43,15 @@ export default Mixin.create({
       } else {
         set(this, 'testing', true);
 
+        let allowedPrincipals = [];
+
+        if (get(this, 'editing')) {
+          allowedPrincipals = get(model, 'allowedPrincipalIds');
+        }
+
         setProperties(model, {
           'enabled':             false, // It should already be, but just in case..
-          'allowedPrincipalIds': [],
+          'allowedPrincipalIds': allowedPrincipals,
         });
 
         model.save().then(() => {


### PR DESCRIPTION
## Proposed changes

If we were editing a SAML auth config (e.g., `pingConfig`) the `allowedPrincipalIds` list was being reset. Added a check for editing, if so we reuse the previous configs APIDs.

## Types of changes

What types of changes does your code introduce to Rancher?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Issues

rancher/rancher#15769

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
_Tip: `yarn lint` or `npm run lint`_
- [x] Any dependent issues or pr's have been linked
- [x] If updating dependencies, `yarn.lock` file has been updated and committed

## Further comments

N/A
