### PR TITLE
Allow TLS Ingress controller to be created without selecting a certificate

### DIFF
--- a/lib/shared/addon/components/form-certificate-row/component.js
+++ b/lib/shared/addon/components/form-certificate-row/component.js
@@ -1,0 +1,22 @@
+import Component from '@ember/component';
+import layout from './template';
+import { get, observer, set } from '@ember/object';
+
+export default Component.extend({
+  layout,
+  tagName:         '',
+  mode:            'default',
+  cert:            null,
+  allCertificates: null,
+  editing:         null,
+
+  modeChanged: observer('mode', function() {
+    let out = null;
+
+    if (get(this, 'mode') === 'custom') {
+      out = get(this, 'allCertificates.firstObject.id');
+    }
+
+    set(this, 'cert.certificateId', out);
+  }),
+});

--- a/lib/shared/addon/components/form-certificate-row/template.hbs
+++ b/lib/shared/addon/components/form-certificate-row/template.hbs
@@ -1,0 +1,34 @@
+{{#if editing}}
+  <div class="row">
+    <div class="pull-right">
+      <button class="btn bg-transparent text-small vertical-middle" {{action (action removeCert cert)}}>
+        {{t 'formSslTermination.removeCertLabel'}}
+      </button>
+    </div>
+  </div>
+{{/if}}
+<div class="row">
+  <div class="col span-6 mt-0 mb-0">
+    <div class="radio">
+      <label>
+        {{radio-button selection=mode value="default"}} {{t 'formSslTermination.default.label'}}
+      </label>
+    </div>
+    <div class="radio">
+      <label>
+        {{radio-button selection=mode value="custom"}} {{t 'formSslTermination.custom.label'}}
+      </label>
+    </div>
+  </div>
+  <div class="col span-6 mt-0 mb-0">
+    <label class="acc-label">{{t 'formSslTermination.certificate'}}{{#if (or editing (eq mode "custom") )}}{{field-required}}{{/if}}</label>
+    {{new-select
+        classNames="form-control"
+        content=allCertificates
+        optionLabelPath="displayDetailedName"
+        optionValuePath="id"
+        disabled=(or (not editing) (eq mode "default"))
+        value=cert.certificateId
+    }}
+  </div>
+</div>

--- a/lib/shared/addon/components/form-ssl-rows/template.hbs
+++ b/lib/shared/addon/components/form-ssl-rows/template.hbs
@@ -9,7 +9,7 @@
 </div>
 
 {{#if hostArray.length}}
-  <table class="fixed striped mt-20">
+  <table class="fixed mt-20">
     <thead>
       <tr>
         <th>{{t 'formSslTermination.host.label'}}</th>

--- a/lib/shared/addon/components/form-ssl-termination/component.js
+++ b/lib/shared/addon/components/form-ssl-termination/component.js
@@ -31,12 +31,6 @@ export default Component.extend({
     }
   },
 
-  didInsertElement() {
-    if (get(this, 'editing') && get(this, 'certs.length') === 0) {
-      this.send('addCert');
-    }
-  },
-
   actions: {
     removeCert(cert) {
       get(this, 'certs').removeObject(cert);

--- a/lib/shared/addon/components/form-ssl-termination/component.js
+++ b/lib/shared/addon/components/form-ssl-termination/component.js
@@ -12,11 +12,10 @@ export default Component.extend({
   namespacedCertificates: null,
   namespace:              null,
   certificates:           null,
+  certs:                  null,
+  statusClass:            null,
+  status:                 null,
 
-  certs: null,
-
-  statusClass:     null,
-  status:          null,
   init() {
     this._super(...arguments);
     const certs = get(this, 'ingress.tls') || [];
@@ -52,9 +51,9 @@ export default Component.extend({
   },
 
   inputDidChange: observer('certs.@each.{certificateId,hosts}', function() {
-    const certs = get(this, 'certs').filter((cert) => cert.certificateId).map((cert) => {
+    const certs = get(this, 'certs').filter((cert) => cert.certificateId || cert.hosts.length > 0).map((cert) => {
       return {
-        certificateId: cert.certificateId,
+        certificateId: cert.certificateId || null,
         hosts:         cert.hosts,
       };
     });

--- a/lib/shared/addon/components/form-ssl-termination/template.hbs
+++ b/lib/shared/addon/components/form-ssl-termination/template.hbs
@@ -1,41 +1,30 @@
 {{#accordion-list-item
-  title=(t 'formSslTermination.title')
-  detail=(t 'formSslTermination.detail' appName=settings.appName)
-  status=status
-  statusClass=statusClass
-  expandAll=expandAll
-  expand=(action expandFn)
+     title=(t 'formSslTermination.title')
+     detail=(t 'formSslTermination.detail' appName=settings.appName)
+     status=status
+     statusClass=statusClass
+     expandAll=expandAll
+     expand=(action expandFn)
 }}
   {{#if allCertificates.length}}
-    {{#each certs as |cert|}}
-      <div class="box mb-10 pt-5">
-        {{#if editing}}
-          <div class="row">
-            <div class="pull-right">
-              <button class="btn bg-transparent text-small vertical-middle" {{action "removeCert" cert}}>
-                {{t 'formSslTermination.removeCertLabel'}}
-              </button>
-            </div>
-          </div>
-        {{/if}}
-        <div class="row">
-          <div class="col span-11-of-23 mt-0 mb-0">
-            <label class="acc-label">{{t 'formSslTermination.certificate'}}{{#if editing}}{{field-required}}{{/if}}</label>
-              {{new-select
-                classNames="form-control"
-                prompt=(t 'formSslTermination.defaultCertificate.prompt')
-                content=allCertificates
-                optionLabelPath="displayDetailedName"
-                optionValuePath="id"
-                disabled=(not editing)
-                value=cert.certificateId
-              }}
-          </div>
-        </div>
+    {{#each certs as |cert index|}}
+      <div class="mb-10 pt-5">
+        {{form-certificate-row
+            cert=cert
+            allCertificates=allCertificates
+            editing=editing
+            removeCert=(action "removeCert")
+        }}
         <hr class="mt-20 mb-20" />
-        {{form-ssl-rows editing=editing hosts=cert.hosts}}
+        {{form-ssl-rows
+            editing=editing
+            hosts=cert.hosts
+        }}
+        {{#if (gt index 0)}}
+          <hr />
+        {{/if}}
       </div>
-    {{else}}
+  {{else}}
       <span class="text-muted">{{t 'formSslTermination.noCertificatesConfiged'}}</span>
     {{/each}}
   {{else}}

--- a/lib/shared/addon/components/form-ssl-termination/template.hbs
+++ b/lib/shared/addon/components/form-ssl-termination/template.hbs
@@ -6,30 +6,30 @@
      expandAll=expandAll
      expand=(action expandFn)
 }}
-  {{#if allCertificates.length}}
-    {{#each certs as |cert index|}}
-      <div class="mb-10 pt-5">
-        {{form-certificate-row
-            cert=cert
-            allCertificates=allCertificates
-            editing=editing
-            removeCert=(action "removeCert")
-        }}
-        <hr class="mt-20 mb-20" />
-        {{form-ssl-rows
-            editing=editing
-            hosts=cert.hosts
-        }}
-        {{#if (gt index 0)}}
-          <hr />
-        {{/if}}
-      </div>
+  {{#each certs as |cert index|}}
+    <div class="mb-10 pt-5">
+      {{form-certificate-row
+          cert=cert
+          allCertificates=allCertificates
+          editing=editing
+          removeCert=(action "removeCert")
+      }}
+      <hr class="mt-20 mb-20" />
+      {{form-ssl-rows
+          editing=editing
+          hosts=cert.hosts
+      }}
+      <hr />
+    </div>
   {{else}}
-      <span class="text-muted">{{t 'formSslTermination.noCertificatesConfiged'}}</span>
-    {{/each}}
-  {{else}}
-    <span class="text-muted">{{t 'formSslTermination.noCertificates'}}</span>
-  {{/if}}
+    <div class="text-center">
+      <div class="text-muted mb-20">{{t 'formSslTermination.noCertificatesConfiged'}}</div>
+      <button class="btn bg-link icon-btn inline-block " {{action "addCert"}}>
+        <span class="darken"><i class="icon icon-plus text-small"></i></span>
+        <span>{{t 'formSslTermination.addCertLabel'}}</span>
+      </button>
+    </div>
+  {{/each}}
   {{#if (and editing allCertificates.length)}}
     <div class="row">
       <button class="btn bg-link icon-btn inline-block pull-right" {{action "addCert"}}>

--- a/lib/shared/app/components/form-certificate-row/component.js
+++ b/lib/shared/app/components/form-certificate-row/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/form-certificate-row/component';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "2.0.77",
+  "version": "2.1.0",
   "private": true,
   "directories": {
     "doc": "doc",

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3913,7 +3913,11 @@ formSslTermination:
   title: SSL/TLS Certificates
   detail: Configure the certificates that will be presented for requests to encrypted ports.
   defaultCertificate:
-    prompt: Choose a Certificate...
+    prompt: Default ingress certificate selected...
+  default:
+    label: Use default ingress controller certificate
+  custom:
+    label: Choose a certificate
   alternateCertificate:
     prompt: Choose a Certificate...
   certificate: Certificate


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Previously we only allowed users to create a TSL Ingress controller if they selected a certificate they created in rancher. We also have the capability to add a TLS Ingress controller by using the default certificate created my nginx so we can allow users to create a TLS Ingress without selecting a cert. 


Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

New feature

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

rancher/rancher#15021
rancher/rancher#16021

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->

N/A