### PR TITLE
After preload all schemas are found

### DIFF
--- a/lib/shared/addon/mixins/preload.js
+++ b/lib/shared/addon/mixins/preload.js
@@ -20,6 +20,7 @@ export default Mixin.create({
       url:      'schema',
       dataType: 'json'
     }).then((xhr) => {
+      store._state.foundAll['schema'] = true;
       store._bulkAdd('schema', xhr.body.data);
     });
   },


### PR DESCRIPTION
Mark schemas as all found so that a subsequent findAll() doesn't make another request