### PR TITLE
Allow forwarding github auth to other localhost ports

### DIFF
--- a/app/mixins/verify-auth.js
+++ b/app/mixins/verify-auth.js
@@ -13,6 +13,7 @@ export default Mixin.create({
   queryParams: {
     config:            { refreshModel: false },
     code:              { refreshModel: false },
+    forward:           { refreshModel: false },
     state:             { refreshModel: false },
     authProvider:      { refreshModel: false },
     error_description: { refreshModel: false },

--- a/app/verify-auth/route.js
+++ b/app/verify-auth/route.js
@@ -3,15 +3,44 @@ import RSVP from 'rsvp';
 import { get } from '@ember/object';
 import { inject as service } from '@ember/service';
 import C from 'shared/utils/constants';
+import { addQueryParams, parseUrl } from 'shared/utils/util';
+import { reject } from 'rsvp';
 import VerifyAuth from 'ui/mixins/verify-auth';
 
 const samlProviders = ['ping', 'adfs', 'keycloak'];
+const allowedForwards = ['localhost'];
 
 export default Route.extend(VerifyAuth, {
   github: service(),
 
   model(params/* , transition */) {
-    if (window.opener && !get(params, 'login')) {
+    const github  = get(this, 'github');
+    const code    = get(params, 'code');
+    const forward = get(params, 'forward');
+
+    // Allow another redirect if the hostname is in the whitelist above.
+    // This allows things like sharing github auth between rancher at localhost:8000
+    // and rio dev at localhost:8004
+    if ( forward ) {
+      const parsed = parseUrl(forward);
+
+      if ( allowedForwards.includes(parsed.hostname.toLowerCase()) ) {
+        if ( get(params, 'login') ) {
+          window.location.href = addQueryParams(forward, {
+            forwarded: 'true',
+            code
+          });
+        } else {
+          github.login(forward);
+        }
+      } else {
+        return reject(new Error('Invalid forward url'));
+      }
+
+      return;
+    }
+
+    if ( window.opener && !get(params, 'login') ) {
       let openersGithub = window.opener.ls('github');
       let openerStore   = window.opener.ls('globalStore');
       let qp            = get(params, 'config') || get(params, 'authProvider');
@@ -20,23 +49,22 @@ export default Route.extend(VerifyAuth, {
       let gh            = get(this, 'github');
       let stateMsg      = 'Authorization state did not match, please try again.';
 
-      if (get(params, 'config') === 'github') {
+      if ( get(params, 'config') === 'github' ) {
         return gh.testConfig(config).then((resp) => {
           gh.authorize(resp, openersGithub.get('state'));
-        })
-          .catch((err) => {
-            this.send('gotError', err);
-          });
-      } else if (samlProviders.includes(get(params, 'config'))) {
-        if (window.opener.window.onAuthTest) {
+        }).catch((err) => {
+          this.send('gotError', err);
+        });
+      } else if ( samlProviders.includes(get(params, 'config')) ) {
+        if ( window.opener.window.onAuthTest ) {
           reply(null, config);
         } else {
           reply({ err: 'failure' });
         }
       }
 
-      if (get(params, 'code')) {
-        if (openersGithub.stateMatches(get(params, 'state'))) {
+      if ( get(params, 'code') ) {
+        if ( openersGithub.stateMatches(get(params, 'state')) ) {
           reply(params.error_description, params.code);
         } else {
           reply(stateMsg);
@@ -44,12 +72,12 @@ export default Route.extend(VerifyAuth, {
       }
     }
 
-    if (get(params, 'code') && get(params, 'login')) {
-      if (get(this, 'github').stateMatches(get(params, 'state'))) {
+    if ( code && get(params, 'login') ) {
+      if ( github.stateMatches(get(params, 'state')) ) {
         let ghProvider = get(this, 'access.providers').findBy('id', 'github');
 
         return ghProvider.doAction('login', {
-          code:         get(params, 'code'),
+          code,
           responseType: 'cookie',
           description:  C.SESSION.DESCRIPTION,
           ttl:          C.SESSION.TTL,

--- a/lib/shared/addon/github/service.js
+++ b/lib/shared/addon/github/service.js
@@ -1,5 +1,5 @@
 import Service, { inject as service } from '@ember/service';
-import Util from 'shared/utils/util';
+import { addQueryParam, addQueryParams, popupWindowOptions } from 'shared/utils/util';
 import { get, set } from '@ember/object';
 import C from 'shared/utils/constants';
 
@@ -28,7 +28,7 @@ export default Service.extend({
   },
 
   authorize(auth, state) {
-    const url = Util.addQueryParams(get(auth, 'redirectUrl'), {
+    const url = addQueryParams(get(auth, 'redirectUrl'), {
       scope:        'read:org',
       redirect_uri: `${ window.location.origin }/verify-auth`,
       authProvider: 'github',
@@ -38,15 +38,19 @@ export default Service.extend({
     return window.location.href = url;
   },
 
-  login() {
+  login(forwardUrl) {
     const provider     = get(this, 'access.providers').findBy('id', 'github');
     const authRedirect = get(provider, 'redirectUrl');
-    const redirect     = Util.addQueryParams(`${ window.location.origin }/verify-auth`, {
+    let   redirect     = addQueryParams(`${ window.location.origin }/verify-auth`, {
       login: true,
       state: this.generateState(),
     });
 
-    const url = Util.addQueryParams(authRedirect, {
+    if ( forwardUrl ) {
+      redirect = addQueryParam(redirect, 'forward', forwardUrl);
+    }
+
+    const url = addQueryParams(authRedirect, {
       scope:        'read:org',
       redirect_uri: redirect,
     });
@@ -69,9 +73,9 @@ export default Service.extend({
 
     set(this, 'state', this.generateState());
 
-    let url = Util.addQueryParams(`${ window.location.origin }/verify-auth`, { config: 'github', });
+    let url = addQueryParams(`${ window.location.origin }/verify-auth`, { config: 'github', });
 
-    const popup = window.open(url, 'rancherAuth', Util.popupWindowOptions());
+    const popup = window.open(url, 'rancherAuth', popupWindowOptions());
     const intl = get(this, 'intl');
 
     let timer = setInterval(() => {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1818,7 +1818,7 @@ catalogSettings:
       header: "You can define your own additional custom catalog sources. Each custom catalog needs the following:"
       help-name: '<strong>Unique name</strong>'
       help-repo: '<strong>Repository URL:</strong>'
-      help-git: "GIT based catalog URL, <em class='text-lowercase'>e.g. https://github.com/{appName}/charts.git</em>"
+      help-git: "Git-based catalog URL, <em class='text-lowercase'>e.g. https://github.com/{appName}/charts.git</em>"
       help-chart: 'Helm Charts server URL, <em>e.g. https://kubernetes-charts.storage.googleapis.com/ (see <a href="https://docs.helm.sh/developing_charts/#hosting-chart-repositories" target="_blank" rel="nofollow noopener noreferrer">Hosting Chart Repositories</a> for specifics)</em>'
     addActionLabel: Add Catalog
     noMatch: No catalogs match the current search.


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Adds support for an additional redirect to pass the GitHub auth code to (only) another port on localhost, so that the same Rancher install can be used against a Rio UI on another port.