### PR TITLE
Fix incorrect check on project namespaces for the grouped view

### DIFF
--- a/app/authenticated/project/ns/index/template.hbs
+++ b/app/authenticated/project/ns/index/template.hbs
@@ -42,7 +42,7 @@
         </td>
       </tr>
     {{else if (eq kind "group")}}
-      {{#if obj.ref}}
+      {{#if obj.ref.type}}
         <tr class="group-row">
           <td colspan="{{sortable.fullColspan}}" class="pl-10">
             {{t 'projectsListNamespacePage.current'}}


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

The grouped namespace view on project level would list namespaces with no project as 'in this project' because we were checking if an  grouped ref obj exist. We need to check if the type exists because ns's with no group still have a ref object in the sortable table. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#17219
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
