### PR TITLE
ingress model missing canHaveLabels property

### DIFF
--- a/app/components/form-labels-annotations/template.hbs
+++ b/app/components/form-labels-annotations/template.hbs
@@ -66,7 +66,7 @@
       {{/if}}
     {{/if}}
     {{#unless editing}}
-      <div class="pt-20"></div>
+      <hr class="mt-20 mb-20"/>
     {{/unless}}
     <div class="col {{if editing 'span-6' 'span-12'}}">
       {{#if editing}}

--- a/app/models/ingress.js
+++ b/app/models/ingress.js
@@ -4,14 +4,15 @@ import { reference } from 'ember-api-store/utils/denormalize';
 import { inject as service } from '@ember/service';
 
 export default Resource.extend({
-  clusterStore: service(),
-  router:       service(),
+  clusterStore:  service(),
+  router:        service(),
 
-  type: 'ingress',
+  type:          'ingress',
 
-  canClone: true,
+  canClone:      true,
+  canHaveLabels: true,
 
-  namespace: reference('namespaceId', 'namespace', 'clusterStore'),
+  namespace:     reference('namespaceId', 'namespace', 'clusterStore'),
 
   targets: computed('rules.@each.paths', function() {
     const out = [];

--- a/lib/shared/addon/components/form-ssl-termination/template.hbs
+++ b/lib/shared/addon/components/form-ssl-termination/template.hbs
@@ -24,10 +24,12 @@
   {{else}}
     <div class="text-center">
       <div class="text-muted mb-20">{{t 'formSslTermination.noCertificatesConfiged'}}</div>
-      <button class="btn bg-link icon-btn inline-block " {{action "addCert"}}>
-        <span class="darken"><i class="icon icon-plus text-small"></i></span>
-        <span>{{t 'formSslTermination.addCertLabel'}}</span>
-      </button>
+      {{#if editing}}
+        <button class="btn bg-link icon-btn inline-block " {{action "addCert"}}>
+          <span class="darken"><i class="icon icon-plus text-small"></i></span>
+          <span>{{t 'formSslTermination.addCertLabel'}}</span>
+        </button>
+      {{/if}}
     </div>
   {{/each}}
   {{#if (and editing allCertificates.length)}}


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Because the ingress model was missing the `canHaveLabels` property the detail page would filter out any labels that were present. This did not affect the annotations. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#15096
rancher/rancher#16112
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
