### PR TITLE
Add note for private ips on EKS cluster re multiple subnets

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-amazoneks/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-amazoneks/template.hbs
@@ -1,14 +1,14 @@
 {{#accordion-list showExpandAll=false as | al expandFn |}}
   {{#accordion-list-item
-       title=(t 'clusterNew.amazoneks.access.title')
-       detail=(t 'clusterNew.amazoneks.access.detail')
+       title=(t "clusterNew.amazoneks.access.title")
+       detail=(t "clusterNew.amazoneks.access.detail")
        expandAll=expandAll
        expand=(action expandFn)
        expandOnInit=true
   }}
     <div class="row">
       <div class="col span-3">
-        <label class="acc-label">{{t 'nodeDriver.amazoneks.region.label'}}</label>
+        <label class="acc-label">{{t "nodeDriver.amazoneks.region.label"}}</label>
         {{#if (eq step 1)}}
           <select class="form-control" onchange={{action (mut config.region) value="target.value"}}>
             {{#each regionChoices as |choice|}}
@@ -21,29 +21,47 @@
       </div>
 
       <div class="col span-3">
-        <label class="acc-label">{{t 'nodeDriver.amazoneks.accessKey.label'}}</label>
+        <label class="acc-label">{{t "nodeDriver.amazoneks.accessKey.label"}}</label>
         {{#if (eq step 1)}}
-          {{input type="text" name="username" classNames="form-control" placeholder=(t 'nodeDriver.amazoneks.accessKey.placeholder') value=config.accessKey}}
+          {{input
+              type="text"
+              name="username"
+              classNames="form-control"
+              placeholder=(t "nodeDriver.amazoneks.accessKey.placeholder")
+              value=config.accessKey
+          }}
         {{else}}
           <div>{{config.accessKey}}</div>
         {{/if}}
       </div>
 
       <div class="col span-3">
-        <label class="acc-label">{{t 'nodeDriver.amazoneks.secretKey.label'}}</label>
+        <label class="acc-label">{{t "nodeDriver.amazoneks.secretKey.label"}}</label>
         {{#if (eq step 1)}}
-          {{input type="password" name="password" classNames="form-control" placeholder=(t 'nodeDriver.amazoneks.secretKey.placeholder') value=config.secretKey}}
+          {{input
+              type="password"
+              name="password"
+              classNames="form-control"
+              placeholder=(t "nodeDriver.amazoneks.secretKey.placeholder")
+              value=config.secretKey
+          }}
         {{else}}
-          <div class="text-muted text-italic">{{t 'nodeDriver.amazoneks.secretKey.provided'}}</div>
+          <div class="text-muted text-italic">{{t "nodeDriver.amazoneks.secretKey.provided"}}</div>
         {{/if}}
       </div>
 
       <div class="col span-3">
-        <label class="acc-label">{{t 'nodeDriver.amazoneks.sessionToken.label' htmlSafe=true}}</label>
+        <label class="acc-label">{{t "nodeDriver.amazoneks.sessionToken.label" htmlSafe=true}}</label>
         {{#if (eq step 1)}}
-          {{input type="password" name="session-token" classNames="form-control" placeholder=(t 'nodeDriver.amazoneks.sessionToken.placeholder') value=config.sessionToken}}
+          {{input
+              type="password"
+              name="session-token"
+              classNames="form-control"
+              placeholder=(t "nodeDriver.amazoneks.sessionToken.placeholder")
+              value=config.sessionToken
+          }}
         {{else}}
-          <div class="text-muted text-italic">{{t 'nodeDriver.amazoneks.sessionToken.provided'}}</div>
+          <div class="text-muted text-italic">{{t "nodeDriver.amazoneks.sessionToken.provided"}}</div>
         {{/if}}
       </div>
     </div>
@@ -51,7 +69,7 @@
     {{#if (eq step 1)}}
       <div class="row">
         <div class="span-9 offset-3">
-          <p class="text-info text-small m-0">{{t 'nodeDriver.amazonec2.access.help'}}</p>
+          <p class="text-info text-small m-0">{{t "nodeDriver.amazonec2.access.help"}}</p>
         </div>
       </div>
     {{/if}}
@@ -59,7 +77,7 @@
 
   {{#if (eq step 1)}}
     {{save-cancel
-        editing=(eq mode 'edit')
+        editing=(eq mode "edit")
         save="awsLogin"
         cancel=close
         createLabel="nodeDriver.amazoneks.access.next"
@@ -69,8 +87,8 @@
 
   {{#if (gte step 2)}}
     {{#accordion-list-item
-         title=(t 'nodeDriver.amazoneks.role.title')
-         detail=(t 'nodeDriver.amazoneks.role.detail')
+         title=(t "nodeDriver.amazoneks.role.title")
+         detail=(t "nodeDriver.amazoneks.role.detail")
          showExpand=false
          expandOnInit=true
          expandAll=al.expandAll
@@ -78,21 +96,21 @@
     }}
       <div class="row">
         <div class="col span-6">
-          <label class="acc-label">{{t 'nodeDriver.amazoneks.role.label'}}</label>
+          <label class="acc-label">{{t "nodeDriver.amazoneks.role.label"}}</label>
           {{#if (eq step 2)}}
             <div class="radio">
               <div class="radio">
                 <label>
                   {{radio-button selection=serviceRoleMode value="default"}}
-                  {{t 'nodeDriver.amazoneks.role.radio.default'}}
+                  {{t "nodeDriver.amazoneks.role.radio.default"}}
                 </label>
                 <label>
                   {{radio-button selection=serviceRoleMode value="custom"}}
-                  {{t 'nodeDriver.amazoneks.role.radio.custom'}}
+                  {{t "nodeDriver.amazoneks.role.radio.custom"}}
                 </label>
               </div>
             </div>
-            {{#unless (eq serviceRoleMode 'default')}}
+            {{#unless (eq serviceRoleMode "default")}}
               {{new-select
                   classNames="form-control"
                   value=selectedServiceRole
@@ -106,7 +124,7 @@
               {{#if config.serviceRole}}
                 {{readableServiceRole}}
               {{else}}
-                {{t 'nodeDriver.amazoneks.role.noneSelected'}}
+                {{t "nodeDriver.amazoneks.role.noneSelected"}}
               {{/if}}
             </div>
           {{/if}}
@@ -116,7 +134,7 @@
 
     {{#if (eq step 2)}}
       {{save-cancel
-          editing=(eq mode 'edit')
+          editing=(eq mode "edit")
           save="loadVPS"
           cancel=close
           createLabel="nodeDriver.amazoneks.role.next"
@@ -127,8 +145,8 @@
 
   {{#if (gte step 3)}}
     {{#accordion-list-item
-         title=(t 'nodeDriver.amazoneks.vpc.title')
-         detail=(t 'nodeDriver.amazoneks.vpc.detail')
+         title=(t "nodeDriver.amazoneks.vpc.title")
+         detail=(t "nodeDriver.amazoneks.vpc.detail")
          showExpand=false
          expandOnInit=true
          expandAll=al.expandAll
@@ -136,48 +154,62 @@
     }}
       <div class="row">
         <div class="col span-6">
-          <label class="acc-label">{{t 'nodeDriver.amazoneks.associateWorkerNodePublicIp.title'}}</label>
+          <label class="acc-label">{{t "nodeDriver.amazoneks.associateWorkerNodePublicIp.title"}}</label>
           {{#if (or (eq step 3) (eq step 4))}}
             <div class="radio">
               <label>
-                {{radio-button selection=config.associateWorkerNodePublicIp value=true}}
-                {{t 'nodeDriver.amazoneks.associateWorkerNodePublicIp.radio.default'}}
+                {{radio-button
+                    selection=config.associateWorkerNodePublicIp
+                    value=true
+                }}
+                {{t "nodeDriver.amazoneks.associateWorkerNodePublicIp.radio.default"}}
               </label>
             </div>
             <div class="radio">
               <label>
-                {{radio-button selection=config.associateWorkerNodePublicIp value=false}}
-                {{t 'nodeDriver.amazoneks.associateWorkerNodePublicIp.radio.off'}}
+                {{radio-button
+                    selection=config.associateWorkerNodePublicIp
+                    value=false
+                }}
+                {{t "nodeDriver.amazoneks.associateWorkerNodePublicIp.radio.off"}}
               </label>
             </div>
           {{else}}
             {{#if (eq config.associateWorkerNodePublicIp true)}}
               <div>
-                {{t 'nodeDriver.amazoneks.associateWorkerNodePublicIp.radio.default'}}
+                {{t "nodeDriver.amazoneks.associateWorkerNodePublicIp.radio.default"}}
               </div>
             {{else}}
               <div>
-                {{t 'nodeDriver.amazoneks.associateWorkerNodePublicIp.radio.off'}}
+                {{t "nodeDriver.amazoneks.associateWorkerNodePublicIp.radio.off"}}
               </div>
             {{/if}}
           {{/if}}
         </div>
         <div class="col span-6">
-          <label class="acc-label">{{t 'nodeDriver.amazoneks.vpc.title'}}</label>
+          <label class="acc-label">{{t "nodeDriver.amazoneks.vpc.title"}}</label>
           {{#if (or (eq step 3) (eq step 4))}}
             <div class="radio">
               <label>
-                {{radio-button selection=vpcSubnetMode value="default" disabled=(eq config.associateWorkerNodePublicIp false)}}
-                {{t 'nodeDriver.amazoneks.vpc.radio.default'}}
+                {{radio-button
+                    selection=vpcSubnetMode
+                    value="default"
+                    disabled=(eq config.associateWorkerNodePublicIp false)
+                }}
+                {{t "nodeDriver.amazoneks.vpc.radio.default"}}
               </label>
             </div>
             <div class="radio">
               <label>
-                {{radio-button selection=vpcSubnetMode value="custom" disabled=(eq config.associateWorkerNodePublicIp false)}}
-                {{t 'nodeDriver.amazoneks.vpc.radio.custom'}}
+                {{radio-button
+                    selection=vpcSubnetMode
+                    value="custom"
+                    disabled=(eq config.associateWorkerNodePublicIp false)
+                }}
+                {{t "nodeDriver.amazoneks.vpc.radio.custom"}}
               </label>
             </div>
-            {{#unless (eq vpcSubnetMode 'default')}}
+            {{#unless (eq vpcSubnetMode "default")}}
               {{new-select
                   classNames="form-control"
                   value=config.virtualNetwork
@@ -189,7 +221,7 @@
           {{else}}
             {{#if (eq vpcSubnetMode "default")}}
               <div>
-                {{t 'nodeDriver.amazoneks.vpc.noneSelected'}}
+                {{t "nodeDriver.amazoneks.vpc.noneSelected"}}
               </div>
             {{else}}
               <div>
@@ -199,19 +231,22 @@
           {{/if}}
         </div>
 
-        {{#if (and (eq step 4) (eq vpcSubnetMode 'custom'))}}
+        {{#if (and (eq step 4) (eq vpcSubnetMode "custom"))}}
           <div class="col span-6">
-            <label class="acc-label">{{t 'nodeDriver.amazoneks.subnet.title'}}</label>
-            <select class="form-control existing-subnet-groups" multiple="true" onchange={{action 'multiSubnetGroupSelect' ''}}>
+            <label class="acc-label">{{t "nodeDriver.amazoneks.subnet.title"}}</label>
+            <select class="form-control existing-subnet-groups" multiple="true" onchange={{action "multiSubnetGroupSelect" ""}}>
               {{#each filteredSubnets as |choice|}}
                 <option value={{choice.subnetId}} selected={{array-includes config.subnets choice.subnetId}}>{{choice.subnetName}} ({{choice.subnetId}})</option>
               {{/each}}
             </select>
+            {{#if (eq config.associateWorkerNodePublicIp false)}}
+              <p class="help-block">{{t "nodeDriver.amazoneks.subnet.help"}}</p>
+            {{/if}}
           </div>
         {{else}}
           {{#if (and (eq vpcSubnetMode "custom") (gte step 4)) }}
             <div class="col span-6">
-              <label class="acc-label">{{t 'nodeDriver.amazoneks.subnet.title'}}</label>
+              <label class="acc-label">{{t "nodeDriver.amazoneks.subnet.title"}}</label>
               {{#each config.subnets as |sub|}}
                 <div>{{sub}}</div>
               {{/each}}
@@ -225,7 +260,7 @@
     {{#if (eq step 3)}}
       {{#if (eq vpcSubnetMode "default")}}
         {{save-cancel
-            editing=(eq mode 'edit')
+            editing=(eq mode "edit")
             saveDisabled=canSaveVPC
             save="setVPCS"
             cancel=close
@@ -234,7 +269,7 @@
         }}
       {{else}}
         {{save-cancel
-            editing=(eq mode 'edit')
+            editing=(eq mode "edit")
             saveDisabled=canSaveVPC
             save="setVPCS"
             cancel=close
@@ -246,7 +281,7 @@
 
     {{#if (eq step 4)}}
       {{save-cancel
-          editing=(eq mode 'edit')
+          editing=(eq mode "edit")
           saveDisabled=(lte config.subnets.length 0)
           save="setSubnets"
           cancel=close
@@ -258,8 +293,8 @@
 
   {{#if (and (gte step 5) (eq vpcSubnetMode "custom") )}}
     {{#accordion-list-item
-         title=(t 'nodeDriver.amazoneks.securityGroup.title')
-         detail=(t 'nodeDriver.amazoneks.securityGroup.detail')
+         title=(t "nodeDriver.amazoneks.securityGroup.title")
+         detail=(t "nodeDriver.amazoneks.securityGroup.detail")
          showExpand=false
          expandOnInit=true
          expandAll=al.expandAll
@@ -267,7 +302,7 @@
     }}
       <div class="row">
         {{#if (eq step 5)}}
-          <select class="form-control existing-security-groups" multiple="true" onchange={{action 'multiSecurityGroupSelect' ''}}>
+          <select class="form-control existing-security-groups" multiple="true" onchange={{action "multiSecurityGroupSelect" ""}}>
             {{#each filteredSecurityGroups as |choice|}}
               <option value={{choice.GroupId}} selected={{array-includes config.securityGroups choice.GroupId}}>{{choice.GroupName}} ({{choice.GroupId}})</option>
             {{/each}}
@@ -284,7 +319,7 @@
 
     {{#if (eq step 5)}}
       {{save-cancel
-          editing=(eq mode 'edit')
+          editing=(eq mode "edit")
           saveDisabled=canSaveSG
           save=(action (mut step) 6)
           cancel=close
@@ -296,8 +331,8 @@
 
   {{#if (eq step 6)}}
     {{#accordion-list-item
-         title=(t 'clusterNew.nodes.title')
-         detail=(t 'clusterNew.nodes.detail')
+         title=(t "clusterNew.nodes.title")
+         detail=(t "clusterNew.nodes.detail")
          showExpand=false
          expandOnInit=true
          expandAll=al.expandAll
@@ -305,7 +340,7 @@
     }}
       <div class="row">
         <div class="col span-6">
-          <label class="acc-label">{{t 'nodeDriver.amazonec2.instanceType.label'}}</label>
+          <label class="acc-label">{{t "nodeDriver.amazonec2.instanceType.label"}}</label>
           {{new-select
               classNames="form-control"
               value=config.instanceType
@@ -316,29 +351,29 @@
           }}
         </div>
         <div class="col span-6">
-          <label class="acc-label">{{t 'nodeDriver.amazoneks.ami.label'}}</label>
+          <label class="acc-label">{{t "nodeDriver.amazoneks.ami.label"}}</label>
           {{input type="text" value=config.ami}}
           <p class="help-block">
-            {{t 'nodeDriver.amazoneks.ami.help'}}
+            {{t "nodeDriver.amazoneks.ami.help"}}
           </p>
         </div>
 
       </div>
       <div class="row">
         <div class="col span-6">
-          <label class="acc-label">{{t 'nodeDriver.amazoneks.min.label'}}</label>
+          <label class="acc-label">{{t "nodeDriver.amazoneks.min.label"}}</label>
           {{input-number value=config.minimumNodes min=1}}
         </div>
 
         <div class="col span-6">
-          <label class="acc-label">{{t 'nodeDriver.amazoneks.max.label'}}</label>
+          <label class="acc-label">{{t "nodeDriver.amazoneks.max.label"}}</label>
           {{input-number value=config.maximumNodes min=1}}
         </div>
       </div>
     {{/accordion-list-item}}
 
     {{save-cancel
-        editing=(eq mode 'edit')
+        editing=(eq mode "edit")
         save="driverSave"
         cancel=close
     }}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -5315,6 +5315,7 @@ nodeDriver:
         custom: "Custom: Choose from your existing VPC and Subnets"
     subnet:
       title: Subnet
+      help: 2 subnets required
       next: "Next: Select Security Group"
       loading: "Loading Security Groups from Amazon..."
     associateWorkerNodePublicIp:


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

When setting Public IPs Exposed to false on creation of an eks cluster we should show a note that the user must select 2 subnets
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#16766

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
