### PR TITLE
Remove capAdd & capDrop if array is empty

### DIFF
--- a/app/components/container/new-edit/component.js
+++ b/app/components/container/new-edit/component.js
@@ -355,6 +355,15 @@ export default Component.extend(NewOrEdit, ChildHook, {
       description: get(this, 'description'),
     });
 
+    if (get(pr, 'launchConfig.capAdd.length') === 0) {
+      delete pr.launchConfig.capAdd;
+    }
+
+    if (get(pr, 'launchConfig.capDrop.length') === 0) {
+      delete pr.launchConfig.capDrop;
+    }
+
+
     set(this, 'primaryResource', pr);
     set(this, 'originalPrimaryResource', pr);
 
@@ -378,10 +387,9 @@ export default Component.extend(NewOrEdit, ChildHook, {
         .catch((err) => {
           set(this, 'errors', [Errors.stringify(err)]);
         });
-    })
-      .catch((err) => {
-        set(this, 'errors', [Errors.stringify(err)]);
-      });
+    }).catch((err) => {
+      set(this, 'errors', [Errors.stringify(err)]);
+    });
   },
 
   doneSaving() {

--- a/app/models/workload.js
+++ b/app/models/workload.js
@@ -301,6 +301,14 @@ var Workload = Resource.extend(DisplayImage, StateCounts, EndpointPorts, {
       cancel(get(this, 'scaleTimer'));
     }
 
+    if (get(this, 'launchConfig.capAdd.length') === 0) {
+      delete this.launchConfig.capAdd;
+    }
+
+    if (get(this, 'launchConfig.capDrop.length') === 0) {
+      delete this.launchConfig.capDrop;
+    }
+
     var timer = later(this, function() {
       this.save().catch((err) => {
         get(this, 'growl').fromError('Error updating scale', err);


### PR DESCRIPTION
## Proposed changes

If we're scaling up or editing a workload container we would automatically add the `capAdd` & `capDrop` properties to the container. This was hosing up deployments created outside of rancher and then scaled via the rancher ui. 

## Types of changes

What types of changes does your code introduce to Rancher?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Issues

rancher/rancher#15863

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
_Tip: `yarn lint` or `npm run lint`_
- [x] Any dependent issues or pr's have been linked
- [x] If updating dependencies, `yarn.lock` file has been updated and committed

## Further comments

n/a
