### PR TITLE
Unable to clone a cloned secret

### DIFF
--- a/app/components/cru-secret/component.js
+++ b/app/components/cru-secret/component.js
@@ -38,6 +38,8 @@ export default Component.extend(ViewNewEdit, OptionallyNamespaced, {
 
     set(pr, 'namespaceId', nsId);
 
+    delete pr.kind
+
     return ok;
   },
 


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

- Reson: when clone s2  to s1, `kind` in request body is `Opaque`, but `kind` in respond body have been changed to `opaque`, when clone s2 to s3, `kind: opaque` is a invalid option and get 422 error.

- Solution: Remove `kind` in request body because new a secret does not carry `kind`.

Types of changes
======

- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

https://github.com/rancher/rancher/issues/16219

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
