### PR TITLE
Fix incorrect styling of labels for rke windows support

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -95,7 +95,7 @@
             <div class="col span-4">
               <label class="acc-label">{{t "clusterNew.rke.windowsSupport.label"}}</label>
               <div class="radio">
-                <label class={{if (not-eq config.network.plugin "flannel") "text-muted"}}>
+                <label class={{if (not-eq cluster.rancherKubernetesEngineConfig.network.plugin "flannel") "text-muted"}}>
                   {{radio-button
                       selection=windowsSupport
                       value=true
@@ -105,7 +105,7 @@
                 </label>
               </div>
               <div class="radio">
-                <label class={{if (not-eq config.network.plugin "flannel") "text-muted"}}>
+                <label class={{if (not-eq cluster.rancherKubernetesEngineConfig.network.plugin "flannel") "text-muted"}}>
                   {{radio-button
                       selection=windowsSupport
                       value=false


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

We weren't reading the correct parameter to display the text-muted class on the windows support label for rke clusters network config.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#16397

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
