### PR TITLE
Redeploy action, update timestamp on edit so edit always redeploys

### DIFF
--- a/app/components/container/new-edit/component.js
+++ b/app/components/container/new-edit/component.js
@@ -371,6 +371,8 @@ export default Component.extend(NewOrEdit, ChildHook, {
     const self = this;
     const sup = this._super;
 
+    pr.updateTimestamp();
+
     return this.applyHooks('_beforeSaveHooks').then(() => {
       set(pr, 'namespaceId', get(this, 'namespace.id'));
 

--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -151,7 +151,8 @@ var C = {
 
     DEPLOYMENT_REVISION: 'deployment.kubernetes.io/revision',
 
-    CREATOR_ID: 'field.cattle.io/creatorId'
+    CREATOR_ID: 'field.cattle.io/creatorId',
+    TIMESTAMP:  'cattle.io/timestamp'
   },
 
   LANGUAGE: {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -5,7 +5,6 @@ languageContribute: "Help Translate Rancher"
 # Really generic things used in multiple places (use sparingly)
 ##############################
 generic:
-
   actions: Actions
   activate: Activate
   add: Add
@@ -5878,6 +5877,7 @@ action:
   move: Move
   pause: Pause Orchestration
   pauseAll: Pause All
+  redeploy: Redeploy
   remove: Delete
   replay: Replay
   restart: Restart


### PR DESCRIPTION
## Proposed Changes

Adds bulkable redeploy action which sets an annotation and causes the pods of a workload to get recreated, and does the same on workload edit so that clicking Edit -> Save always results in a redeploy instead of being unpredictable.

## What types of changes does your code introduce to Rancher?

New feature (non-breaking change which adds functionality)

## Issues

rancher/rancher#13389
rancher/rancher#15863
rancher/rancher#15844