### PR TITLE
UI Import YAML on wide lines makes UI fail

### DIFF
--- a/lib/shared/addon/components/input-yaml/component.js
+++ b/lib/shared/addon/components/input-yaml/component.js
@@ -38,6 +38,7 @@ export default Component.extend(ThrottledResize, {
   showDownload:     true,
 
   shouldChangeName: true,
+  wrapLines:        false,
 
   init() {
     this._super(...arguments);
@@ -109,8 +110,10 @@ export default Component.extend(ThrottledResize, {
       }
 
       const desired = this.$(window).height() - position.top - get(this, 'resizeFooter');
+      const width = this.$(window).width() - 2 * position.left
 
       container.css('max-height', Math.max(get(this, 'minHeight'), desired));
+      container.css('max-width', width);
     }
   },
 

--- a/lib/shared/addon/components/input-yaml/template.hbs
+++ b/lib/shared/addon/components/input-yaml/template.hbs
@@ -55,10 +55,16 @@
           readOnly=(if (or (eq modalOpts.type 'review') readOnly) true false)
           gutters=gutters
           lint=true
-          lineWrapping=true
+          lineWrapping=(if wrapLines true false)
           viewportMargin=viewportMargin
         )
       }}
+    </div>
+    <div class="checkbox pt-10">
+      <label>
+        {{input type="checkbox" checked=wrapLines}}
+        {{t 'containerLogs.wrapLines'}}
+      </label>
     </div>
   {{/if}}
 </div>


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Add max-width and wrapline checkbox for `{{input-yaml}}`

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

https://github.com/rancher/rancher/issues/16273

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
