### PR TITLE
Show warning messages when removing bound pvc

### DIFF
--- a/lib/shared/addon/components/confirm-delete/component.js
+++ b/lib/shared/addon/components/confirm-delete/component.js
@@ -73,6 +73,10 @@ export default Component.extend(ModalBase, {
     return !!get(this, 'resources').findBy('type', 'clusterRoleTemplateBinding');
   }),
 
+  isBoundPvc: computed('resources', function() {
+    return !!get(this, 'resources').find((pvc) => get(pvc, 'type') === 'persistentVolumeClaim' && get(pvc, 'state') === 'bound');
+  }),
+
   isSystemProject: computed('resources', function() {
     const project = get(this, 'resources').findBy('type', 'project');
 

--- a/lib/shared/addon/components/confirm-delete/template.hbs
+++ b/lib/shared/addon/components/confirm-delete/template.hbs
@@ -41,6 +41,13 @@
     {{t 'confirmDelete.clusterRoleTemplateBindingNote'}}
   </div>
 {{/if}}
+{{#if isBoundPvc}}
+  <div class="mb-20 mt-20">
+    {{#banner-message color='bg-warning m-0'}}
+      {{t 'confirmDelete.pvcProtection'}}
+    {{/banner-message}}
+  </div>
+{{/if}}
 <div class="footer-actions">
   <button {{action "confirm"}} class="btn bg-error">{{t 'confirmDelete.confirmAction'}}</button>
   <button {{action "cancel"}} class="btn bg-transparent">{{t 'confirmDelete.cancelAction'}}</button>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -2287,6 +2287,7 @@ confirmDelete:
   confirmAction: Delete
   cancelAction: Cancel
   largeDeleteText: '{key} and {othersCount} others'
+  pvcProtection: 'Note: If the PVC is in active use by a pod, the PVC might not be removed until the PVC is no longer actively used by any pods.'
 
 containerLogs:
   download: Download Logs


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
If a user deletes a PVC in active use by a pod, the PVC is not removed immediately. PVC removal is postponed until the PVC is no longer actively used by any pods.

We should show a warning message when user deletes it as the state of the PVC will be always `Removing`
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
- New feature (non-breaking change which adds functionality)
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/16268
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
