### PR TITLE
Add cluster capabilites ui

### DIFF
--- a/app/authenticated/cluster/nodes/index/controller.js
+++ b/app/authenticated/cluster/nodes/index/controller.js
@@ -4,14 +4,15 @@ import { headersCluster as hostHeaders } from 'ui/components/node-row/component'
 import { get, computed } from '@ember/object';
 
 export default Controller.extend({
-  growl:             service(),
-  prefs:             service(),
-  scope:             service(),
+  growl:        service(),
+  prefs:        service(),
+  scope:        service(),
+  capabilities: service(),
 
-  queryParams:       ['sortBy'],
-  sortBy:            'name',
-  searchText:        '',
-  headers:           hostHeaders,
+  queryParams:  ['sortBy'],
+  sortBy:       'name',
+  searchText:   '',
+  headers:      hostHeaders,
 
   extraSearchFields: [
     'displayUserLabelStrings',

--- a/app/authenticated/cluster/nodes/index/template.hbs
+++ b/app/authenticated/cluster/nodes/index/template.hbs
@@ -38,10 +38,12 @@
         </td>
         <td colspan="2" data-title="{{dt.actions}}" class="text-right">
           <p class="m-0">{{t 'pagination.node' pages=1 count=node.ref.quantity}}</p>
-          <p class="m-0">
-            <button class="btn btn-xs bg-primary" {{action "scaleDownPool" node.ref.id}} disabled={{lte node.ref.quantity 1}}><i class="icon icon-minus icon-fw"/></button>
-            <button style="margin-left: -5px;" class="btn btn-xs bg-primary" {{action "scaleUpPool" node.ref.id}}><i class="icon icon-plus icon-fw"/></button>
-          </p>
+          {{#if capabilities.nodePoolsCanScale}}
+            <p class="m-0">
+              <button class="btn btn-xs bg-primary" {{action "scaleDownPool" node.ref.id}} disabled={{lte node.ref.quantity 1}}><i class="icon icon-minus icon-fw"/></button>
+              <button style="margin-left: -5px;" class="btn btn-xs bg-primary" {{action "scaleUpPool" node.ref.id}}><i class="icon icon-plus icon-fw"/></button>
+            </p>
+          {{/if}}
         </td>
         <td data-title="{{dt.actions}}" class="actions">
           {{action-menu model=node.ref}}

--- a/app/components/container/form-ports/component.js
+++ b/app/components/container/form-ports/component.js
@@ -18,21 +18,22 @@ const protocolOptions = [
 ];
 
 export default Component.extend({
-  intl:     service(),
-  scope:    service(),
-  settings: service(),
+  intl:                service(),
+  scope:               service(),
+  settings:            service(),
+  capabilities:        service(),
 
   layout,
-  initialPorts: null,
-  editing:      false,
-  showWarning:  false,
-  kindChoices:  null,
+  protocolOptions,
+  initialPorts:        null,
+  editing:             false,
+  showWarning:         false,
+  kindChoices:         null,
 
   ports:               null,
   nodePortFrom:        null,
   nodePortTo:          null,
   nodePortPlaceholder: null,
-  protocolOptions,
 
   init() {
     this._super(...arguments);
@@ -122,15 +123,26 @@ export default Component.extend({
   }),
 
   nodePortRangeDidChange: observer('intl.locale', 'scope.currentCluster.rancherKubernetesEngineConfig.services.kubeApi.serviceNodePortRange', function() {
-    const intl = get(this, 'intl');
+    const intl          = get(this, 'intl');
     const nodePortRange = get(this, 'scope.currentCluster.rancherKubernetesEngineConfig.services.kubeApi.serviceNodePortRange')
+    const ccPorts       = get(this, 'capabilities.allowedNodePortRanges');
 
     if ( nodePortRange  ) {
       const ports = nodePortRange.split('-');
 
       if ( ports.length === 2 ) {
-        const from = parseInt(ports[0], 10);
-        const to = parseInt(ports[1], 10);
+        let from = parseInt(ports[0], 10);
+        let to   = parseInt(ports[1], 10);
+
+        if (ccPorts.length > 0) {
+          if (from < ccPorts[0]) {
+            from = ccPorts[0];
+          }
+
+          if (to > ccPorts[1]) {
+            to = ccPorts[1];
+          }
+        }
 
         setProperties(this, {
           nodePortFrom:        from,

--- a/app/components/new-edit-ingress/template.hbs
+++ b/app/components/new-edit-ingress/template.hbs
@@ -5,26 +5,26 @@
 <div class="row">
   <div class="col span-11-of-23 mt-0 mb-0">
     {{form-name-description
+        descriptionPlaceholder="servicePage.newIngress.form.description.placeholder"
         model=ingress
         nameDisabled=existing
         namePlaceholder="servicePage.newIngress.form.name.placeholder"
-        descriptionPlaceholder="servicePage.newIngress.form.description.placeholder"
     }}
   </div>
 
   <div class="col span-11-of-23 mt-0 mb-0 offset-1-of-23">
     {{form-namespace
         editing=(and editing (not existing))
-        namespace=namespace
         errors=namespaceErrors
+        namespace=namespace
     }}
   </div>
 </div>
 
 <section class="mt-40 horizontal-form container-fluid">
   {{form-ingress-rule
-      ingress=ingress
       editing=true
+      ingress=ingress
   }}
   <hr class="mt-30 mb-30" />
 </section>

--- a/app/ingresses/run/template.hbs
+++ b/app/ingresses/run/template.hbs
@@ -1,10 +1,10 @@
 {{new-edit-ingress
-  ingress=model.ingress
-  namespace=model.ingress.namespace
-  existing=model.existing
-  editing=true
-  namespacedCertificates=model.namespacedcertificates
-  certificates=model.certificates
-  done=(action 'done')
-  cancel=(action 'cancel')
+    cancel=(action 'cancel')
+    certificates=model.certificates
+    done=(action 'done')
+    editing=true
+    existing=model.existing
+    ingress=model.ingress
+    namespace=model.ingress.namespace
+    namespacedCertificates=model.namespacedcertificates
 }}

--- a/lib/shared/addon/capabilities/service.js
+++ b/lib/shared/addon/capabilities/service.js
@@ -1,0 +1,47 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import { alias } from '@ember/object/computed';
+import { get, computed } from '@ember/object';
+
+export default Service.extend({
+  scope:        service(),
+
+  cluster:      alias('scope.currentCluster'),
+
+  nodePoolsCanScale: computed('cluster.capabilities.nodePoolScalingSupported', function() {
+    const capabilities = get(this, 'scope.currentCluster.capabilities');
+
+    let poolScaleSupported = false;
+
+    if (capabilities && get(capabilities, 'nodePoolScalingSupported')) {
+      poolScaleSupported = true;
+    }
+
+    return poolScaleSupported;
+  }),
+
+  allowedNodePortRanges: computed('cluster.capabilities.nodePortRange', function() {
+    const clusterCapabilities = get(this, 'scope.currentCluster.capabilities');
+    var ccPorts               = [];
+
+    if (clusterCapabilities && get(clusterCapabilities, 'nodePortRange')) {
+      ccPorts = get(clusterCapabilities, 'nodePortRange').split('-');
+
+      ccPorts = [parseInt(ccPorts[0], 10), parseInt(ccPorts[1], 10)];
+    }
+
+    return ccPorts;
+  }),
+
+  ingressCapabilities: computed('cluster.capabilities.ingressControllers.[]', function() {
+    const capabilities = get(this, 'cluster.capabilities');
+    const controllers  = capabilities.ingressControllers ? get(capabilities, 'ingressControllers') : []; // will be ingressCapabilities
+    const provider     = controllers.length > 0 ? get(controllers, 'firstObject.ingressProvider') : null;
+
+    return {
+      defaultIngressProvider:         provider,
+      ingressControllersCapabilities: controllers,
+    };
+  }),
+
+});

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -1,6 +1,104 @@
+{{#unless isCustom}}
+  {{cru-node-pools
+      mode=mode
+      cluster=cluster
+      driver=nodeWhich
+      nodeTemplates=model.nodeTemplates
+      registerHook=(action "registerHook")
+      setNodePoolErrors=(action "setNodePoolErrors")
+  }}
+{{/unless}}
+
+<section class="header has-tabs clearfix p-0">
+  <ul class="tab-nav">
+    {{#if pasteOrUpload}}
+      <li>
+        <button class="btn bg-transparent" {{action 'cancel'}}>{{t 'clusterNew.advanced.cancel'}}</button>
+      </li>
+    {{else}}
+      <li>
+        <button class="btn bg-transparent" {{action 'showPaste'}}>{{t 'clusterNew.advanced.yaml'}} <span class="icon icon-copy"></span></button>
+      </li>
+    {{/if}}
+  </ul>
+</section>
+
 {{#if (or isEdit (eq step 1))}}
-  {{#accordion-list showExpandAll=false as |al expandFn|}}
-    {{#unless pasteOrUpload}}
+  {{#accordion-list
+       showExpandAll=false
+       as |al expandFn|
+  }}
+    {{#if pasteOrUpload}}
+      <div class="accordion">
+        <div class="accordion-header">
+          <div class="expand"></div>
+          <div class="title">
+            <span class="m-0">{{t 'clusterNew.rke.customize.label' }}</span>
+            <p class="help-block">{{t 'clusterNew.rke.customize.detail' }}</p>
+          </div>
+        </div>
+        <div class="accordion-content">
+          <div class="banner bg-info">
+            <div class="banner-icon p-10"><i class="icon icon-info"></i></div>
+            <div class="banner-message">
+              {{t 'clusterNew.advanced.helpText'}}
+            </div>
+          </div>
+          <div class="mt-25">
+            {{input-yaml
+                showDownload=false
+                canChangeName=false
+                autoResize=true
+                value=value
+            }}
+          </div>
+          {{copy-to-clipboard tooltipText="" buttonText="copyToClipboard.tooltip" clipboardText=value class="with-clip"}}
+        </div>
+      </div>
+    {{else}}
+      {{#accordion-list-item
+           title=(t 'clusterNew.rke.customize.label')
+           detail=(t 'clusterNew.rke.customize.detail')
+           expandOnInit=(eq mode "edit" true false)
+           expandAll=al.expandAll
+           expand=(action expandFn)
+      }}
+        <div class="row">
+          <div class="col span-6">
+            <label class="acc-label">{{t 'clusterNew.rke.version.label'}}</label>
+            {{new-select
+                content=versionChoices
+                value=cluster.rancherKubernetesEngineConfig.kubernetesVersion
+            }}
+          </div>
+          {{#if (and (eq nodeWhich 'custom') (eq mode 'new'))}}
+            <div class="col span-6">
+              <label class="acc-label">{{t 'clusterNew.rke.windowsSupport.label'}}</label>
+              <div class="radio">
+                <label class={{if (not-eq config.network.plugin 'flannel') 'text-muted'}}>
+                  {{radio-button selection=windowsSupport value=true disabled=(not-eq config.network.plugin 'flannel')}}
+                  {{t 'generic.enabled'}}
+                </label>
+              </div>
+              <div class="radio">
+                <label class={{if (not-eq config.network.plugin 'flannel') 'text-muted'}}>
+                  {{radio-button selection=windowsSupport value=false disabled=(not-eq config.network.plugin 'flannel')}}
+                  {{t 'generic.disabled'}}
+                </label>
+              </div>
+            </div>
+          {{/if}}
+        </div>
+        <div class="row">
+          <div class="col span-12">
+            {{cru-cloud-provider
+                cluster=model.cluster
+                driver=nodeWhich
+            }}
+          </div>
+        </div>
+      {{/accordion-list-item}}
+
       {{#accordion-list-item
            title=(t 'clusterNew.rke.network.title')
            detail=(t 'clusterNew.rke.network.detail')
@@ -68,176 +166,8 @@
           </div>
         </div>
       {{/accordion-list-item}}
-    {{/unless}}
 
-    {{#accordion-list-item
-         title=(t 'clusterNew.rke.customize.label')
-         detail=(t 'clusterNew.rke.customize.detail')
-         expandOnInit=(eq mode "edit" true false)
-         expandAll=al.expandAll
-         expand=(action expandFn)
-    }}
-      <div class="row">
-        <div class="btn-group  pull-right">
-          {{#if pasteOrUpload}}
-            <button class="btn btn-sm" {{action 'cancel'}}>{{t 'clusterNew.advanced.cancel'}}</button>
-          {{else}}
-            <button class="btn btn-sm bg-primary" {{action 'showPaste'}}>{{t 'clusterNew.advanced.yaml'}} <span class="icon icon-copy"></span></button>
-          {{/if}}
-          <button class="btn btn-sm bg-primary" {{action "click"}}>{{t 'uploadFile.label'}} <span class="icon icon-upload"></span></button>
-        </div>
-      </div>
-
-      {{#if pasteOrUpload}}
-        <div class="banner bg-info">
-          <div class="banner-icon p-10"><i class="icon icon-info"></i></div>
-          <div class="banner-message">
-            {{t 'clusterNew.advanced.helpText'}}
-          </div>
-        </div>
-        <div class="mt-25">
-          {{input-yaml
-              showUpload=false
-              showDownload=false
-              canChangeName=false
-              value=value
-          }}
-        </div>
-        {{copy-to-clipboard tooltipText="" buttonText="copyToClipboard.tooltip" clipboardText=value class="with-clip"}}
-      {{else}}
-        <div class="row">
-          <div class="col span-4">
-            <label class="acc-label">{{t 'clusterNew.rke.version.label'}}</label>
-            {{new-select
-                content=versionChoices
-                value=cluster.rancherKubernetesEngineConfig.kubernetesVersion
-            }}
-          </div>
-        </div>
-        <div class="row">
-          <div class="col span-4">
-            <label class="acc-label">{{t 'clusterNew.rke.monitoring.label'}}</label>
-            <div class="radio">
-              <label>
-                {{!--
-                  {{radio-button selection=monitoringProvider value="metrics-server"}}
-                  --}}
-                {{radio-button selection=cluster.rancherKubernetesEngineConfig.monitoring.provider value="metrics-server"}}
-                {{t 'generic.enabled'}}
-              </label>
-            </div>
-            <div class="radio">
-              <label>
-                {{!--
-                  {{radio-button selection=monitoringProvider value=null}}
-                  --}}
-                {{radio-button selection=cluster.rancherKubernetesEngineConfig.monitoring.provider value="none"}}
-                {{t 'generic.disabled'}}
-              </label>
-            </div>
-          </div>
-          <div class="col span-4">
-            <label class="acc-label">{{t 'clusterNew.rke.podSecurityPolicy.label'}}</label>
-            <div class="radio">
-              <label class={{unless model.psps.length 'text-muted'}}>
-                {{!--
-                  {{radio-button selection=kubeApiPodSecurityPolicy value=true disabled=(not model.psps.length)}}
-                  --}}
-                {{radio-button selection=cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy value=true disabled=(not model.psps.length)}}
-                {{t 'generic.enabled'}}
-                {{#unless model.psps.length}}
-                  &mdash; {{t 'clusterNew.psp.none'}}
-                {{/unless}}
-              </label>
-            </div>
-            <div class="radio">
-              <label>
-                {{!--
-                  {{radio-button selection=kubeApiPodSecurityPolicy value=false disabled=(not model.psps.length)}}
-                  --}}
-                {{radio-button selection=cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy value=false disabled=(not model.psps.length)}}
-                {{t 'generic.disabled'}}
-              </label>
-            </div>
-          </div>
-          <div class="col span-4">
-            {{#if cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy}}
-              <label class="acc-label">{{t 'clusterNew.psp.label'}}{{field-required}}</label>
-              {{new-select
-                  content=model.psps
-                  optionLabelPath='displayName'
-                  optionValuePath='id'
-                  prompt='clusterNew.psp.prompt'
-                  localizedPrompt=true
-                  value=cluster.defaultPodSecurityPolicyTemplateId
-                  disabled=(not cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy)
-              }}
-            {{else}}
-              <label class="acc-label">{{t 'clusterNew.psp.label'}}</label>
-              <div class="form-control-static">{{t 'generic.none'}}</div>
-            {{/if}}
-          </div>
-        </div>
-        <div class="row">
-          <div class="col span-4">
-            <label class="acc-label">{{t 'clusterNew.rke.ignoreDockerVersion.label'}}</label>
-            <div class="radio">
-              <label>
-                {{radio-button selection=cluster.rancherKubernetesEngineConfig.ignoreDockerVersion value=false}}
-                {{t 'clusterNew.rke.ignoreDockerVersion.disabled'}}
-              </label>
-            </div>
-            <div class="radio">
-              <label>
-                {{radio-button selection=cluster.rancherKubernetesEngineConfig.ignoreDockerVersion value=true}}
-                {{t 'clusterNew.rke.ignoreDockerVersion.enabled'}}
-              </label>
-            </div>
-          </div>
-
-          <div class="col span-4">
-            <label class="acc-label">{{t 'loggingPage.dockerRootDir.label'}}</label>
-            {{input
-                type="text"
-                value=model.cluster.dockerRootDir
-                className="form-control"
-                placeholder=(t 'clusterNew.rke.dockerRootDir.placeholder' dir=defaultDockerRootDir)
-            }}
-          </div>
-
-        </div>
-        <div class="row">
-          {{#if (and (eq nodeWhich 'custom') (eq mode 'new'))}}
-            <div class="col span-4">
-              <label class="acc-label">{{t 'clusterNew.rke.windowsSupport.label'}}</label>
-              <div class="radio">
-                <label class={{if (not-eq config.network.plugin 'flannel') 'text-muted'}}>
-                  {{radio-button selection=windowsSupport value=true disabled=(not-eq config.network.plugin 'flannel')}}
-                  {{t 'generic.enabled'}}
-                </label>
-              </div>
-              <div class="radio">
-                <label class={{if (not-eq config.network.plugin 'flannel') 'text-muted'}}>
-                  {{radio-button selection=windowsSupport value=false disabled=(not-eq config.network.plugin 'flannel')}}
-                  {{t 'generic.disabled'}}
-                </label>
-              </div>
-            </div>
-          {{/if}}
-        </div>
-        <div class="row">
-          <div class="col span-12">
-            {{cru-cloud-provider
-                cluster=model.cluster
-                driver=nodeWhich
-            }}
-          </div>
-        </div>
-      {{/if}}
-    {{/accordion-list-item}}
-
-    {{#if isCustom }}
-      {{#unless pasteOrUpload}}
+      {{#advanced-section advanced=advanced}}
         {{#accordion-list-item
              title=(t 'cruPrivateRegistry.title.label')
              detail=(t 'cruPrivateRegistry.title.detail')
@@ -249,20 +179,112 @@
               cluster=cluster
           }}
         {{/accordion-list-item}}
-      {{/unless}}
+
+
+        {{#accordion-list-item
+             title=(t 'clusterNew.rke.advanced.label')
+             detail=(t 'clusterNew.rke.advanced.detail')
+             expandOnInit=(eq mode "edit" true false)
+             expandAll=al.expandAll
+             expand=(action expandFn)
+        }}
+          <div class="row">
+            <div class="col span-4">
+              <label class="acc-label">{{t 'clusterNew.rke.monitoring.label'}}</label>
+              <div class="radio">
+                <label>
+                  {{!--
+                  {{radio-button selection=monitoringProvider value="metrics-server"}}
+                  --}}
+                  {{radio-button selection=cluster.rancherKubernetesEngineConfig.monitoring.provider value="metrics-server"}}
+                  {{t 'generic.enabled'}}
+                </label>
+              </div>
+              <div class="radio">
+                <label>
+                  {{!--
+                  {{radio-button selection=monitoringProvider value=null}}
+                  --}}
+                  {{radio-button selection=cluster.rancherKubernetesEngineConfig.monitoring.provider value="none"}}
+                  {{t 'generic.disabled'}}
+                </label>
+              </div>
+            </div>
+            <div class="col span-4">
+              <label class="acc-label">{{t 'clusterNew.rke.podSecurityPolicy.label'}}</label>
+              <div class="radio">
+                <label class={{unless model.psps.length 'text-muted'}}>
+                  {{!--
+                  {{radio-button selection=kubeApiPodSecurityPolicy value=true disabled=(not model.psps.length)}}
+                  --}}
+                  {{radio-button selection=cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy value=true disabled=(not model.psps.length)}}
+                  {{t 'generic.enabled'}}
+                  {{#unless model.psps.length}}
+                    &mdash; {{t 'clusterNew.psp.none'}}
+                  {{/unless}}
+                </label>
+              </div>
+              <div class="radio">
+                <label>
+                  {{!--
+                  {{radio-button selection=kubeApiPodSecurityPolicy value=false disabled=(not model.psps.length)}}
+                  --}}
+                  {{radio-button selection=cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy value=false disabled=(not model.psps.length)}}
+                  {{t 'generic.disabled'}}
+                </label>
+              </div>
+            </div>
+            <div class="col span-4">
+              {{#if cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy}}
+                <label class="acc-label">{{t 'clusterNew.psp.label'}}{{field-required}}</label>
+                {{new-select
+                    content=model.psps
+                    optionLabelPath='displayName'
+                    optionValuePath='id'
+                    prompt='clusterNew.psp.prompt'
+                    localizedPrompt=true
+                    value=cluster.defaultPodSecurityPolicyTemplateId
+                    disabled=(not cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy)
+                }}
+              {{else}}
+                <label class="acc-label">{{t 'clusterNew.psp.label'}}</label>
+                <div class="form-control-static">{{t 'generic.none'}}</div>
+              {{/if}}
+            </div>
+          </div>
+          <div class="row">
+            <div class="col span-4">
+              <label class="acc-label">{{t 'clusterNew.rke.ignoreDockerVersion.label'}}</label>
+              <div class="radio">
+                <label>
+                  {{radio-button selection=cluster.rancherKubernetesEngineConfig.ignoreDockerVersion value=false}}
+                  {{t 'clusterNew.rke.ignoreDockerVersion.disabled'}}
+                </label>
+              </div>
+              <div class="radio">
+                <label>
+                  {{radio-button selection=cluster.rancherKubernetesEngineConfig.ignoreDockerVersion value=true}}
+                  {{t 'clusterNew.rke.ignoreDockerVersion.enabled'}}
+                </label>
+              </div>
+            </div>
+
+            <div class="col span-4">
+              <label class="acc-label">{{t 'loggingPage.dockerRootDir.label'}}</label>
+              {{input
+                  type="text"
+                  value=model.cluster.dockerRootDir
+                  className="form-control"
+                  placeholder=(t 'clusterNew.rke.dockerRootDir.placeholder' dir=defaultDockerRootDir)
+              }}
+            </div>
+
+          </div>
+        {{/accordion-list-item}}
+
+      {{/advanced-section}}
     {{/if}}
   {{/accordion-list}}
-
-  {{#unless isCustom}}
-    {{cru-node-pools
-        mode=mode
-        cluster=cluster
-        driver=nodeWhich
-        nodeTemplates=model.nodeTemplates
-        registerHook=(action "registerHook")
-        setNodePoolErrors=(action "setNodePoolErrors")
-    }}
-  {{/unless}}
 {{/if}}
 
 {{#if (and isCustom (eq step 2)) }}

--- a/lib/shared/addon/components/cru-private-registry/component.js
+++ b/lib/shared/addon/components/cru-private-registry/component.js
@@ -8,6 +8,11 @@ import { on } from '@ember/object/evented';
 
 const headers = [
   {
+    name:           'url',
+    classNames:     ['text-center'],
+    translationKey: 'cruPrivateRegistry.registry.url.label',
+  },
+  {
     name:           'user',
     classNames:     ['text-center'],
     translationKey: 'cruPrivateRegistry.registry.user.label',
@@ -17,11 +22,6 @@ const headers = [
     classNames:     ['text-center'],
     sort:           false,
     translationKey: 'cruPrivateRegistry.registry.password.label',
-  },
-  {
-    name:           'url',
-    classNames:     ['text-center'],
-    translationKey: 'cruPrivateRegistry.registry.url.label',
   },
   {
     name:           'default',

--- a/lib/shared/addon/components/cru-private-registry/template.hbs
+++ b/lib/shared/addon/components/cru-private-registry/template.hbs
@@ -11,6 +11,20 @@
 }}
   {{#if (eq kind "row")}}
     <tr class="main-row">
+      <td data-title="{{dt.url}}" class="text-center pr-5 pt-5">
+        {{#input-or-display
+             editable=editing
+             value=reg.url
+        }}
+          {{input-url
+              classNames="form-control input-sm"
+              isInvalid=(action (mut urlInvalid))
+              urlWarning=(action (mut urlWarning))
+              urlError=(action (mut urlError))
+              value=reg.url
+          }}
+        {{/input-or-display}}
+      </td>
       <td data-title="{{dt.user}}" class="text-center pr-5 pt-5">
         {{#input-or-display
              editable=editing
@@ -33,20 +47,6 @@
               class="conceal input-sm"
               type="password"
               value=reg.password
-          }}
-        {{/input-or-display}}
-      </td>
-      <td data-title="{{dt.url}}" class="text-center pr-5 pt-5">
-        {{#input-or-display
-             editable=editing
-             value=reg.url
-        }}
-          {{input-url
-              classNames="form-control input-sm"
-              isInvalid=(action (mut urlInvalid))
-              urlWarning=(action (mut urlWarning))
-              urlError=(action (mut urlError))
-              value=reg.url
           }}
         {{/input-or-display}}
       </td>

--- a/lib/shared/addon/components/form-ingress-rows/component.js
+++ b/lib/shared/addon/components/form-ingress-rows/component.js
@@ -3,24 +3,29 @@ import Component from '@ember/component';
 import layout from './template';
 import { inject as service } from '@ember/service';
 import C from 'shared/utils/constants';
+import { alias } from '@ember/object/computed';
 
 export default Component.extend({
-  settings: service(),
+  settings:                       service(),
+  capabilities:                   service(),
 
   layout,
 
-  mode: 'automatic',
+  mode:                           'automatic',
 
-  rule:         null,
-  rules:        null,
-  ingress:      null,
-  editing:      true,
-  existingHost: null,
+  rule:                           null,
+  rules:                          null,
+  ingress:                        null,
+  editing:                        true,
+  existingHost:                   null,
+  selectedProvider:               null,
+  ingressControllersCapabilities: alias('capabilities.ingressCapabilities.ingressControllersCapabilities'),
+  defaultProvider:                alias('capabilities.ingressCapabilities.defaultIngressProvider'),
 
   init() {
     this._super(...arguments);
 
-    const xip = get(this, `settings.${ C.SETTING.INGRESS_IP_DOMAIN }`);
+    const xip  = get(this, `settings.${ C.SETTING.INGRESS_IP_DOMAIN }`);
     const host = get(this, 'rule.host');
 
     if (get(this, 'rule.defaultBackend')) {
@@ -33,6 +38,10 @@ export default Component.extend({
     }
 
     this.modeChanged();
+
+    if (get(this, 'ingressControllersCapabilities.length') >= 1) {
+      set(this, 'selectedProvider', get(this, 'ingressControllersCapabilities.firstObject.ingressProvider'));
+    }
   },
 
   actions: {
@@ -69,16 +78,26 @@ export default Component.extend({
       }
     }
   }),
+
   isDefault: computed('mode', function() {
     return get(this, 'mode') === 'default';
   }),
 
   defaultDisabled: computed('rules.@each.defaultBackend', function() {
-    const def = get(this, 'ingress.defaultBackend');
-    const me = get(this, 'rule.defaultBackend');
+    const { ingressControllersCapabilities, selectedProvider } = this;
 
-    return !!def && !me;
+    const def                                = get(this, 'ingress.defaultBackend');
+    const me                                 = get(this, 'rule.defaultBackend');
+    const cap                                = ingressControllersCapabilities.length >= 1 ? ingressControllersCapabilities.findBy('ingressProvider', selectedProvider) : null;
+
+    // if we dont have capabilities at all we don't want to disable to ability to use the default backend
+    var customDefaultBackend                 = true;
+
+    if (cap !== null) {
+      customDefaultBackend = get(cap, 'customDefaultBackend');
+    }
+
+    return ( !!def && !me ) || !customDefaultBackend;
   }),
-
 
 });

--- a/lib/shared/addon/components/form-ingress-rows/template.hbs
+++ b/lib/shared/addon/components/form-ingress-rows/template.hbs
@@ -1,74 +1,93 @@
-  <div class="box mb-10 pt-5">
-    <div class="row">
-      {{#if (and editing (gt rules.length 1))}}
-        <div class="pull-right">
-          {{#if (lte rules.length 1 )}}
-            <button class="btn btn-disabled-transparent text-small vertical-middle" disabled="true">
-              {{t 'formIngress.removeRuleLabel'}}
-            </button>
-          {{else}}
-            <button class="btn bg-transparent text-small vertical-middle" {{action "removeRule" rule}}>
-              {{t 'formIngress.removeRuleLabel'}}
-            </button>
+<div class="box mb-10">
+  <div class="row">
+    {{#if (and editing (gt rules.length 1))}}
+      <div class="pull-right">
+        {{#if (lte rules.length 1 )}}
+          <button class="btn btn-disabled-transparent text-small vertical-middle" disabled="true">
+            {{t 'formIngress.removeRuleLabel'}}
+          </button>
+        {{else}}
+          <button class="btn bg-transparent text-small vertical-middle" {{action "removeRule" rule}}>
+            {{t 'formIngress.removeRuleLabel'}}
+          </button>
+        {{/if}}
+      </div>
+    {{else}}
+      <!-- 28px is the height of the button, no jumpy -->
+      <div style="height: 28px;" class="pull-right"></div>
+    {{/if}}
+    {{#if (and defaultProvider (gt capabilities.length 1) )}}
+      <div class="row">
+        <div class="col span-3">
+          <label>{{t 'formIngress.defaultBackend.mark'}}:</label>
+          {{new-select
+              classNames="form-control"
+              content=ingressControllersCapabilities
+              localizedPrompt=true
+              optionLabelPath="ingressProvider"
+              optionValuePath="ingressProvider"
+              prompt="editStack.project.prompt"
+              value=selectedProvider
+          }}
+        </div>
+      </div>
+    {{/if}}
+  </div>
+
+  <div class="row">
+    <div class="col mt-0 mb-0 {{if (eq mode 'manual') 'span-6' 'span-12'}}" >
+      {{#if editing}}
+        {{#unless rule.new}}
+          <div class="radio">
+            <label>{{radio-button selection=mode value="existing"}} {{t 'formIngress.hostMode.existing' domain=(if existingHost existingHost 'n/a') htmlSafe=true}}</label>
+          </div>
+        {{/unless}}
+        {{#if settings.ingress-ip-domain}}
+          <div class="radio">
+            <label>{{radio-button selection=mode value="automatic"}} {{t 'formIngress.hostMode.automatic' domain=settings.ingress-ip-domain htmlSafe=true}}</label>
+          </div>
+        {{/if}}
+        <div class="radio">
+          <label>{{radio-button selection=mode value="manual"}} {{t 'formIngress.hostMode.manual'}}</label>
+        </div>
+        <div class="radio">
+          <label class="{{if defaultDisabled 'text-muted'}}">{{radio-button selection=mode value="default" disabled=defaultDisabled}} {{t 'formIngress.hostMode.default'}}</label>
+          {{#if defaultDisabled}}
+            <p class="help-block pl-20">{{t 'formIngress.hostMode.defaultDisabled'}}</p>
           {{/if}}
         </div>
       {{else}}
-        <!-- 28px is the height of the button, no jumpy -->
-        <div style="height: 28px;"></div>
-      {{/if}}
-    </div>
-
-    <div class="row">
-      <div class="col mt-0 mb-0 {{if (eq mode 'manual') 'span-6' 'span-12'}}" >
-        {{#if editing}}
-          {{#unless rule.new}}
-            <div class="radio">
-              <label>{{radio-button selection=mode value="existing"}} {{t 'formIngress.hostMode.existing' domain=(if existingHost existingHost 'n/a') htmlSafe=true}}</label>
-            </div>
-          {{/unless}}
-          {{#if settings.ingress-ip-domain}}
-            <div class="radio">
-              <label>{{radio-button selection=mode value="automatic"}} {{t 'formIngress.hostMode.automatic' domain=settings.ingress-ip-domain htmlSafe=true}}</label>
-            </div>
-          {{/if}}
-          <div class="radio">
-            <label>{{radio-button selection=mode value="manual"}} {{t 'formIngress.hostMode.manual'}}</label>
+        <div>
+          <label>{{t 'generic.hostname'}}</label>
+          <div class="mt-5">
+            {{#if (eq mode "default")}}
+              {{t 'formIngress.defaultBackend.mark'}}
+            {{else}}
+              <code>
+                {{rule.host}}
+              </code>
+            {{/if}}
           </div>
-          <div class="radio">
-            <label class="{{if defaultDisabled 'text-muted'}}">{{radio-button selection=mode value="default" disabled=defaultDisabled}} {{t 'formIngress.hostMode.default'}}</label>
-          </div>
-        {{else}}
-          <div>
-            <label>{{t 'generic.hostname'}}</label>
-            <div class="mt-5">
-              {{#if (eq mode "default")}}
-                {{t 'formIngress.defaultBackend.mark'}}
-              {{else}}
-                <code>
-                  {{rule.host}}
-                </code>
-              {{/if}}
-            </div>
-          </div>
-        {{/if}}
-      </div>
-
-      {{#if (eq mode "manual")}}
-        <div class="col span-6 mt-0 mb-0">
-          <label class="acc-label">{{t 'formIngress.host.label'}}</label>
-          {{#input-or-display editable=editing value=rule.host classesForDisplay="clip"}}
-            {{input type="text" class="form-control input-sm" value=rule.host placeholder=(t 'formIngress.host.placeholder')}}
-          {{/input-or-display}}
         </div>
       {{/if}}
     </div>
 
-    <hr class="mt-20 mb-20" />
-
-    {{form-ingress-backends
-        ingress=ingress
-        isDefault=isDefault
-        rule=rule
-        editing=editing
-    }}
+    {{#if (eq mode "manual")}}
+      <div class="col span-6 mt-0 mb-0">
+        <label class="acc-label">{{t 'formIngress.host.label'}}</label>
+        {{#input-or-display editable=editing value=rule.host classesForDisplay="clip"}}
+          {{input type="text" class="form-control input-sm" value=rule.host placeholder=(t 'formIngress.host.placeholder')}}
+        {{/input-or-display}}
+      </div>
+    {{/if}}
   </div>
+
+  <hr class="mt-20 mb-20" />
+
+  {{form-ingress-backends
+      ingress=ingress
+      isDefault=isDefault
+      rule=rule
+      editing=editing
+  }}
+</div>

--- a/lib/shared/addon/components/form-ingress-rule/template.hbs
+++ b/lib/shared/addon/components/form-ingress-rule/template.hbs
@@ -4,11 +4,11 @@
 <hr/>
 {{#each rules as |rule|}}
   {{form-ingress-rows
-      removeRule=(action 'removeRule')
-      rules=rules
-      rule=rule
-      ingress=ingress
       editing=editing
+      ingress=ingress
+      removeRule=(action 'removeRule')
+      rule=rule
+      rules=rules
   }}
 {{else}}
   <div class="p-20">{{t 'formIngress.noRules'}}</div>

--- a/lib/shared/addon/components/input-yaml/template.hbs
+++ b/lib/shared/addon/components/input-yaml/template.hbs
@@ -49,6 +49,7 @@
         options=(hash
           autofocus=true
           theme="monokai"
+          tabSize=2
           lineNumbers=true
           mode="yaml"
           readOnly=(if (or (eq modalOpts.type 'review') readOnly) true false)

--- a/lib/shared/app/capabilities/service.js
+++ b/lib/shared/app/capabilities/service.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/capabilities/service';

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -2216,6 +2216,9 @@ clusterNew:
     windowsSupport:
       label: Windows Support (Experimental)
       disabled: Not support {plugin} network provider.
+    advanced:
+      label: Advanced Cluster Options
+      detail: Customize advanced options
   custom:
     label: Custom
     shortLabel: Custom
@@ -3209,6 +3212,7 @@ formIngress:
     existing: Keep the existing hostname <code>{domain}</code>
     manual: Specify a hostname to use
     default: Use as the default backend
+    defaultDisabled: Ingress controller does not support default backend
   defaultBackend:
     label: Set this rule as default backend
     mark: Default backend
@@ -3224,6 +3228,7 @@ formIngress:
   mode:
     workload: Workload
     service: DNS Record
+
 formIngressBackends:
   label: Target Backend
   noRules: No Backends


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

This PR adds logic to the UI to deal with cluster capabilities. Currently we have 4 new fields but only 3 are apart of this PR:

`ingressControllers`
`nodePoolScalingSupported`
`nodePortRange`

`l4loadBalancer` was added as well but we do not currently support l4 load balancers in the UI and this will be coming shortly in a different PR. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

New feature
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#15105

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

`ingressControllers`: Adds a new row to ingress rule rows when creating/editing ingress. If there are multiple `ingressControllers` you will have a select, otherwise it will be static text of the default backend provider. 
If the selected `ingressController` has `customDefaultBackend` set to `false` then you should see the `Use As Default Backend` field disabled.


`nodePoolScalingSupported`: If set to false you will not be able to scale node pools for the cluster. 

`nodePortRange`: When creating containers for a cluster you will have an updated `nodePortRange` in the `Port Mapping` section in the `Listening Port` input when a node port is the selected `As a` option. 
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
