### PR TITLE
Jobs are not editable or scalable

### DIFF
--- a/app/components/workload-row/component.js
+++ b/app/components/workload-row/component.js
@@ -2,7 +2,6 @@ import { or } from '@ember/object/computed';
 import Component from '@ember/component';
 import layout from './template';
 import { inject as service } from '@ember/service'
-import { computed } from '@ember/object';
 
 export default Component.extend({
   scope:          service(),
@@ -14,6 +13,7 @@ export default Component.extend({
   subMatches:        null,
   expanded:          null,
 
+  canExpand:         true,
   showInstanceCount: true,
   showImage:         true,
 
@@ -23,8 +23,4 @@ export default Component.extend({
       this.sendAction('toggle');
     },
   },
-  canExpand:    computed('model.isReal', function() {
-    return !!this.get('model.isReal');
-  }),
-
 });

--- a/app/models/workload.js
+++ b/app/models/workload.js
@@ -24,7 +24,6 @@ var Workload = Resource.extend(DisplayImage, StateCounts, EndpointPorts, {
   scaleTimer:       null,
 
   // @TODO-2.0 cleanup all these...
-  isReal:              true,
   hasPorts:            true,
   canUpgrade:          true,
   canHaveLabels:       true,
@@ -57,24 +56,26 @@ var Workload = Resource.extend(DisplayImage, StateCounts, EndpointPorts, {
     return (get(this, 'type') || '').toLowerCase();
   }),
 
-  canEdit: computed('links.update', 'isReal', function() {
-    return !!get(this, 'links.update') && get(this, 'isReal');
+  canEdit: computed('links.update', 'lcType', function() {
+    const lcType = get(this, 'lcType');
+
+    return !!get(this, 'links.update') && ( lcType !== 'job' );
   }),
 
   availableActions: function() {
-    let a = get(this, 'actionLinks') || {};
+    const a = get(this, 'actionLinks') || {};
 
-    let isReal = get(this, 'isReal');
-    let podForShell = get(this, 'podForShell');
+    const podForShell = get(this, 'podForShell');
 
-    let isPaused = get(this, 'isPaused');
+    const isPaused = get(this, 'isPaused');
+    const canEdit = get(this, 'canEdit');
 
     let choices = [
       {
         label:    'action.redeploy',
         icon:     'icon icon-refresh',
         action:   'redeploy',
-        enabled:  isReal,
+        enabled:  canEdit,
         bulkable: true,
       },
       {
@@ -86,7 +87,7 @@ var Workload = Resource.extend(DisplayImage, StateCounts, EndpointPorts, {
         label:   'action.rollback',
         icon:    'icon icon-history',
         action:  'rollback',
-        enabled: !!a.rollback && isReal
+        enabled: !!a.rollback,
       },
       { divider: true },
       {
@@ -116,7 +117,7 @@ var Workload = Resource.extend(DisplayImage, StateCounts, EndpointPorts, {
 
     return choices;
   }.property('actionLinks.{activate,deactivate,pause,restart,rollback,garbagecollect}', 'links.{update,remove}',
-    'podForShell', 'isPaused'
+    'podForShell', 'isPaused', 'canEdit'
   ),
 
   displayType: function() {
@@ -163,7 +164,7 @@ var Workload = Resource.extend(DisplayImage, StateCounts, EndpointPorts, {
   canScale: computed('lcType', function() {
     let lcType = get(this, 'lcType');
 
-    return  lcType !== 'cronjob' && lcType !== 'daemonset';
+    return lcType !== 'cronjob' && lcType !== 'daemonset' && lcType !== 'job';
   }),
 
   activeIcon: function() {

--- a/app/workload/template.hbs
+++ b/app/workload/template.hbs
@@ -119,29 +119,27 @@
       {{/accordion-list-item}}
     {{/if}}
 
-    {{#if service.isReal}}
-      {{#accordion-list-item
-        title=(t 'containerPage.portsTab.header')
-        detail=(t 'containerPage.portsTab.detail')
-        expandAll=al.expandAll
-        expand=(action expandFn)
-      }}
-        {{container/form-ports
-          initialPorts=service.launchConfig.ports
-          editing=false
-        }}
-      {{/accordion-list-item}}
-
-      {{container/form-scheduling
-        initialHostId=model.workload.nodeId
-        service=service
-        scheduling=service.scheduling
+    {{#accordion-list-item
+      title=(t 'containerPage.portsTab.header')
+      detail=(t 'containerPage.portsTab.detail')
+      expandAll=al.expandAll
+      expand=(action expandFn)
+    }}
+      {{container/form-ports
+        initialPorts=service.launchConfig.ports
         editing=false
-        expandAll=al.expandAll
-        expandFn=expandFn
-        classNames="accordion"
       }}
-    {{/if}}
+    {{/accordion-list-item}}
+
+    {{container/form-scheduling
+      initialHostId=model.workload.nodeId
+      service=service
+      scheduling=service.scheduling
+      editing=false
+      expandAll=al.expandAll
+      expandFn=expandFn
+      classNames="accordion"
+    }}
 
     {{#if service.canHaveHealthCheck}}
       {{#accordion-list-item
@@ -197,17 +195,15 @@
       expandFn=expandFn
     }}
 
-    {{#if service.isReal}}
-      {{container/form-command
-        tagName=''
-        instance=launchConfig
-        service=model.workload
-        initialLabels=launchConfig.labels
-        editing=false
-        expandAll=al.expandAll
-        expandFn=expandFn
-      }}
-    {{/if}}
+    {{container/form-command
+      tagName=''
+      instance=launchConfig
+      service=model.workload
+      initialLabels=launchConfig.labels
+      editing=false
+      expandAll=al.expandAll
+      expandFn=expandFn
+    }}
 
     {{container/form-networking
       classNames="accordion-wrapper"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "2.0.75",
+  "version": "2.0.76",
   "private": true,
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
You should not be able to edit, scale, or redeploy a workload of type=job.

Also cleanup `isReal`, which was just always true for workloads since 2.0.

rancher/rancher#15910