### PR TITLE
Fix graph issue when switching clusters

### DIFF
--- a/lib/monitoring/addon/components/cluster-dashboard/component.js
+++ b/lib/monitoring/addon/components/cluster-dashboard/component.js
@@ -1,10 +1,13 @@
 import C from 'ui/utils/constants';
 import { on } from '@ember/object/evented';
 import Component from '@ember/component';
-import { get, computed, observer, setProperties } from '@ember/object';
+import {
+  set, get, computed, observer, setProperties
+} from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import layout from './template';
+import { next } from '@ember/runloop';
 
 export default Component.extend({
   intl:        service(),
@@ -17,6 +20,7 @@ export default Component.extend({
 
   nodes:             null,
   components:        null,
+  showClusterTabs:   true,
   monitoringEnabled: alias('scope.currentCluster.enableClusterMonitoring'),
   componentStatuses: alias('scope.currentCluster.componentStatuses'),
 
@@ -25,6 +29,13 @@ export default Component.extend({
       get(this, 'router').transitionTo('authenticated.cluster.monitoring.cluster-setting');
     },
   },
+
+  clusterDidChange: observer('scope.currentCluster.id', function() {
+    set(this, 'showClusterTabs', false);
+    next(() => {
+      set(this, 'showClusterTabs', true);
+    });
+  }),
 
   setComponents: on('init', observer('componentStatuses.@each.conditions', 'nodes.@each.{state}', function() {
     setProperties(this, {

--- a/lib/monitoring/addon/components/cluster-dashboard/template.hbs
+++ b/lib/monitoring/addon/components/cluster-dashboard/template.hbs
@@ -56,7 +56,7 @@
     {{/each}}
   </div>
 
-  {{#if scope.currentCluster.isMonitoringReady}}
+  {{#if (and showClusterTabs scope.currentCluster.isMonitoringReady)}}
     {{cluster-dashboard-tabs dashboards=dashboards}}
   {{/if}}
 {{else}}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Graph become stale when switching from one cluster monitoring page to another

We need to force the graphs to re-render after switching from one cluster monitoring page to another

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/16973
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
