### PR TITLE
[bugfix] Chinese translation wrong written

### DIFF
--- a/translations/zh-hans.yaml
+++ b/translations/zh-hans.yaml
@@ -581,7 +581,7 @@ authPage:
           labelText: 确认密码
     accessControl:
       header: '2. 启用访问控制'
-      helpText: '点击以开启访问控制并登陆'
+      helpText: '点击以开启访问控制并登录'
       buttonText:
         pre: 启用本地认证
         post: '启用中...'
@@ -1892,7 +1892,7 @@ clusterRow:
   noClusterData: 没有任何集群。
   addHost: 添加主机...
   importCluster: 使用已有的Kubernetes
-  loginDefault: 登陆
+  loginDefault: 登录
 
 clusterNew:
   advanced:

--- a/translations/zh-hant.yaml
+++ b/translations/zh-hant.yaml
@@ -580,7 +580,7 @@ authPage:
           labelText: 確認密碼
     accessControl:
       header: '2. 啟用訪問控制'
-      helpText: '點擊以開啟訪問控制並登陸'
+      helpText: '點擊以開啟訪問控制並登錄'
       buttonText:
         pre: 啟用本地認證
         post: '啟用中...'
@@ -1867,7 +1867,7 @@ clusterRow:
   noClusterData: 沒有任何集群。
   addHost: 添加主機...
   importCluster: 使用已有的Kubernetes
-  loginDefault: 登陸
+  loginDefault: 登錄
 
 clusterNew:
   advanced:


### PR DESCRIPTION

Proposed changes
======

In Chinese, "登陆" means someone land on island, while you should use "登录" if you want to say login system by account. 

Types of changes
======

- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======

Further comments
======

