### PR TITLE
Add 'Download Logs' to container logs

### DIFF
--- a/app/components/container-logs/component.js
+++ b/app/components/container-logs/component.js
@@ -6,6 +6,7 @@ import Util from 'ui/utils/util';
 import { alternateLabel } from 'ui/utils/platform';
 import layout from './template';
 import C from 'ui/utils/constants';
+import { downloadFile } from 'shared/utils/download-files';
 
 const LINES = 500;
 
@@ -73,6 +74,22 @@ export default Component.extend({
   },
 
   actions: {
+    download() {
+      const ignore = function(el, sel){
+        return el.clone().find( sel || '>*' ).remove().end();
+      };
+
+      const log    = this.$('.log-body').children('.log-msg');
+
+      let stripped = '';
+
+      log.each((i, e) => {
+        stripped += `${ ignore(this.$(e), 'span').text() } \n`;
+      });
+
+      downloadFile('container.log', stripped);
+    },
+
     cancel() {
       this.disconnect();
       this.sendAction('dismiss');

--- a/app/components/container-logs/template.hbs
+++ b/app/components/container-logs/template.hbs
@@ -35,6 +35,7 @@
   </div>
   <button {{action "scrollToTop"}} class="btn bg-default">{{t 'containerLogs.scrollTop'}}</button>
   <button {{action "followLog"}} class="btn bg-default scroll-bottom">{{t 'containerLogs.scrollBottom'}}</button>
+  <button {{action "download"}} class="btn bg-default">{{t 'containerLogs.download'}}</button>
   <button {{action "clear"}} class="btn bg-default">{{t 'containerLogs.clear'}}</button>
   <button {{action "cancel"}} class="btn bg-primary">{{t 'generic.closeModal'}}</button>
 </div>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -2261,6 +2261,7 @@ confirmDelete:
   largeDeleteText: '{key} and {othersCount} others'
 
 containerLogs:
+  download: Download Logs
   title: "Logs: "
   onlyCombined: "<b>Note:</b> Only combined stdout/stderr logs are available for this container because it was run with the TTY (-t) flag."
   combined: Combined


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Users requested having a way to copy container logs without copying the markup on the client. I added a download log button that strips the markup & prepended timestamp from the log content and downloads a plain text `container.log`
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

New feature
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#16229
rancher/rancher#16253
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
