### PR TITLE
Consolidate version checking cluster logic

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-azureaks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-azureaks/component.js
@@ -74,10 +74,8 @@ export default Component.extend(ClusterDriver, {
         const { versions, virtualNetworks } = resp;
 
         setProperties(this, {
-          step:     2,
-          versions: (get(versions, 'body') || []).map( (r) => {
-            return { 'value': r };
-          }),
+          step:            2,
+          versions:        (get(versions, 'body') || []),
           virtualNetworks: (get(virtualNetworks, 'body') || []),
         });
 

--- a/lib/shared/addon/components/cluster-driver/driver-azureaks/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-azureaks/template.hbs
@@ -125,15 +125,13 @@
         <div class="row">
           <div class="col span-6">
             <label class="acc-label" for="azureaks-kube-version">{{t 'clusterNew.azureaks.kubernetesVersion.label'}}</label>
-            {{new-select
-                id="azureaks-kube-version"
-                classNames="form-control"
-                content=versions
-                optionValuePath="value"
-                optionLabelPath="value"
+
+            {{form-versions
+                cluster=cluster
+                editing=(eq mode 'edit')
+                initialVersion=config.kubernetesVersion
                 value=config.kubernetesVersion
-                prompt="clusterNew.azureaks.kubernetesVersion.prompt"
-                localizedPrompt=true
+                versions=versions
             }}
           </div>
           <div class="col span-6">

--- a/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
@@ -3,7 +3,6 @@ import ClusterDriver from 'shared/mixins/cluster-driver';
 import layout from './template';
 
 import { get, set, computed, observer } from '@ember/object';
-import { satisfies } from 'shared/utils/parse-version';
 import { sortableNumericSuffix } from 'shared/utils/util';
 import { reject, all } from 'rsvp';
 
@@ -148,10 +147,10 @@ export default Component.extend(ClusterDriver, {
   versionChanged: observer('config.masterVersion', 'versionChoices.[]', function() {
     const versions = get(this, 'versionChoices') || [];
     const current = get(this, 'config.masterVersion');
-    const exists = versions.findBy('value', current);
+    const exists = versions[versions.indexOf(current)];
 
     if ( !exists ) {
-      set(this, 'config.masterVersion', versions[0].value);
+      set(this, 'config.masterVersion', versions[0]);
     }
   }),
 
@@ -183,35 +182,9 @@ export default Component.extend(ClusterDriver, {
   }),
 
   versionChoices: computed('versions.validMasterVersions.[]', 'config.masterVersion', function() {
-    const versions = get(this, 'versions');
-
-    if ( !versions ) {
-      return [];
-    }
-
-    const initialMasterVersion = get(this, 'initialMasterVersion');
-    let oldestSupportedVersion = '>=1.8.0';
-
-    if ( initialMasterVersion ) {
-      oldestSupportedVersion = `>=${  initialMasterVersion }`;
-    }
-
-    let out = versions.validMasterVersions.slice();
-
-    out = out.filter((v) => {
-      const str = v.replace(/-.*/, '');
-
-      return satisfies(str, oldestSupportedVersion);
-    });
-
-    if (get(this, 'editing') &&  !out.includes(initialMasterVersion) ) {
-      out.unshift(initialMasterVersion);
-    }
-
-    return out.map((v) => {
-      return { value: v }
-    });
+    return get(this, 'versions.validMasterVersions');
   }),
+
   fetchZones() {
     return get(this, 'globalStore').rawRequest({
       url:    '/meta/gkeZones',

--- a/lib/shared/addon/components/cluster-driver/driver-googlegke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-googlegke/template.hbs
@@ -43,14 +43,12 @@
       <div class="row">
         <div class="col span-6">
           <label class="acc-label">{{t 'clusterNew.googlegke.masterVersion.label'}}</label>
-          {{new-select
-              classNames="form-control"
-              content=versionChoices
-              optionValuePath="value"
-              optionLabelPath="value"
+          {{form-versions
+              cluster=cluster
+              editing=(eq mode 'edit')
+              initialVersion=config.masterVersion
               value=config.masterVersion
-              prompt="clusterNew.googlegke.masterVersion.prompt"
-              localizedPrompt=true
+              versions=versionChoices
           }}
         </div>
         <div class="col span-6">

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -3,8 +3,7 @@ import { equal, alias, or } from '@ember/object/computed';
 import {
   get, set, computed, observer, setProperties
 } from '@ember/object';
-import { satisfies } from 'shared/utils/parse-version';
-import { sortVersions } from 'shared/utils/sort';
+import { maxSatisfying } from 'shared/utils/parse-version';
 import { inject as service } from '@ember/service';
 import { underlineToCamel, removeEmpty, keysToCamel, validateEndpoint } from 'shared/utils/util';
 import { validateHostname } from 'ember-api-store/utils/validate';
@@ -199,12 +198,15 @@ export default InputTextFile.extend(ClusterDriver, {
 
   driverDidChange: observer('nodeWhich', function() {
     if ( get(this, 'isNew') ) {
-      const globalStore = get(this, 'globalStore');
+      const globalStore    = get(this, 'globalStore');
+      const versions       = get(this, 'versionChoices');
+      const defaultVersion = get(this, `settings.${ C.SETTING.VERSION_SYSTEM_K8S_DEFAULT_RANGE }`);
+      const satisfying     = maxSatisfying(versions, defaultVersion);
 
       const rkeConfig = globalStore.createRecord({
         type:                'rancherKubernetesEngineConfig',
         ignoreDockerVersion: true,
-        kubernetesVersion:   get(this, `settings.${ C.SETTING.VERSION_K8S_DEFAULT }`),
+        kubernetesVersion:   satisfying,
         authentication:      globalStore.createRecord({
           type:     'authnConfig',
           strategy: 'x509',
@@ -253,16 +255,6 @@ export default InputTextFile.extend(ClusterDriver, {
       set(flannel, 'label', 'clusterNew.rke.network.flannelCustom');
     } else {
       set(flannel, 'label', 'clusterNew.rke.network.flannel');
-    }
-  }),
-
-  versionChanged: observer('config.kubernetesVersion', 'versionChoices.[]', function() {
-    const versions = get(this, 'versionChoices') || [];
-    const current  = get(this, 'config.kubernetesVersion');
-    const exists   = versions.findBy('value', current);
-
-    if ( !exists ) {
-      set(this, 'config.kubernetesVersion', versions[0].value);
     }
   }),
 
@@ -368,46 +360,10 @@ export default InputTextFile.extend(ClusterDriver, {
     }
   }),
 
-  versionChoices: computed('initialVersion', `settings.${ C.SETTING.VERSIONS_K8S }`, 'config.kubernetesVersion', function() {
-    const versions = JSON.parse(get(this, `settings.${ C.SETTING.VERSIONS_K8S }`) || '{}');
-    const { experimentalVersion } = this;
+  versionChoices: computed(`settings.${ C.SETTING.VERSIONS_K8S }`, function() {
+    const out = JSON.parse(get(this, `settings.${ C.SETTING.VERSIONS_K8S }`) || '{}');
 
-    if ( !versions ) {
-      return [];
-    }
-
-    const initialVersion = get(this, 'initialVersion');
-
-    let oldestSupportedVersion = '>=1.8.0';
-
-    if ( initialVersion ) {
-      oldestSupportedVersion = `>=${  initialVersion }`;
-    }
-
-    let out = Object.keys(versions);
-
-    out = out.filter((v) => {
-      const str = v.replace(/-.*/, '');
-
-      return satisfies(str, oldestSupportedVersion);
-    });
-
-    if (get(this, 'mode') === 'edit' && !out.includes(initialVersion) ) {
-      out.unshift(initialVersion);
-    }
-
-    return sortVersions(out).reverse().map((v) => {
-      let label = v;
-
-      if (v === experimentalVersion) {
-        label = `${ v } (experimental)`
-      }
-
-      return {
-        label,
-        value: v
-      };
-    });
+    return Object.keys(out);
   }),
 
   isNodeNameValid: computed('nodeName', function() {
@@ -584,8 +540,6 @@ export default InputTextFile.extend(ClusterDriver, {
       return value;
     }
   }),
-
-  experimentalVersion:  C.EXPERIMENTAL_VERSIONS.RKE_K8S,
 
   validate() {
     this._super(...arguments);

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -66,9 +66,12 @@
         <div class="row">
           <div class="col span-6">
             <label class="acc-label">{{t 'clusterNew.rke.version.label'}}</label>
-            {{new-select
-                content=versionChoices
-                value=cluster.rancherKubernetesEngineConfig.kubernetesVersion
+            {{form-versions
+                cluster=cluster
+                editing=(eq mode 'edit')
+                initialVersion=initialVersion
+                value=config.kubernetesVersion
+                versions=versionChoices
             }}
           </div>
         </div>

--- a/lib/shared/addon/components/form-versions/component.js
+++ b/lib/shared/addon/components/form-versions/component.js
@@ -1,0 +1,90 @@
+import Component from '@ember/component';
+import layout from './template';
+import { get, set, computed, setProperties } from '@ember/object';
+import C from 'shared/utils/constants';
+import { inject as service } from '@ember/service';
+import { alias } from '@ember/object/computed';
+import { satisfies, maxSatisfying } from 'shared/utils/parse-version';
+import { sortVersions } from 'shared/utils/sort';
+import { scheduleOnce } from '@ember/runloop';
+import { lt, gt }  from 'semver';
+
+export default Component.extend({
+  settings: service(),
+  intl:     service(),
+
+  layout,
+
+  cluster:                null,
+  versionChoices:         null,
+  versions:               null,
+  initialVersion:         null,
+  editing:                false,
+  value:                  null,
+
+  defaultK8sVersionRange: alias(`settings.${ C.SETTING.VERSION_SYSTEM_K8S_DEFAULT_RANGE }`),
+  supportedVersionsRange: alias(`settings.${ C.SETTING.VERSION_K8S_SUPPORTED_RANGE }`),
+
+  init() {
+    this._super(...arguments);
+
+    scheduleOnce('afterRender', () => {
+      this.initVersions();
+    });
+  },
+
+  isRke: computed('cluster', function() {
+    const { cluster } = this;
+
+    if (get(cluster, 'rancherKubernetesEngineConfig')) {
+      return true;
+    }
+
+    return false;
+  }),
+
+  initVersions() {
+    const {
+      defaultK8sVersionRange, versions, supportedVersionsRange, editing, initialVersion
+    } = this;
+
+    if (!editing && defaultK8sVersionRange) {
+      var maxVersion = maxSatisfying(versions, defaultK8sVersionRange);
+
+      if (maxVersion) {
+        set(this, 'value', maxVersion);
+      }
+    }
+
+    let out = versions;
+
+    if ( !out.includes(initialVersion) && editing ) {
+      out.unshift(initialVersion);
+    }
+
+    set(this, 'versionChoices', sortVersions(out).reverse().map((v) => {
+      let label = v;
+      let out   = null;
+
+      if (gt(v, maxVersion)) {
+        label = `${ v } ${ this.intl.t('formVersions.experimental') }`
+      }
+
+      out = {
+        label,
+        value: v
+      };
+
+      if ((supportedVersionsRange && !satisfies(v, supportedVersionsRange) ) || (editing && initialVersion && lt(v, initialVersion))) {
+        if (!gt(v, maxVersion)) {
+          setProperties(out, {
+            disabled: true,
+            label:    `${ label } ${ this.intl.t('formVersions.unsupported') }`,
+          });
+        }
+      }
+
+      return out;
+    }));
+  },
+});

--- a/lib/shared/addon/components/form-versions/template.hbs
+++ b/lib/shared/addon/components/form-versions/template.hbs
@@ -1,0 +1,4 @@
+{{new-select
+    content=versionChoices
+    value=value
+}}

--- a/lib/shared/addon/components/new-select/component.js
+++ b/lib/shared/addon/components/new-select/component.js
@@ -87,6 +87,7 @@ export default Component.extend({
   _change() {
     const selectEl = this.$()[0];
     const selectedIndex = selectEl.selectedIndex;
+    const value = get(this, 'value');
 
     if ( selectedIndex === -1 ) {
       return;
@@ -108,7 +109,11 @@ export default Component.extend({
     }
 
     if ( selection ) {
-      this.set('value', get(selection, this.get('optionValuePath')));
+      if (typeof value === 'function') {
+        value(get(selection, this.get('optionValuePath')));
+      } else {
+        this.set('value', get(selection, this.get('optionValuePath')));
+      }
     } else {
       this.set('value', null);
     }

--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -473,37 +473,39 @@ var C = {
   },
 
   SETTING: {
-    IMAGE_RANCHER:             'server-image',
-    VERSION_RANCHER:           'server-version',
-    VERSION_COMPOSE:           'compose-version',
-    VERSION_CLI:               'cli-version',
-    VERSION_MACHINE:           'machine-version',
-    VERSION_HELM:              'helm-version',
-    VERSIONS_K8S:              'k8s-version-to-images',
-    VERSION_K8S_DEFAULT:       'k8s-version',
+    IMAGE_RANCHER:                    'server-image',
+    VERSION_RANCHER:                  'server-version',
+    VERSION_COMPOSE:                  'compose-version',
+    VERSION_CLI:                      'cli-version',
+    VERSION_MACHINE:                  'machine-version',
+    VERSION_HELM:                     'helm-version',
+    VERSIONS_K8S:                     'k8s-version-to-images',
+    VERSION_RKE_K8S_DEFAULT:          'k8s-version',
+    VERSION_K8S_SUPPORTED_RANGE:      'ui-k8s-supported-versions-range',
+    VERSION_SYSTEM_K8S_DEFAULT_RANGE: 'ui-k8s-default-version-range',
 
-    CLI_URL:                   {
-      DARWIN:                  'cli-url-darwin',
-      WINDOWS:                 'cli-url-windows',
-      LINUX:                   'cli-url-linux',
+    CLI_URL:                    {
+      DARWIN:                   'cli-url-darwin',
+      WINDOWS:                  'cli-url-windows',
+      LINUX:                    'cli-url-linux',
     },
 
-    API_HOST:                  'api-host',
-    CA_CERTS:                  'cacerts',
-    // CLUSTER_DEFAULTS:          'cluster-defaults',
-    ENGINE_URL:                'engine-install-url',
-    ENGINE_ISO_URL:            'engine-iso-url',
-    FIRST_LOGIN:               'first-login',
-    INGRESS_IP_DOMAIN:         'ingress-ip-domain',
-    PL:                        'ui-pl',
-    PL_RANCHER_VALUE:          'rancher',
-    SUPPORTED_DOCKER:          'engine-supported-range',
-    NEWEST_DOCKER:             'engine-newest-version',
-    SERVER_URL:                'server-url',
-    TELEMETRY:                 'telemetry-opt',
+    API_HOST:                   'api-host',
+    CA_CERTS:                   'cacerts',
+    // CLUSTER_DEFAULTS:        'cluster-defaults',
+    ENGINE_URL:                 'engine-install-url',
+    ENGINE_ISO_URL:             'engine-iso-url',
+    FIRST_LOGIN:                'first-login',
+    INGRESS_IP_DOMAIN:          'ingress-ip-domain',
+    PL:                         'ui-pl',
+    PL_RANCHER_VALUE:           'rancher',
+    SUPPORTED_DOCKER:           'engine-supported-range',
+    NEWEST_DOCKER:              'engine-newest-version',
+    SERVER_URL:                 'server-url',
+    TELEMETRY:                  'telemetry-opt',
 
-    AUTH_LOCAL_VALIDATE_DESC:  'auth-password-requirements-description',
-    FEEDBACK_FORM:             'ui-feedback-form',
+    AUTH_LOCAL_VALIDATE_DESC:   'auth-password-requirements-description',
+    FEEDBACK_FORM:              'ui-feedback-form',
   },
 
   TABLES: { DEFAULT_COUNT: 50 },
@@ -699,8 +701,6 @@ C.NOTIFIER_TABLE_LABEL = {
   WEBHOOK:   'URL',
   DEFAULT:   'Notifier',
 }
-
-C.EXPERIMENTAL_VERSIONS = { RKE_K8S: 'v1.12.0-rancher1-1' }
 
 C.CONDITION = {
   SUCCESS: 'Success',

--- a/lib/shared/addon/utils/parse-version.js
+++ b/lib/shared/addon/utils/parse-version.js
@@ -3,8 +3,9 @@ import Semver from 'semver';
 
 export function satisfies(version, range) {
   // Semver doesn't take padding zeros like 17.03.1
-  range = range.replace(/\.0+(\d+)/g, '.$1');
+  range   = range.replace(/\.0+(\d+)/g, '.$1');
   version = version.replace(/\.0+(\d+)/g, '.$1');
+  version = version.replace(/\-.*$/g, ''); // strip hyphen (prerelease in semver) because cloud providers dont use it as prerelease
 
   if ( !Semver.validRange(range) ) {
     console.error('Invalid semver range:', range);
@@ -19,6 +20,47 @@ export function satisfies(version, range) {
   }
 
   return Semver.satisfies(version, range);
+}
+
+export function maxSatisfying(versions, range) {
+  const versionsErrors = [];
+  const nueVersions = [].concat(versions);
+
+  let satisfiedVersion = null;
+
+  // Semver doesn't take padding zeros like 17.03.1
+  range   = range.replace(/\.0+(\d+)/g, '.$1');
+
+  nueVersions.forEach( ( version, i, ary ) => {
+    ary[i] = version.replace(/\.0+(\d+)/g, '.$1');
+    ary[i] = version.replace(/\-.*$/g, ''); // strip hyphen (prerelease in semver) because cloud providers dont use it as prerelease
+
+    if ( !Semver.valid(version) ) {
+      versionsErrors.pushObject(`Invalid semver version: ${ version }`);
+    }
+  });
+
+  if ( !Semver.validRange(range) ) {
+    console.error('Invalid semver range:', range);
+
+    return false;
+  }
+
+  if ( versionsErrors.length > 0 ) {
+    versionsErrors.forEach( (v) => console.log(v));
+
+    return false;
+  }
+
+  satisfiedVersion = Semver.maxSatisfying(nueVersions, range);
+
+  if (satisfiedVersion) {
+    return versions.find((v) => {
+      return v.includes(satisfiedVersion);
+    });
+  } else {
+    return null;
+  }
 }
 
 // @TODO replace with semver calls and verify compare works the same for -preX tags

--- a/lib/shared/app/components/form-versions/component.js
+++ b/lib/shared/app/components/form-versions/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/form-versions/component';

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4505,7 +4505,7 @@ formValueArray:
 
 formVersions:
   experimental: "(experimental)"
-  unsupoorted: "(unsupoorted)"
+  unsupported: "(unsupported)"
 
 formVolumeRow:
   prompt: Select a Persistent Volume Claim...

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4503,6 +4503,10 @@ formValueArray:
   noData: No Data
   protip: "ProTip: Paste one or more lines of values into any field for easy bulk entry."
 
+formVersions:
+  experimental: "(experimental)"
+  unsupoorted: "(unsupoorted)"
+
 formVolumeRow:
   prompt: Select a Persistent Volume Claim...
   name:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

New api settings were added (`KubernetesDefaultVersion`, `KubernetesSupportedVersions`) to give us a centralized location to expose our default K8s version and supported version in range formats. This PR adds a new component that will sort and compare version only using versions that are within our ranges. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

New feature
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#16113
rancher/rancher#15592
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

When launching any cluster you should see the latest version for Kube selected now regardless of provider. Additionally if the version is outside our two new settings for the ranges we should see either `experimental` or `unsupported` added to the list. In the case of unsupported you should not be able to select that option. 

new settings are: 
`ui-k8s-supported-versions-range`
`ui-k8s-default-version-range`
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->