### PR TITLE
Set default backend type for Linux RKE hosts with flannel network

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -49,6 +49,7 @@ const NETWORKCHOICES = [
 const FLANNEL = 'flannel'
 const CANAL = 'canal'
 const HOST_GW = 'host-gw'
+const DEFAULT_BACKEND_TYPE = 'vxlan';
 
 const AUTHCHOICES = [
   {
@@ -160,7 +161,7 @@ export default InputTextFile.extend(ClusterDriver, {
       }
 
       if (get(this, 'isEdit')) {
-        if (get(this, 'config.network.options.flannel_backend_type')) {
+        if (get(this, 'config.network.options.flannel_backend_type') === HOST_GW) {
           set(this, 'windowsSupport', true)
         }
       }
@@ -211,7 +212,7 @@ export default InputTextFile.extend(ClusterDriver, {
         network: globalStore.createRecord({
           type:    'networkConfig',
           plugin:  'canal',
-          options: { flannel_backend_type: null, },
+          options: { flannel_backend_type: DEFAULT_BACKEND_TYPE, },
         }),
         ingress: globalStore.createRecord({
           type:     'ingressConfig',
@@ -271,7 +272,7 @@ export default InputTextFile.extend(ClusterDriver, {
       set(this, 'networkContent', NETWORKCHOICES)
       set(config, 'network', {
         plugin:  CANAL,
-        options: { flannel_backend_type: null }
+        options: { flannel_backend_type: DEFAULT_BACKEND_TYPE }
       })
     }
   }),


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
`flannel_backend_type` on the `networkConfig.options` object in the RKE config expects to be non-null. I added a default backend type to the RKE launch page. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#15936

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
