### PR TITLE
Support vSphere network protocol profiles

### DIFF
--- a/lib/nodes/addon/components/driver-vmwarevsphere/component.js
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/component.js
@@ -8,6 +8,88 @@ import C from 'shared/utils/constants';
 
 const DRIVER = 'vmwarevsphere';
 const CONFIG = 'vmwarevsphereConfig';
+const VAPP_MODE_DISABLED = 'disabled';
+const VAPP_MODE_AUTO = 'auto';
+const VAPP_MODE_MANUAL = 'manual';
+
+const stringsToParams = (params, str) => {
+  const index = str.indexOf('=');
+
+  if ( index > -1 ) {
+    params.push({
+      key:   str.slice(0, index),
+      value: str.slice(index + 1),
+    });
+  }
+
+  return params;
+}
+
+const paramsToStrings = (strs, param) => {
+  if (param.value && param.key) {
+    strs.push(`${ param.key }=${ param.value }`);
+  }
+
+  return strs;
+}
+
+const initialVAppOptions = {
+  vappIpprotocol:         '',
+  vappIpallocationpolicy: '',
+  vappTransport:          '',
+  vappProperty:           []
+}
+
+const getDefaultVappOptions = (networks) => ({
+  vappIpprotocol:         'IPv4',
+  vappIpallocationpolicy: 'fixedAllocated',
+  vappTransport:          'com.vmware.guestInfo',
+  vappProperty:           networksToVappProperties(networks)
+})
+const networksToVappProperties = (networks) => networks.length === 0
+  ? []
+  : networks.reduce(networkToVappProperties, [
+    `guestinfo.dns.servers=\${dns:${ networks[0] }}`,
+    `guestinfo.dns.domains=\${searchPath:${ networks[0] }}`
+  ])
+const networkToVappProperties = (props, network, i) => {
+  const n = i.toString();
+
+  props.push(
+    `guestinfo.interface.${ n }.ip.0.address=ip:${ network }`,
+    `guestinfo.interface.${ n }.ip.0.netmask=\${netmask:${ network }}`,
+    `guestinfo.interface.${ n }.route.0.gateway=\${gateway:${ network }}`
+  );
+
+  return props;
+}
+
+const getInitialVappMode = (c) => {
+  const vappProperty = c.vappProperty || []
+
+  if (
+    !c.vappIpprotocol &&
+    !c.vappIpallocationpolicy &&
+    !c.vappTransport &&
+    vappProperty.length === 0
+  ) {
+    return VAPP_MODE_DISABLED;
+  }
+
+  const d = getDefaultVappOptions(c.network);
+
+  if (
+    c.vappIpprotocol === d.vappIpprotocol &&
+    c.vappIpallocationpolicy === d.vappIpallocationpolicy &&
+    c.vappTransport === d.vappTransport &&
+    vappProperty.length === d.vappProperty.length &&
+    vappProperty.join() === d.vappProperty.join()
+  ) {
+    return VAPP_MODE_AUTO;
+  }
+
+  return VAPP_MODE_MANUAL;
+}
 
 export default Component.extend(NodeDriver, {
   settings: service(),
@@ -17,25 +99,30 @@ export default Component.extend(NodeDriver, {
   model:          null,
   showEngineUrl:  false,
   initParamArray: null,
+  initVappArray:  null,
+  vappMode:       VAPP_MODE_DISABLED,
 
   config:  alias(`model.${ CONFIG }`),
   init() {
     this._super(...arguments);
-    this.initCfgParam();
+    this.initKeyValueParams('config.cfgparam', 'initParamArray');
+    this.initKeyValueParams('config.vappProperty', 'initVappArray');
+    this.initVappMode();
   },
 
   actions: {
     paramChanged(array) {
-      const out = [];
-
-      array.filter((param) => param.value && param.key).forEach((param) => {
-        out.push(`${ param.key }=${ param.value }`);
-      });
-      set(this, 'config.cfgparam', out);
+      this.updateKeyValueParams('config.cfgparam', array);
+    },
+    vappPropertyChanged(array) {
+      this.updateKeyValueParams('config.vappProperty', array);
     }
   },
 
   network: computed('config.network', {
+    get() {
+      return (get(this, 'config.network') || []).join(', ');
+    },
     set(k, value) {
       set(this, 'config.network', value.split(',').filter((x) => {
         return x.trim().length !== 0
@@ -49,33 +136,56 @@ export default Component.extend(NodeDriver, {
     let iso = get(this, `settings.${ C.SETTING.ENGINE_ISO_URL }`) || 'https://releases.rancher.com/os/latest/rancheros-vmware.iso';
 
     let config = get(this, 'globalStore').createRecord({
-      type:           CONFIG,
-      password:       '',
-      cpuCount:       2,
-      memorySize:     2048,
-      diskSize:       20000,
-      vcenterPort:    443,
-      network:        [],
-      cfgparam:       ['disk.enableUUID=TRUE'],
-      boot2dockerUrl: iso,
+      type:                   CONFIG,
+      password:               '',
+      cpuCount:               2,
+      memorySize:             2048,
+      diskSize:               20000,
+      vcenterPort:            443,
+      network:                [],
+      cfgparam:               ['disk.enableUUID=TRUE'],
+      boot2dockerUrl:         iso,
+      vappIpprotocol:         initialVAppOptions.vappIpprotocol,
+      vappIpallocationpolicy: initialVAppOptions.vappIpallocationpolicy,
+      vappTransport:          initialVAppOptions.vappTransport,
+      vappProperty:           initialVAppOptions.vappProperty
     });
 
     set(this, `model.${ CONFIG }`, config);
   },
 
-  initCfgParam() {
-    const cfgparam = get(this, 'config.cfgparam') || [];
-
-    set(this, 'initParamArray', []);
-    (cfgparam || []).forEach((param) => {
-      const index = (param || '').indexOf('=');
-
-      if ( index > -1 ) {
-        get(this, 'initParamArray').push({
-          key:   param.slice(0, index),
-          value: param.slice(index + 1),
-        });
-      }
-    });
+  initKeyValueParams(pairsKey, paramsKey) {
+    set(this, paramsKey, (get(this, pairsKey) || []).reduce(stringsToParams, []));
   },
+
+  updateKeyValueParams(pairsKey, params) {
+    set(this, pairsKey, params.reduce(paramsToStrings, []));
+  },
+
+  initVappMode() {
+    set(this, 'vappMode', getInitialVappMode(get(this, 'config')));
+  },
+
+  updateVappOptions(opts) {
+    set(this, 'config.vappIpprotocol', opts.vappIpprotocol);
+    set(this, 'config.vappIpallocationpolicy', opts.vappIpallocationpolicy);
+    set(this, 'config.vappTransport', opts.vappTransport);
+    set(this, 'config.vappProperty', opts.vappProperty);
+    this.initKeyValueParams('config.vappProperty', 'initVappArray');
+  },
+
+  willSave() {
+    const vappMode = get(this, 'vappMode')
+
+    if (vappMode === VAPP_MODE_DISABLED) {
+      this.updateVappOptions(initialVAppOptions);
+    } else if (vappMode === VAPP_MODE_AUTO) {
+      const network = get(this, 'config.network')
+      const defaultVappOptions = getDefaultVappOptions(network)
+
+      this.updateVappOptions(defaultVappOptions);
+    }
+
+    return this._super(...arguments);
+  }
 });

--- a/lib/nodes/addon/components/driver-vmwarevsphere/template.hbs
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/template.hbs
@@ -144,6 +144,64 @@
     </div>
   {{/accordion-list-item}}
 
+  {{#accordion-list-item
+    title=(t 'nodeDriver.vmwarevsphere.vappOptions.title')
+    detail=(t 'nodeDriver.vmwarevsphere.vappOptions.detail')
+    expandAll=expandAll
+    expand=(action expandFn)
+    expandOnInit=true
+  }}
+    <p class="help-block">{{t 'nodeDriver.vmwarevsphere.vappHelp'}}</p>
+    <div class="row">
+      <div class="col span-12">
+        <div class="radio">
+          <label>{{radio-button selection=vappMode value="disabled"}} {{t 'nodeDriver.vmwarevsphere.vappMode.disabled'}}</label>
+        </div>
+        <div class="radio">
+          <label>{{radio-button selection=vappMode value="auto"}} {{t 'nodeDriver.vmwarevsphere.vappMode.auto'}}</label>
+        </div>
+        <div class="radio">
+          <label>{{radio-button selection=vappMode value="manual"}} {{t 'nodeDriver.vmwarevsphere.vappMode.manual'}}</label>
+        </div>
+      </div>
+    </div>
+    {{#if (eq vappMode "manual")}}
+      <div>
+        <div class="row">
+          <div class="col span-4">
+            <label class="acc-label">{{t 'nodeDriver.vmwarevsphere.vappTransport.label'}}</label>
+            {{input type="text" value=config.vappTransport classNames="form-control" placeholder=(t 'nodeDriver.vmwarevsphere.vappTransport.placeholder')}}
+            <p class="help-block">{{t 'nodeDriver.vmwarevsphere.vappTransport.help'}}</p>
+          </div>
+          <div class="col span-4">
+            <label class="acc-label">{{t 'nodeDriver.vmwarevsphere.vappIpprotocol.label'}}</label>
+            {{input type="text" value=config.vappIpprotocol classNames="form-control" placeholder=(t 'nodeDriver.vmwarevsphere.vappIpprotocol.placeholder')}}
+            <p class="help-block">{{t 'nodeDriver.vmwarevsphere.vappIpprotocol.help'}}</p>
+          </div>
+          <div class="col span-4">
+            <label class="acc-label">{{t 'nodeDriver.vmwarevsphere.vappIpallocationpolicy.label'}}</label>
+            {{input type="text" value=config.vappIpallocationpolicy classNames="form-control" placeholder=(t 'nodeDriver.vmwarevsphere.vappIpallocationpolicy.placeholder')}}
+            <p class="help-block">{{t 'nodeDriver.vmwarevsphere.vappIpallocationpolicy.help'}}</p>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col span-12">
+            {{form-key-value
+                allowEmptyValue=false
+                initialArray=initVappArray
+                changedArray=(action "vappPropertyChanged")
+                header=(t 'nodeDriver.vmwarevsphere.vappProperty.label')
+                valuePlaceholder="nodeDriver.vmwarevsphere.vappProperty.value.placeholder"
+                keyPlaceholder="nodeDriver.vmwarevsphere.vappProperty.key.placeholder"
+                addActionLabel="nodeDriver.vmwarevsphere.vappProperty.addActionLabel"
+            }}
+          </div>
+        </div>
+      </div>
+    {{/if}}
+  {{/accordion-list-item}}
+
   <div class="over-hr"><span>{{templateOptionsTitle}}</span></div>
 
   {{form-name-description

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -5064,6 +5064,9 @@ nodeDriver:
     scheduling:
       title: 3. Scheduling
       detail: Choose what hypervisor the virtual machine will be scheduled to
+    vappOptions:
+      title: 4. vApp Options
+      detail: Choose OVF environment properties
     vcenter:
       label: vCenter or ESXi Server
       placeholder: vCenter or ESXi hostname/IP
@@ -5123,6 +5126,30 @@ nodeDriver:
         placeholder: "e.g. myrancherhost"
       label: Configuration Parameters used for guestinfo
       addActionLabel: Add Parameter
+    vappHelp: "Note: standalone ESXI does not support vApp options and network protocol profiles"
+    vappMode:
+      disabled: "Do not use vApp"
+      auto: "Use vApp to configure networks with network protocol profiles"
+      manual: "Provide a custom vApp config"
+    vappTransport:
+      label: OVF environment transport
+      placeholder: "e.g. com.vmware.guestInfo"
+      help: "com.vmware.guestInfo or iso"
+    vappIpprotocol:
+      label: vApp IP protocol
+      placeholder: "e.g. IPv4"
+      help: "IPv4 or IPv6"
+    vappIpallocationpolicy:
+      label: vApp IP allocation policy
+      placeholder: "e.g. fixedAllocated"
+      help: "dhcp, fixed, transient or fixedAllocated"
+    vappProperty:
+      key:
+        placeholder: "e.g. guestinfo.interface.0.ip.0.address"
+      value:
+        placeholder: "e.g. ip:VM Network, expression or string"
+      label: vApp properties
+      addActionLabel: Add Property
   azure:
     placement:
       title: Placement


### PR DESCRIPTION
## Proposed changes

This changes adds 4 params to vSphere node template:

- `vappIpprotocol`
- `vappIpallocationpolicy`
- `vappTransport`
- `vappProperty`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Issues

rancher/rancher#15817
rancher/machine#13
rancher/os#2490

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] Any dependent issues or pr's have been linked
- [x] If updating dependencies, `yarn.lock` file has been updated and committed
