### PR TITLE
Rollback lazy-load on nodes engine

### DIFF
--- a/lib/nodes/index.js
+++ b/lib/nodes/index.js
@@ -8,7 +8,7 @@ const EngineAddon = require('ember-engines/lib/engine-addon');
 module.exports = EngineAddon.extend({
   name: 'nodes',
 
-  lazyLoading: { enabled: true },
+  lazyLoading: { enabled: false },
 
   isDevelopingAddon() {
     return true;


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Rolling back lazy-loading on the node engine to fix a regression. If you visited either the `Node Drivers` or `Node Templates` routes before launching a cluster you would not see this issue, but if you try to add or use a node template from the add cluster you would see this. I've decided to roll this back because we dont add back _that_ much. We could roll this back into the shared repo but I prefer to keep this in a distinct engine because the decoupling is clean and easy to understand.  
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#16122
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
