### PR TITLE
Fix storage class default flag

### DIFF
--- a/app/models/storageclass.js
+++ b/app/models/storageclass.js
@@ -1,5 +1,5 @@
 import Resource from 'ember-api-store/models/resource';
-import { get, computed } from '@ember/object';
+import { get, set, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { all } from 'rsvp';
 
@@ -119,7 +119,12 @@ export default Resource.extend({
   },
 
   setDefault(on) {
-    const annotations = get(this, 'annotations') || {};
+    let annotations = get(this, 'annotations');
+
+    if ( !annotations ) {
+      annotations = {};
+      set(this, 'annotations', annotations);
+    }
 
     if ( on ) {
       annotations[DEFAULT_ANNOTATION] = 'true';


### PR DESCRIPTION
Proposed changes
======
Fix setting the default flag on a storage class if the model doesn't already have an annotations object.

Types of changes
======

Bugfix

Linked Issues
======

rancher/rancher#15097