### PR TITLE
Fix graph area bug

### DIFF
--- a/lib/shared/addon/components/metrics-summary/component.js
+++ b/lib/shared/addon/components/metrics-summary/component.js
@@ -1,7 +1,16 @@
 import Component from '@ember/component';
 import layout from './template'
+import { get, observer } from '@ember/object';
+import $ from 'jquery';
+
 export default Component.extend({
   layout,
 
   title: null,
+
+  expandedDidChange: observer('expanded', function() {
+    if ( get(this, 'expanded') ) {
+      $(window).trigger('resize');
+    }
+  }),
 });

--- a/lib/shared/addon/components/metrics-summary/template.hbs
+++ b/lib/shared/addon/components/metrics-summary/template.hbs
@@ -4,6 +4,7 @@
     detail=(t 'metricsAction.description')
     expandAll=expandAll
     expand=(action expandFn)
+    expanded=expanded
     componentName='sortable-table'
     as | parent |
 }}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Now the graph is under an accordion. 
`accordion` component will add a `display: none` style for the accordion content.

Graph will do the re-draw when resize happens. It will calculate the width during the re-draw.

So it is safe to force to trigger the resize event when user expand the accordion for metrics
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
