### PR TITLE
Add S3 Etcd Backup & Restore API to UI

### DIFF
--- a/app/authenticated/cluster/backups/controller.js
+++ b/app/authenticated/cluster/backups/controller.js
@@ -1,0 +1,34 @@
+import Controller from '@ember/controller';
+import { get, computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default Controller.extend({
+  scope:            service(),
+  sortBy:           'created',
+  currentClusterId: null,
+
+  headers: [
+    {
+      name:           'target',
+      translationKey: 'backupsPage.table.target.label',
+      width:          80,
+    },
+    {
+      name:           'name',
+      sort:           ['name', 'id'],
+      translationKey: 'backupsPage.table.name',
+    },
+    {
+      classNames:     'text-right pr-20',
+      name:           'created',
+      sort:           ['created', 'name', 'id'],
+      translationKey: 'backupsPage.table.created',
+    },
+  ],
+
+  rows:    computed('model.[]', function() {
+    let { currentClusterId } = this;
+
+    return get(this, 'model').filterBy('clusterId', currentClusterId);
+  }),
+});

--- a/app/authenticated/cluster/backups/route.js
+++ b/app/authenticated/cluster/backups/route.js
@@ -1,0 +1,25 @@
+import { get, set, observer } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
+import { alias } from '@ember/object/computed';
+
+export default Route.extend({
+  scope:          service(),
+  globalStore:    service(),
+  currentCluster: alias('scope.currentCluster'),
+
+  model() {
+    return this.globalStore.findAll('etcdbackup');
+  },
+
+  setupController(controller, model) {
+
+    let { currentCluster } = this;
+
+    let clusterId = currentCluster.id;
+
+    controller.set('currentClusterId', clusterId);
+
+    this._super(controller, model);
+  }
+});

--- a/app/authenticated/cluster/backups/template.hbs
+++ b/app/authenticated/cluster/backups/template.hbs
@@ -1,0 +1,47 @@
+<section class="header clearfix">
+  <h1>{{t "backupsPage.header"}}</h1>
+</section>
+
+<section>
+  {{#sortable-table
+     tableClassNames="bordered mt-30"
+     bulkActions=false
+     descending=descending
+     paging=false
+     search=false
+     sortBy=sortBy
+     headers=headers
+     body=rows
+     as |sortable kind backup dt|
+  }}
+    {{#if (eq kind "row")}}
+      <tr class="main-row">
+        <td data-title="{{dt.target}}">
+          {{#if backup.backupConfig.s3BackupConfig }}
+            {{t "backupsPage.table.target.s3"}}
+          {{else}}
+            {{t "backupsPage.table.target.local"}}
+          {{/if}}
+        </td>
+        <td class="force-wrap" data-title="{{dt.name}}">
+          {{backup.displayName}}
+        </td>
+        <td data-title="{{dt.created}}" class="text-right pr-20">
+          {{date-from-now backup.created}}
+        </td>
+        <td data-title="{{dt.actions}}" class="actions">
+          {{action-menu model=backup}}
+        </td>
+      </tr>
+    {{else if (eq kind "norows")}}
+      <tr>
+        <td
+          colspan="{{sortable.fullColspan}}"
+          class="text-center text-muted pt-20 pb-20"
+        >
+          {{t "backupsPage.table.noData"}}
+        </td>
+      </tr>
+    {{/if}}
+  {{/sortable-table}}
+</section>

--- a/app/authenticated/cluster/route.js
+++ b/app/authenticated/cluster/route.js
@@ -41,6 +41,10 @@ export default Route.extend(Preload, {
       .catch((err) => this.loadingError(err, transition));
   },
 
+  afterModel(model) {
+    return get(this, 'scope').finishSwitchToCluster(model);
+  },
+
   redirect(router, transition) {
     let route = this.get(`session.${ C.SESSION.CLUSTER_ROUTE }`);
 
@@ -48,11 +52,6 @@ export default Route.extend(Preload, {
       this.replaceWith(route);
     }
   },
-  setupController(controller, model) {
-    this._super(...arguments);
-    get(this, 'scope').finishSwitchToCluster(model);
-  },
-
   actions: {
     becameReady() {
       get(this, 'clusterStore').reset();

--- a/app/authenticated/route.js
+++ b/app/authenticated/route.js
@@ -135,9 +135,8 @@ export default Route.extend(Preload, {
       .catch((err) => this.loadingError(err, transition));
   },
 
-  setupController(/* controller, model*/) {
-    this._super(...arguments);
-    get(this, 'scope').finishSwitchToGlobal();
+  afterModel() {
+    return get(this, 'scope').finishSwitchToGlobal();
   },
 
   activate() {

--- a/app/components/modal-restore-backup/component.js
+++ b/app/components/modal-restore-backup/component.js
@@ -1,0 +1,66 @@
+import { inject as service } from '@ember/service';
+import { get, set, setProperties } from '@ember/object';
+import Component from '@ember/component';
+import ModalBase from 'shared/mixins/modal-base';
+import layout from './template';
+import { alias } from '@ember/object/computed';
+import moment from 'moment';
+
+export default Component.extend(ModalBase, {
+  intl:             service(),
+  growl:            service(),
+
+  layout,
+  classNames:       ['large-modal'],
+  backupId:         null,
+  availableBackups: null,
+
+  init() {
+    this._super(...arguments);
+
+    setProperties(this, {
+      backupId: '',
+      errors:   [],
+    });
+  },
+
+  didReceiveAttrs() {
+    const etcdBackUps = get(this, 'modalOpts.cluster.etcdbackups');
+    const out         = [];
+
+    etcdBackUps.forEach((backup) => {
+      let time = moment(get(backup, 'created'));
+
+      out.pushObject({
+        id:      backup.id,
+        label:   `${ backup.displayName } ( ${ time.format('MMMM Do YYYY, H:mm:ss') })`,
+        created: backup.created,
+      });
+    });
+
+    set(this, 'availableBackups', out.sortBy('created'));
+  },
+
+  actions: {
+    restore(cb) {
+      const { backupId } = this;
+      const out = {};
+
+      if (backupId) {
+        set(out, 'etcdBackupId', backupId);
+        this.modalOpts.cluster.doAction('restoreFromEtcdBackup', out).then(() => {
+          this.send('cancel');
+        })
+          .catch((err) => {
+            this.growl.fromError(err);
+
+            if (cb) {
+              cb(false);
+            }
+          });
+      } else {
+        this.growl.fromError(this.intl.t('modalRestoreBackup.error'));
+      }
+    }
+  },
+});

--- a/app/components/modal-restore-backup/template.hbs
+++ b/app/components/modal-restore-backup/template.hbs
@@ -1,0 +1,46 @@
+<div class="container-header-text">
+  <h3>{{t "modalRestoreBackup.title"}}</h3>
+  <hr/>
+</div>
+
+<section class="p-20 pt-0">
+  <div class="row">
+    <div class="col span-6">
+      <label
+        class="acc-label"
+        for="available-backups"
+      >
+        {{t "modalRestoreBackup.backups"}}{{field-required}}
+      </label>
+      <select
+        id="available-backups"
+        class="form-control"
+        onchange={{action (mut backupId) value="target.value"}}
+      >
+        {{#unless (eq backupId value)}}
+          <option
+            value=""
+            selected=true
+          >
+            {{t "modalRestoreBackup.select.all"}}
+          </option>
+        {{/unless}}
+        {{#each availableBackups as |backup|}}
+          <option
+            value={{backup.id}}
+            selected={{eq backup.id value}}
+          >
+            {{backup.label}}
+          </option>
+        {{/each}}
+      </select>
+    </div>
+  </div>
+</section>
+
+{{save-cancel
+  editing=true
+  save="restore"
+  saveDisabled=(not backupId)
+  cancel="cancel"
+}}

--- a/app/components/modal-rotate-certificates/component.js
+++ b/app/components/modal-rotate-certificates/component.js
@@ -42,7 +42,7 @@ export default Component.extend(ModalBase, {
           if (cb) {
             cb(false);
           }
-        })
+        });
     },
 
     mutServices(select) {

--- a/app/instance-initializers/nav.js
+++ b/app/instance-initializers/nav.js
@@ -235,6 +235,17 @@ const rootNav = [
         ctx:            [getClusterId],
       },
       {
+        id:             'cluster-tools-backups',
+        localizedLabel: 'nav.tools.backups',
+        route:          'authenticated.cluster.backups',
+        resourceScope:  'global',
+        resource:       ['etcdbackup'],
+        ctx:            [getClusterId],
+        condition() {
+          return get(this, 'cluster.rancherKubernetesEngineConfig')
+        }
+      },
+      {
         id:             'cluster-tools-notifiers',
         localizedLabel: 'nav.tools.notifiers',
         route:          'authenticated.cluster.notifier',

--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -19,6 +19,7 @@ export default Resource.extend(Grafana, ResourceUsage, {
   nodes:                       hasMany('id', 'node', 'clusterId'),
   nodePools:                   hasMany('id', 'nodePool', 'clusterId'),
   clusterRoleTemplateBindings: hasMany('id', 'clusterRoleTemplateBinding', 'clusterId'),
+  etcdbackups:                 hasMany('id', 'etcdbackup', 'clusterId'),
   grafanaDashboardName:        'Cluster',
   machines:                    alias('nodes'),
   roleTemplateBindings:        alias('clusterRoleTemplateBindings'),
@@ -181,10 +182,30 @@ export default Resource.extend(Grafana, ResourceUsage, {
         action:    'rotateCertificates',
         enabled:   !!a.rotateCertificates,
       },
+      {
+        label:     'action.backupEtcd',
+        icon:      'icon icon-history',
+        action:    'backupEtcd',
+        enabled:   !!a.backupEtcd,
+      },
+      {
+        label:     'action.restoreFromEtcdBackup',
+        icon:      'icon icon-history',
+        action:    'restoreFromEtcdBackup',
+        enabled:   !!a.restoreFromEtcdBackup,
+      },
     ];
   }),
 
   actions: {
+    backupEtcd() {
+      this.doAction('backupEtcd');
+    },
+
+    restoreFromEtcdBackup() {
+      get(this, 'modalService').toggleModal('modal-restore-backup', { cluster: this, });
+    },
+
     promptDelete() {
       const hasSessionToken = get(this, 'canBulkRemove') ? false : true; // canBulkRemove returns true of the session token is set false
 

--- a/app/router.js
+++ b/app/router.js
@@ -57,6 +57,10 @@ Router.map(function() {
       this.route('edit');
       this.route('cluster-catalogs', { path: '/catalogs' })
 
+      this.route('backups', function() {
+        this.route('index', { path: '/' });
+      });
+
       this.route('nodes', function() {
         this.route('index', { path: '/' });
       });

--- a/lib/global-admin/addon/clusters/route.js
+++ b/lib/global-admin/addon/clusters/route.js
@@ -7,8 +7,16 @@ export default Route.extend({
   model() {
     const store = this.get('globalStore');
 
-    return store.findAll('cluster').then(() => {
-      return { clusters: store.all('cluster'), };
+    return store.findAll('cluster').then((/* resp */) => {
+      const clusters = store.all('cluster');
+
+      if (clusters.length > 0) {
+        clusters.forEach((cluster) => {
+          cluster.store.findAll('etcdbackup');
+        });
+      }
+
+      return { clusters };
     });
   },
 });

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -19,6 +19,7 @@ import { isEmpty } from '@ember/utils';
 import InputTextFile from 'ui/components/input-text-file/component';
 import { scheduleOnce } from '@ember/runloop';
 import { azure as AzureInfo } from 'shared/components/cru-cloud-provider/cloud-provider-info';
+import moment from 'moment';
 
 const EXCLUDED_KEYS = ['extra_args'];
 
@@ -76,6 +77,8 @@ const INGRESSCHOICES = [
   },
 ];
 
+const AVAILABLE_STRATEGIES = ['local', 's3'];
+
 export default InputTextFile.extend(ClusterDriver, {
   globalStore:          service(),
   settings:             service(),
@@ -86,10 +89,12 @@ export default InputTextFile.extend(ClusterDriver, {
   networkContent:       NETWORKCHOICES,
   authChoices:          AUTHCHOICES,
   ingressChoices:       INGRESSCHOICES,
+  availableStrategies:  AVAILABLE_STRATEGIES,
 
   configField:          'rancherKubernetesEngineConfig',
   registry:             'default',
   accept:               '.yml, .yaml',
+  backupStrategy:       'local',
   loading:              false,
   pasteOrUpload:        false,
   model:                null,
@@ -125,42 +130,24 @@ export default InputTextFile.extend(ClusterDriver, {
   init() {
     this._super();
 
-    const globalStore = get(this, 'globalStore');
-    const counts = {};
+    this.initNodeCounts();
 
-    set(this, 'existingNodes', globalStore.all('node'));
+    if ( get(this, 'isNew') ) {
+      this.createRkeConfigWithDefaults();
+    } else {
+      this.initPrivateRegistries();
 
-    globalStore.findAll('node').then((all) => {
-      all.forEach((node) => {
-        const id = get(node, 'clusterId');
+      const etcd = get(this, 'cluster.rancherKubernetesEngineConfig.services.etcd');
 
-        counts[id] = (counts[id] || 0) + 1;
-      });
-
-      this.notifyPropertyChange('initialNodeCounts');
-    });
-
-    set(this, 'initialNodeCounts', counts);
-
-    set(this, 'initialVersion', get(this, 'cluster.rancherKubernetesEngineConfig.kubernetesVersion'));
-
-    const config = get(this, 'cluster.rancherKubernetesEngineConfig');
-
-    if ( config && get(config, 'privateRegistries.length') > 0 ) {
-      const registry = get(config, 'privateRegistries.firstObject');
-
-      setProperties(this, {
-        registry:     'custom',
-        registryUrl:  get(registry, 'url'),
-        registryUser: get(registry, 'user'),
-        registryPass: get(registry, 'password'),
-      });
+      if (etcd && etcd.snapshot) {
+        this.migrateLegacyEtcdSnapshotSettings();
+      }
     }
 
-    this.driverDidChange();
+    this.setFlannelLables();
 
     scheduleOnce('afterRender', () => {
-      let defaultCluster = globalStore.createRecord({ type: 'cluster' })
+      let defaultCluster = this.globalStore.createRecord({ type: 'cluster' })
 
       set(this, 'defaultDockerRootDir', defaultCluster.dockerRootDir)
 
@@ -217,65 +204,8 @@ export default InputTextFile.extend(ClusterDriver, {
   }),
 
   driverDidChange: observer('nodeWhich', function() {
-    if ( get(this, 'isNew') ) {
-      const globalStore    = get(this, 'globalStore');
-      const versions       = get(this, 'versionChoices');
-      const defaultVersion = get(this, `settings.${ C.SETTING.VERSION_SYSTEM_K8S_DEFAULT_RANGE }`);
-      const satisfying     = maxSatisfying(versions, defaultVersion);
-
-      const rkeConfig = globalStore.createRecord({
-        type:                'rancherKubernetesEngineConfig',
-        ignoreDockerVersion: true,
-        kubernetesVersion:   satisfying,
-        authentication:      globalStore.createRecord({
-          type:     'authnConfig',
-          strategy: 'x509',
-        }),
-        network: globalStore.createRecord({
-          type:    'networkConfig',
-          plugin:  'canal',
-          options: { flannelBackendType: DEFAULT_BACKEND_TYPE, },
-        }),
-        ingress: globalStore.createRecord({
-          type:     'ingressConfig',
-          provider: 'nginx',
-        }),
-        monitoring: globalStore.createRecord({
-          type:     'monitoringConfig',
-          provider: 'metrics-server',
-        }),
-        services: globalStore.createRecord({
-          type:    'rkeConfigServices',
-          kubeApi: globalStore.createRecord({
-            type:                  'kubeAPIService',
-            podSecurityPolicy:     false,
-            serviceNodePortRange: '30000-32767',
-          }),
-          etcd: globalStore.createRecord({
-            type:      'etcdService',
-            extraArgs: {
-              'heartbeat-interval': 500,
-              'election-timeout':   5000
-            },
-          }),
-        }),
-      });
-
-
-      scheduleOnce('afterRender', () => {
-        set(this, 'cluster.rancherKubernetesEngineConfig', rkeConfig);
-        set(this, 'cluster.enableNetworkPolicy', false);
-      });
-    }
-
-    let { networkContent } = this;
-    let flannel = networkContent.findBy('value', 'flannel');
-
-    if (get(this, 'isCustom')) {
-      set(flannel, 'label', 'clusterNew.rke.network.flannelCustom');
-    } else {
-      set(flannel, 'label', 'clusterNew.rke.network.flannel');
-    }
+    this.createRkeConfigWithDefaults();
+    this.setFlannelLables();
   }),
 
   windowsSupportChange: observer('windowsSupport', function() {
@@ -303,6 +233,38 @@ export default InputTextFile.extend(ClusterDriver, {
         worker:       true,
       })
     }
+  }),
+
+  strategyChanged: observer('backupStrategy', function() {
+    const { backupStrategy, globalStore } = this;
+    const services = this.cluster.rancherKubernetesEngineConfig.services.clone();
+
+    switch (backupStrategy) {
+    case 'local':
+      if (services) {
+        setProperties(services.etcd, {
+          backupConfig: globalStore.createRecord({
+            type:           'backupConfig',
+            s3BackupConfig: null,
+          })
+        });
+      }
+      break;
+    case 's3':
+      if (services) {
+        setProperties(services.etcd, {
+          backupConfig: globalStore.createRecord({
+            type:           'backupConfig',
+            s3BackupConfig: globalStore.createRecord({ type: 's3BackupConfig' })
+          })
+        });
+      }
+      break;
+    default:
+      break;
+    }
+
+    set(this, 'cluster.rancherKubernetesEngineConfig.services', services);
   }),
 
   kubeApiPodSecurityPolicy: computed('config.services.kubeApi.podSecurityPolicy', {
@@ -582,7 +544,7 @@ export default InputTextFile.extend(ClusterDriver, {
     this._super(...arguments);
 
     let errors = get(this, 'errors') || [];
-    let config = get(this, `primaryResource.${ this.configField }`);
+    let config = get(this, `cluster.rancherKubernetesEngineConfig`);
 
     if ( !get(this, 'isCustom') ) {
       errors.pushObjects(get(this, 'nodePoolErrors'));
@@ -601,6 +563,7 @@ export default InputTextFile.extend(ClusterDriver, {
       }
     }
 
+    // TODO - refactor this, we no longer need the extra validation on the times
     if (get(this, 'cluster.rancherKubernetesEngineConfig.services.etcd.snapshot')) {
       errors = this.validateEtcdService(errors);
     }
@@ -797,6 +760,122 @@ export default InputTextFile.extend(ClusterDriver, {
     });
 
     return out;
+  },
+
+  initNodeCounts() {
+    const counts = {};
+
+    set(this, 'existingNodes', this.globalStore.all('node'));
+
+    this.globalStore.findAll('node').then((all) => {
+      all.forEach((node) => {
+        const id = get(node, 'clusterId');
+
+        counts[id] = (counts[id] || 0) + 1;
+      });
+
+      this.notifyPropertyChange('initialNodeCounts');
+    });
+
+    setProperties(this, {
+      initialNodeCounts: counts,
+      initialVersion:    get(this, 'cluster.rancherKubernetesEngineConfig.kubernetesVersion')
+    })
+  },
+
+  initPrivateRegistries() {
+    const config = get(this, 'cluster.rancherKubernetesEngineConfig');
+
+    if ( get(config, 'privateRegistries.length') > 0 ) {
+      const registry = get(config, 'privateRegistries.firstObject');
+
+      setProperties(this, {
+        registry:     'custom',
+        registryUrl:  get(registry, 'url'),
+        registryUser: get(registry, 'user'),
+        registryPass: get(registry, 'password'),
+      });
+    }
+  },
+
+  createRkeConfigWithDefaults() {
+    const { globalStore, versionChoices, } = this;
+    const defaultVersion                   = get(this, `settings.${ C.SETTING.VERSION_SYSTEM_K8S_DEFAULT_RANGE }`);
+    const satisfying                       = maxSatisfying(versionChoices, defaultVersion);
+
+    const rkeConfig = globalStore.createRecord({
+      type:                'rancherKubernetesEngineConfig',
+      ignoreDockerVersion: true,
+      kubernetesVersion:   satisfying,
+      authentication:      globalStore.createRecord({
+        type:     'authnConfig',
+        strategy: 'x509',
+      }),
+      network: globalStore.createRecord({
+        type:    'networkConfig',
+        plugin:  'canal',
+        options: { flannelBackendType: DEFAULT_BACKEND_TYPE, },
+      }),
+      ingress: globalStore.createRecord({
+        type:     'ingressConfig',
+        provider: 'nginx',
+      }),
+      monitoring: globalStore.createRecord({
+        type:     'monitoringConfig',
+        provider: 'metrics-server',
+      }),
+      services: globalStore.createRecord({
+        type:    'rkeConfigServices',
+        kubeApi: globalStore.createRecord({
+          type:                  'kubeAPIService',
+          podSecurityPolicy:     false,
+          serviceNodePortRange: '30000-32767',
+        }),
+        etcd: globalStore.createRecord({
+          type:         'etcdService',
+          backupConfig: globalStore.createRecord({ type: 'backupConfig' }),
+          extraArgs:    {
+            'heartbeat-interval': 500,
+            'election-timeout':   5000
+          },
+        }),
+      }),
+    });
+
+
+    scheduleOnce('afterRender', () => {
+      setProperties(this.cluster, {
+        rancherKubernetesEngineConfig: rkeConfig,
+        enableNetworkPolicy:           false
+      });
+    });
+  },
+
+  setFlannelLables() {
+    let flannel = this.networkContent.findBy('value', 'flannel');
+
+    if (get(this, 'isCustom')) {
+      set(flannel, 'label', 'clusterNew.rke.network.flannelCustom');
+    } else {
+      set(flannel, 'label', 'clusterNew.rke.network.flannel');
+    }
+  },
+
+  migrateLegacyEtcdSnapshotSettings() {
+    const { cluster } = this;
+    const { retention, creation } = cluster.rancherKubernetesEngineConfig.services.etcd;
+
+    const parsedDurationAsHours = moment.duration(creation).hours();
+
+    setProperties(this, {
+      legacyRetention:                                                                  retention,
+      hasLegacySnapshotSettings:                                                        true,
+    });
+
+    setProperties(cluster.rancherKubernetesEngineConfig.services.etcd, {
+      'backupConfig.intervalHours': parsedDurationAsHours,
+      snapshot:                     false,
+    });
   },
 
 });

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -1,11 +1,11 @@
 {{#unless isCustom}}
   {{cru-node-pools
-      mode=mode
-      cluster=cluster
-      driver=nodeWhich
-      nodeTemplates=model.nodeTemplates
-      registerHook=(action "registerHook")
-      setNodePoolErrors=(action "setNodePoolErrors")
+    mode=mode
+    cluster=cluster
+    driver=nodeWhich
+    nodeTemplates=model.nodeTemplates
+    registerHook=(action "registerHook")
+    setNodePoolErrors=(action "setNodePoolErrors")
   }}
 {{/unless}}
 
@@ -25,8 +25,8 @@
 
 {{#if (or isEdit (eq step 1))}}
   {{#accordion-list
-       showExpandAll=false
-       as |al expandFn|
+     showExpandAll=false
+     as |al expandFn|
   }}
     {{#if pasteOrUpload}}
       <div class="accordion">
@@ -46,37 +46,37 @@
           </div>
           <div class="mt-25">
             {{input-yaml
-                showDownload=false
-                canChangeName=false
-                autoResize=true
-                value=value
+              showDownload=false
+              canChangeName=false
+              autoResize=true
+              value=value
             }}
           </div>
           {{copy-to-clipboard
-              tooltipText=""
-              buttonText="copyToClipboard.tooltip"
-              clipboardText=value
-              class="with-clip"
+            tooltipText=""
+            buttonText="copyToClipboard.tooltip"
+            clipboardText=value
+            class="with-clip"
           }}
         </div>
       </div>
     {{else}}
       {{#accordion-list-item
-           title=(t "clusterNew.rke.customize.label")
-           detail=(t "clusterNew.rke.customize.detail")
-           expandOnInit=true
-           expandAll=al.expandAll
-           expand=(action expandFn)
+         title=(t "clusterNew.rke.customize.label")
+         detail=(t "clusterNew.rke.customize.detail")
+         expandOnInit=true
+         expandAll=al.expandAll
+         expand=(action expandFn)
       }}
         <div class="row">
           <div class="col span-6">
             <label class="acc-label">{{t "clusterNew.rke.version.label"}}</label>
             {{form-versions
-                cluster=cluster
-                editing=(eq mode "edit")
-                initialVersion=initialVersion
-                value=config.kubernetesVersion
-                versions=versionChoices
+              cluster=cluster
+              editing=(eq mode "edit")
+              initialVersion=initialVersion
+              value=config.kubernetesVersion
+              versions=versionChoices
             }}
           </div>
         </div>
@@ -84,11 +84,11 @@
           <div class="col {{if (and isCustom (eq mode "new")) "span-4" "span-6"}}">
             <label class="acc-label">{{t "clusterNew.rke.network.label"}}</label>
             {{new-select
-                classNames="form-control"
-                content=networkContent
-                localizedLabel=true
-                value=cluster.rancherKubernetesEngineConfig.network.plugin
-                disabled=isEdit
+              classNames="form-control"
+              content=networkContent
+              localizedLabel=true
+              value=cluster.rancherKubernetesEngineConfig.network.plugin
+              disabled=isEdit
             }}
           </div>
           {{#if (and isCustom (eq mode "new"))}}
@@ -97,9 +97,9 @@
               <div class="radio">
                 <label class={{if (not-eq cluster.rancherKubernetesEngineConfig.network.plugin "flannel") "text-muted"}}>
                   {{radio-button
-                      selection=windowsSupport
-                      value=true
-                      disabled=(not-eq cluster.rancherKubernetesEngineConfig.network.plugin "flannel")
+                    selection=windowsSupport
+                    value=true
+                    disabled=(not-eq cluster.rancherKubernetesEngineConfig.network.plugin "flannel")
                   }}
                   {{t "generic.enabled"}}
                 </label>
@@ -107,9 +107,9 @@
               <div class="radio">
                 <label class={{if (not-eq cluster.rancherKubernetesEngineConfig.network.plugin "flannel") "text-muted"}}>
                   {{radio-button
-                      selection=windowsSupport
-                      value=false
-                      disabled=(not-eq cluster.rancherKubernetesEngineConfig.network.plugin "flannel")
+                    selection=windowsSupport
+                    value=false
+                    disabled=(not-eq cluster.rancherKubernetesEngineConfig.network.plugin "flannel")
                   }}
                   {{t "generic.disabled"}}
                 </label>
@@ -121,9 +121,9 @@
             <div class="radio">
               <label class={{unless (eq cluster.rancherKubernetesEngineConfig.network.plugin "canal")  "text-muted"}}>
                 {{radio-button
-                    selection=cluster.enableNetworkPolicy
-                    value=true
-                    disabled=(not-eq cluster.rancherKubernetesEngineConfig.network.plugin "canal")
+                  selection=cluster.enableNetworkPolicy
+                  value=true
+                  disabled=(not-eq cluster.rancherKubernetesEngineConfig.network.plugin "canal")
                 }}
                 {{t "generic.enabled"}}
               </label>
@@ -131,9 +131,9 @@
             <div class="radio">
               <label class={{unless (eq cluster.rancherKubernetesEngineConfig.network.plugin "canal")  "text-muted"}}>
                 {{radio-button
-                    selection=cluster.enableNetworkPolicy
-                    value=false
-                    disabled=(not-eq cluster.rancherKubernetesEngineConfig.network.plugin "canal")
+                  selection=cluster.enableNetworkPolicy
+                  value=false
+                  disabled=(not-eq cluster.rancherKubernetesEngineConfig.network.plugin "canal")
                 }}
                 {{t "generic.disabled"}}
               </label>
@@ -143,111 +143,117 @@
         <div class="row">
           <div class="col span-12">
             {{cru-cloud-provider
-                cluster=model.cluster
-                driver=nodeWhich
+              cluster=model.cluster
+              driver=nodeWhich
             }}
           </div>
         </div>
       {{/accordion-list-item}}
 
+      {{#if hasLegacySnapshotSettings}}
+        {{#banner-message color="bg-warning m-0"}}
+          <p>{{t "clusterNew.rke.etcd.backupConfig.legacy" duration=legacyRetention}}</p>
+        {{/banner-message}}
+      {{/if}}
+
       {{#advanced-section advanced=advanced}}
         {{#accordion-list-item
-             title=(t "cruPrivateRegistry.title.label")
-             detail=(t "cruPrivateRegistry.title.detail")
-             expandOnInit=(eq mode "edit" true false)
-             expandAll=al.expandAll
-             expand=(action expandFn)
+           title=(t "cruPrivateRegistry.title.label")
+           detail=(t "cruPrivateRegistry.title.detail")
+           expandOnInit=(eq mode "edit" true false)
+           expandAll=al.expandAll
+           expand=(action expandFn)
         }}
           {{cru-private-registry
-              cluster=cluster
+            cluster=cluster
           }}
         {{/accordion-list-item}}
 
 
         {{#accordion-list-item
-             title=(t "clusterNew.rke.advanced.label")
-             detail=(t "clusterNew.rke.advanced.detail")
-             expandOnInit=(eq mode "edit" true false)
-             expandAll=al.expandAll
-             expand=(action expandFn)
+           title=(t "clusterNew.rke.advanced.label")
+           detail=(t "clusterNew.rke.advanced.detail")
+           expandOnInit=(eq mode "edit" true false)
+           expandAll=al.expandAll
+           expand=(action expandFn)
         }}
-        <div class="row">
-          <div class="col span-4">
-            <label class="acc-label">{{t "clusterNew.rke.ingress.label"}}</label>
-            <div class="radio">
-              <label>
-                {{!--
+          <div class="row">
+            <div class="col span-4">
+              <label class="acc-label">{{t "clusterNew.rke.ingress.label"}}</label>
+              <div class="radio">
+                <label>
+                  {{!--
                     {{radio-button selection=nginxIngressProvider value="nginx"}}
                     --}}
-                {{radio-button
+                  {{radio-button
                     selection=cluster.rancherKubernetesEngineConfig.ingress.provider
                     value="nginx"
-                }}
-                {{t "generic.enabled"}}
-              </label>
-            </div>
-            <div class="radio">
-              <label>
-                {{!--
+                  }}
+                  {{t "generic.enabled"}}
+                </label>
+              </div>
+              <div class="radio">
+                <label>
+                  {{!--
                     {{radio-button selection=nginxIngressProvider value=null}}
                     --}}
-                {{radio-button
+                  {{radio-button
                     selection=cluster.rancherKubernetesEngineConfig.ingress.provider
                     value="none"
-                }}
-                {{t "generic.disabled"}}
-              </label>
+                  }}
+                  {{t "generic.disabled"}}
+                </label>
+              </div>
             </div>
-          </div>
-          <div class="col span-4">
-            <label class="acc-label">{{t "clusterNew.rke.serviceNodePortRange.label"}}</label>
-            {{input
+            <div class="col span-4">
+              <label class="acc-label">{{t "clusterNew.rke.serviceNodePortRange.label"}}</label>
+              {{input
                 type="text"
                 value=cluster.rancherKubernetesEngineConfig.services.kubeApi.serviceNodePortRange
                 className="form-control"
                 placeholder=(t "clusterNew.rke.serviceNodePortRange.placeholder")
-            }}
-          </div>
-          <div class="col span-4">
-            <label class="acc-label">{{t "clusterNew.rke.monitoring.label"}}</label>
-            <div class="radio">
-              <label>
-                {{!--
-                      {{radio-button selection=monitoringProvider value="metrics-server"}}
-                      --}}
-                {{radio-button
+              }}
+            </div>
+            <div class="col span-4">
+              <label class="acc-label">{{t "clusterNew.rke.monitoring.label"}}</label>
+              <div class="radio">
+                <label>
+                  {{!--
+                    {{radio-button selection=monitoringProvider value="metrics-server"}}
+                    --}}
+                  {{radio-button
                     selection=cluster.rancherKubernetesEngineConfig.monitoring.provider
                     value="metrics-server"
-                }}
-                {{t "generic.enabled"}}
-              </label>
-            </div>
-            <div class="radio">
-              <label>
-                {{!--
-                      {{radio-button selection=monitoringProvider value=null}}
-                      --}}
-                {{radio-button
+                  }}
+                  {{t "generic.enabled"}}
+                </label>
+              </div>
+              <div class="radio">
+                <label>
+                  {{!--
+                    {{radio-button selection=monitoringProvider value=null}}
+                    --}}
+                  {{radio-button
                     selection=cluster.rancherKubernetesEngineConfig.monitoring.provider
                     value="none"
-                }}
-                {{t "generic.disabled"}}
-              </label>
+                  }}
+                  {{t "generic.disabled"}}
+                </label>
+              </div>
             </div>
           </div>
-        </div>
           <div class="row">
             <div class="col span-4">
               <label class="acc-label">{{t "clusterNew.rke.podSecurityPolicy.label"}}</label>
               <div class="radio">
                 <label class={{unless model.psps.length "text-muted"}}>
                   {{!--
-                  {{radio-button selection=kubeApiPodSecurityPolicy value=true disabled=(not model.psps.length)}}
-                  --}}
+                    {{radio-button selection=kubeApiPodSecurityPolicy value=true disabled=(not model.psps.length)}}
+                    --}}
                   {{radio-button
-                      selection=cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy
-                      value=true
-                      disabled=(not model.psps.length)
+                    selection=cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy
+                    value=true
+                    disabled=(not model.psps.length)
                   }}
                   {{t "generic.enabled"}}
                   {{#unless model.psps.length}}
@@ -258,12 +264,12 @@
               <div class="radio">
                 <label>
                   {{!--
-                  {{radio-button selection=kubeApiPodSecurityPolicy value=false disabled=(not model.psps.length)}}
-                  --}}
+                    {{radio-button selection=kubeApiPodSecurityPolicy value=false disabled=(not model.psps.length)}}
+                    --}}
                   {{radio-button
-                      selection=cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy
-                      value=false
-                      disabled=(not model.psps.length)
+                    selection=cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy
+                    value=false
+                    disabled=(not model.psps.length)
                   }}
                   {{t "generic.disabled"}}
                 </label>
@@ -273,13 +279,13 @@
               {{#if cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy}}
                 <label class="acc-label">{{t "clusterNew.psp.label"}}{{field-required}}</label>
                 {{new-select
-                    content=model.psps
-                    optionLabelPath="displayName"
-                    optionValuePath="id"
-                    prompt="clusterNew.psp.prompt"
-                    localizedPrompt=true
-                    value=cluster.defaultPodSecurityPolicyTemplateId
-                    disabled=(not cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy)
+                  content=model.psps
+                  optionLabelPath="displayName"
+                  optionValuePath="id"
+                  prompt="clusterNew.psp.prompt"
+                  localizedPrompt=true
+                  value=cluster.defaultPodSecurityPolicyTemplateId
+                  disabled=(not cluster.rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy)
                 }}
               {{else}}
                 <label class="acc-label">{{t "clusterNew.psp.label"}}</label>
@@ -293,8 +299,8 @@
               <div class="radio">
                 <label>
                   {{radio-button
-                      selection=cluster.rancherKubernetesEngineConfig.ignoreDockerVersion
-                      value=false
+                    selection=cluster.rancherKubernetesEngineConfig.ignoreDockerVersion
+                    value=false
                   }}
                   {{t "clusterNew.rke.ignoreDockerVersion.disabled"}}
                 </label>
@@ -302,8 +308,8 @@
               <div class="radio">
                 <label>
                   {{radio-button
-                      selection=cluster.rancherKubernetesEngineConfig.ignoreDockerVersion
-                      value=true
+                    selection=cluster.rancherKubernetesEngineConfig.ignoreDockerVersion
+                    value=true
                   }}
                   {{t "clusterNew.rke.ignoreDockerVersion.enabled"}}
                 </label>
@@ -313,63 +319,118 @@
             <div class="col span-4">
               <label class="acc-label">{{t "loggingPage.dockerRootDir.label"}}</label>
               {{input
-                  type="text"
-                  value=model.cluster.dockerRootDir
-                  className="form-control"
-                  placeholder=(t "clusterNew.rke.dockerRootDir.placeholder" dir=defaultDockerRootDir)
+                type="text"
+                value=model.cluster.dockerRootDir
+                className="form-control"
+                placeholder=(t "clusterNew.rke.dockerRootDir.placeholder" dir=defaultDockerRootDir)
               }}
             </div>
 
           </div>
           <div class="row">
             <div class="col span-3">
-              <label class="acc-label">{{t "clusterNew.rke.etcd.snapshot.label"}}</label>
-              <div class="radio">
-                <label>
-                  {{radio-button
-                      selection=cluster.rancherKubernetesEngineConfig.services.etcd.snapshot
-                      value=false
-                  }}
-                  {{t "generic.disabled"}}
-                </label>
-              </div>
-              <div class="radio">
-                <label>
-                  {{radio-button
-                      selection=cluster.rancherKubernetesEngineConfig.services.etcd.snapshot
-                      value=true
-                  }}
-                  {{t "generic.enabled"}}
-                </label>
-              </div>
-            </div>
-            <div class="col span-3 offset-1">
-              <label class="acc-label">{{t "clusterNew.rke.etcd.creation.label"}}</label>
-              <div class="input-group">
-                {{input
-                    type="text"
-                    classNames="form-control"
-                    disabled=(not cluster.rancherKubernetesEngineConfig.services.etcd.snapshot)
-                    placeholder=(t "clusterNew.rke.etcd.creation.placeholder")
-                    value=cluster.rancherKubernetesEngineConfig.services.etcd.creation
-                }}
-                <p class="help-block">{{t "clusterNew.rke.etcd.retention.help"}}</p>
-              </div>
-            </div>
-            <div class="col span-3 offset-1">
-              <label class="acc-label">{{t "clusterNew.rke.etcd.retention.label"}}</label>
-              <div class="input-group">
-                {{input
-                    type="text"
-                    classNames="form-control"
-                    disabled=(not cluster.rancherKubernetesEngineConfig.services.etcd.snapshot)
-                    placeholder=(t "clusterNew.rke.etcd.retention.placeholder")
-                    value=cluster.rancherKubernetesEngineConfig.services.etcd.retention
-                }}
-                <p class="help-block">{{t "clusterNew.rke.etcd.retention.help"}}</p>
-              </div>
+              <label class="acc-label">{{t "clusterNew.rke.etcd.location.label"}}</label>
+              <select
+                class="form-control"
+                onchange={{action (mut backupStrategy) value="target.value" }}
+              >
+                {{#each availableStrategies as |choice|}}
+                  <option
+                    value={{choice}}
+                    selected={{eq backupStrategy choice}}
+                  >
+                    {{choice}}
+                  </option>
+                {{/each}}
+              </select>
             </div>
           </div>
+
+          <div class="row">
+            <div class="col span-3">
+              <label class="acc-label">{{t "clusterNew.rke.etcd.backupConfig.interval.label"}}</label>
+              <div class="input-group">
+                {{input-integer
+                  value=cluster.rancherKubernetesEngineConfig.services.etcd.backupConfig.intervalHours
+                  min=1
+                  classNames="form-control"
+                  placeholder=(t "clusterNew.rke.etcd.backupConfig.interval.placeholder")
+                }}
+                <span class="input-group-addon bg-default">{{t "generic.hours"}}</span>
+              </div>
+            </div>
+
+            <div class="col span-3 offset-1">
+              <label class="acc-label">{{t "clusterNew.rke.etcd.backupConfig.retention.label"}}</label>
+              {{input-integer
+                value=cluster.rancherKubernetesEngineConfig.services.etcd.backupConfig.retention
+                min=1
+                classNames="form-control"
+                placeholder=(t "clusterNew.rke.etcd.backupConfig.retention.placeholder")
+              }}
+            </div>
+          </div>
+
+          {{#unless (eq backupStrategy "local")}}
+
+            <div class="row">
+              <div class="col span-3">
+                <label class="acc-label">{{t "clusterNew.rke.etcd.backupConfig.bucketName.label"}}</label>
+                {{input
+                  type="text"
+                  value=cluster.rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.bucketName
+                  classNames="form-control"
+                  placeholder=(t "clusterNew.rke.etcd.backupConfig.bucketName.placeholder")
+                }}
+              </div>
+
+              <div class="col span-3 offset-1">
+                <label class="acc-label">{{t "clusterNew.rke.etcd.backupConfig.region.label"}}</label>
+                {{input
+                  type="text"
+                  value=cluster.rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.region
+                  classNames="form-control"
+                  placeholder=(t "clusterNew.rke.etcd.backupConfig.region.placeholder")
+                }}
+              </div>
+
+              <div class="col span-3 offset-1">
+                <label class="acc-label">{{t "clusterNew.rke.etcd.backupConfig.endpoint.label"}}</label>
+                {{input
+                  type="text"
+                  value=cluster.rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.endpoint
+                  classNames="form-control"
+                  placeholder=(t "clusterNew.rke.etcd.backupConfig.endpoint.placeholder")
+                }}
+              </div>
+            </div>
+
+            <div class="row">
+
+              <div class="col span-3">
+                <label class="acc-label">{{t "clusterNew.rke.etcd.backupConfig.accessKey.label"}}</label>
+                {{input
+                  type="text"
+                  name="accessKey"
+                  classNames="form-control"
+                  placeholder=(t "clusterNew.rke.etcd.backupConfig.accessKey.placeholder")
+                  value=cluster.rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.accessKey
+                }}
+              </div>
+
+              <div class="col span-3 offset-1">
+                <label class="acc-label">{{t "clusterNew.rke.etcd.backupConfig.secretKey.label"}}</label>
+                {{input
+                  type="password"
+                  name="password"
+                  classNames="form-control"
+                  placeholder=(t "clusterNew.rke.etcd.backupConfig.secretKey.placeholder")
+                  value=cluster.rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.secretKey
+                }}
+              </div>
+
+            </div>
+          {{/unless}}
         {{/accordion-list-item}}
       {{/advanced-section}}
     {{/if}}
@@ -380,11 +441,11 @@
   {{#accordion-list showExpandAll=false as |al expandFn|}}
     {{#if windowsSupport}}
       {{#accordion-list-item
-           title=(t "clusterNew.rke.system.title")
-           detail=(t "clusterNew.rke.system.detail")
-           expandOnInit=true
-           expandAll=al.expandAll
-           expand=(action expandFn)
+         title=(t "clusterNew.rke.system.title")
+         detail=(t "clusterNew.rke.system.detail")
+         expandOnInit=true
+         expandAll=al.expandAll
+         expand=(action expandFn)
       }}
         <div class="row">
           <div class="col span-6 text-center mt-0 mb-0">
@@ -407,11 +468,11 @@
       {{/accordion-list-item}}
     {{/if}}
     {{#accordion-list-item
-         title=(t "clusterNew.rke.role.pageheader")
-         detail=(t "clusterNew.rke.info.text")
-         expandOnInit=true
-         expandAll=al.expandAll
-         expand=(action expandFn)
+       title=(t "clusterNew.rke.role.pageheader")
+       detail=(t "clusterNew.rke.info.text")
+       expandOnInit=true
+       expandAll=al.expandAll
+       expand=(action expandFn)
     }}
       <section>
         <p>
@@ -430,27 +491,27 @@
                     <div class="col span-4 text-center mt-0 mb-0">
                       <label class="p-10 pl-30 pr-30 {{unless isLinux "text-muted"}}">
                         {{input
-                            type="checkbox"
-                            checked=etcd
-                            disabled=(not isLinux)
+                          type="checkbox"
+                          checked=etcd
+                          disabled=(not isLinux)
                         }} {{t "clusterNew.rke.role.header.etcd"}}
                       </label>
                     </div>
                     <div class="col span-4 text-center mt-0 mb-0">
                       <label class="p-10 pl-30 pr-30 {{unless isLinux "text-muted"}}">
                         {{input
-                            type="checkbox"
-                            checked=controlplane
-                            disabled=(not isLinux)
+                          type="checkbox"
+                          checked=controlplane
+                          disabled=(not isLinux)
                         }} {{t "clusterNew.rke.role.header.controlplane"}}
                       </label>
                     </div>
                     <div class="col span-4 text-center mt-0 mb-0">
                       <label class="p-10 pl-30 pr-30">
                         {{input
-                            type="checkbox"
-                            checked=worker
-                            disabled=(not isLinux)
+                          type="checkbox"
+                          checked=worker
+                          disabled=(not isLinux)
                         }} {{t "clusterNew.rke.role.header.worker"}}
                       </label>
                     </div>
@@ -465,9 +526,9 @@
                             <div class="col span-6">
                               <label class="acc-label">{{t "clusterNew.rke.address.public.label"}}</label>
                               {{input
-                                  type="text"
-                                  value=address
-                                  placeholder=(t "clusterNew.rke.address.public.placeholder")
+                                type="text"
+                                value=address
+                                placeholder=(t "clusterNew.rke.address.public.placeholder")
                               }}
                               {{#unless isAddressValid}}
                                 <div class="banner bg-warning">
@@ -481,9 +542,9 @@
                             <div class="col span-6">
                               <label class="acc-label">{{t "clusterNew.rke.address.private.label"}}</label>
                               {{input
-                                  type="text"
-                                  value=internalAddress
-                                  placeholder=(t "clusterNew.rke.address.private.placeholder")
+                                type="text"
+                                value=internalAddress
+                                placeholder=(t "clusterNew.rke.address.private.placeholder")
                               }}
                               {{#unless isInternalAddressValid}}
                                 <div class="banner bg-warning">
@@ -507,9 +568,9 @@
                             <div class="row">
                               <div class="col span-6">
                                 {{input
-                                    type="text"
-                                    value=nodeName
-                                    placeholder=(t "clusterNew.rke.nodeName.placeholder")
+                                  type="text"
+                                  value=nodeName
+                                  placeholder=(t "clusterNew.rke.nodeName.placeholder")
                                 }}
                                 {{#unless isNodeNameValid}}
                                   {{top-errors errors=nodeNameErrors}}
@@ -525,11 +586,11 @@
                         <ul class="list-unstyled">
                           <li>
                             {{#form-user-labels
-                                 setLabels=(action "setLabels")
-                                 expandAll=al.expandAll
-                                 expand=(action expandFn)
-                                 detailKey="formUserLabels.nodeDetail"
-                                 as | userLabelArray removeLabel addUserLabel |
+                               setLabels=(action "setLabels")
+                               expandAll=al.expandAll
+                               expand=(action expandFn)
+                               detailKey="formUserLabels.nodeDetail"
+                               as | userLabelArray removeLabel addUserLabel |
                             }}
                               {{#if userLabelArray.length}}
                                 <table class="table fixed no-lines mt-20">
@@ -543,12 +604,12 @@
                                     <tr>
                                       <td data-title="key">
                                         {{input-paste
-                                            pasted="pastedLabels"
-                                            class="form-control input-sm key"
-                                            type="text"
-                                            value=label.key
-                                            placeholder="formUserLabels.key.placeholder"
-                                            disabled=(eq label.readonly true)
+                                          pasted="pastedLabels"
+                                          class="form-control input-sm key"
+                                          type="text"
+                                          value=label.key
+                                          placeholder="formUserLabels.key.placeholder"
+                                          disabled=(eq label.readonly true)
                                         }}
                                       </td>
 
@@ -558,11 +619,11 @@
 
                                       <td data-title="label">
                                         {{input
-                                            class="form-control input-sm"
-                                            type="text"
-                                            value=label.value
-                                            placeholder=(t "formUserLabels.value.placeholder")
-                                            disabled=(eq label.readonly true)
+                                          class="form-control input-sm"
+                                          type="text"
+                                          value=label.value
+                                          placeholder=(t "formUserLabels.value.placeholder")
+                                          disabled=(eq label.readonly true)
                                         }}
                                       </td>
 
@@ -600,9 +661,9 @@
                       <div class="text-center"><i class="icon icon-spinner icon-spin"></i> {{t "generic.loading"}}</div>
                     {{else if command}}
                       {{copy-to-clipboard
-                          clipboardText=command
-                          tagName="div"
-                          classNames="copy-to-pre"
+                        clipboardText=command
+                        tagName="div"
+                        classNames="copy-to-pre"
                       }}
                       <pre id="registration-command" style="font-size: 14px;">{{command}}</pre>
                     {{/if}}
@@ -636,10 +697,10 @@
 {{top-errors errors=clusterOptErrors}}
 {{#if (or isEdit (eq step 1))}}
   {{save-cancel
-      createLabel=(if isCustom "saveCancel.next" "saveCancel.create")
-      editing=isEdit
-      save="driverSave"
-      cancel="close"
+    createLabel=(if isCustom "saveCancel.next" "saveCancel.create")
+    editing=isEdit
+    save="driverSave"
+    cancel="close"
   }}
 {{else}}
   <div class="footer-actions">

--- a/lib/shared/addon/scope/service.js
+++ b/lib/shared/addon/scope/service.js
@@ -4,6 +4,7 @@ import { get, set, setProperties } from '@ember/object';
 import SubscribeGlobal from 'shared/utils/subscribe-global';
 import SubscribeCluster from 'shared/utils/subscribe-cluster';
 import SubscribeProject from 'shared/utils/subscribe-project';
+import { Promise as EmberPromise } from 'rsvp';
 
 export default Service.extend({
   access:           service(),
@@ -90,7 +91,7 @@ export default Service.extend({
   },
 
   finishSwitchToGlobal() {
-    this._finishSwitchTo(null, null);
+    return this._finishSwitchTo(null, null);
   },
 
   startSwitchToCluster(cluster, connect = true) {
@@ -100,7 +101,7 @@ export default Service.extend({
   },
 
   finishSwitchToCluster(cluster) {
-    this._finishSwitchTo(cluster, null);
+    return this._finishSwitchTo(cluster, null);
   },
 
   startSwitchToProject(project, connect = true) {
@@ -175,8 +176,16 @@ export default Service.extend({
   },
 
   _finishSwitchTo(cluster, project) {
-    set(this, 'currentCluster', cluster);
-    set(this, 'currentProject', project);
+    return new EmberPromise((resolve) => {
+      setProperties(this, {
+        currentCluster: cluster,
+        currentProject: project,
+      });
+
+      resolve();
+
+      return;
+    });
   },
 
   getAllProjects(moreOpt = {}) {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -416,7 +416,7 @@ authPage:
     buttonText:
       pre: 'Authenticate with Okta'
       post: Waiting to hear back from IDP
-      
+
 
   shibboleth:
     enabled:
@@ -596,6 +596,19 @@ authPage:
       buttonText:
         pre: Enable Local Auth
         post: 'Enabling...'
+
+backupsPage:
+  header: etcd Snapshots
+  detail: etcd snapshots, if enabled, are cluster snapshots periodicaly taken at predefined intervals that can be used to restore clusters from a previous version.
+  table:
+    state: State
+    target:
+      label: Target
+      s3: S3
+      local: Local
+    name: Name
+    created: Created
+    noData: There are no etcd snapshots
 
 balancerPage:
   noMatch: No balancers match the current search
@@ -2505,6 +2518,32 @@ clusterNew:
       label: EIP Share Type
   rke:
     etcd:
+      backupConfig:
+        legacy: "This cluster was configured with a legacy ectd snapshot api. The new api replaces the creation time and retention time durations with a simpler creation time in hours and retention count. We have migrated your creation period automatically. Retention count has been configured to the default of 6 backups (current retention duration: {duration}), if you're okay with this setting no further action is required. If not, you may change the setting in the advanced settings section."
+        retention:
+          label: Snapshot Retention Count
+          placeholder: "12"
+        interval:
+          label: Snapshot Creation Period
+          placeholder: "6"
+        bucketName:
+          label: S3 Bucket Name
+          placeholder: "backups"
+        region:
+          label: S3 Region
+          placeholder: "us-west-2"
+        endpoint:
+          label: S3 Region Endpoint
+          placeholder: "s3.us-west-2.amazonaws.com"
+        accessKey:
+          label: Access Key
+          placeholder: Your AWS access key
+        secretKey:
+          label: Secret Key
+          placeholder: Your AWS secret key
+          provided: Provided
+      location:
+        label: etcd Snapshot Target
       heartbeat:
         label: etcd Heartbeat Interval
         placeholder: Time of a heartbeat interval
@@ -5181,6 +5220,13 @@ modalRevertSettings:
   current: Current Value
   default: Default Value
 
+modalRestoreBackup:
+  title: Restore From Backup
+  backups: Available Backups
+  error: A backup is required
+  select:
+    all: Select an available backup
+
 modalRotateCertificates:
   title: Rotate Cluster Certificates
   caCerts: Rotate caCertificates
@@ -6477,12 +6523,13 @@ nav:
     tab: Settings
     advanced: Advanced
   tools:
-    tab: Tools
     alerts: Alerts
-    notifiers: Notifiers
+    backups: Backups
     logging: Logging
     monitoring: Monitoring
+    notifiers: Notifiers
     pipeline: Pipeline
+    tab: Tools
   project:
     none: Grouped Projects/Namespaces
     namespaces: Namespaces
@@ -6495,6 +6542,8 @@ action:
   activate: Activate
   addContainer: Deploy Pod
   addSidekick: Add a Sidecar
+  backupEtcd: Backup Now
+  restoreFromEtcdBackup: Restore From Backup
   clone: Clone
   console: Open Console
   cordon: Cordon

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,11 +8,42 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
+"@babel/core@^7.1.6":
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.2.2.tgz#07adba6dde27bb5ad8d8672f15fde3e08184a687"
+  integrity sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.2.2"
+    "@babel/helpers" "^7.2.0"
+    "@babel/parser" "^7.2.2"
+    "@babel/template" "^7.2.2"
+    "@babel/traverse" "^7.2.2"
+    "@babel/types" "^7.2.2"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.10"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0.tgz#1efd58bffa951dc846449e58ce3a1d7f02d393aa"
   dependencies:
     "@babel/types" "^7.0.0"
+    jsesc "^2.5.1"
+    lodash "^4.17.10"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/generator@^7.2.2":
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.2.2.tgz#18c816c70962640eab42fe8cae5f3947a5c65ccc"
+  integrity sha512-I4o675J/iS8k+P38dvJ3IBGqObLXyQLTxtrR4u9cSUJOURvafeEWb/pFMOTwtNrmq73mJzyF6ueTbO1BtN0Zeg==
+  dependencies:
+    "@babel/types" "^7.2.2"
     jsesc "^2.5.1"
     lodash "^4.17.10"
     source-map "^0.5.0"
@@ -38,6 +69,15 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
+"@babel/helpers@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.2.0.tgz#8335f3140f3144270dc63c4732a4f8b0a50b7a21"
+  integrity sha512-Fr07N+ea0dMcMN8nFpuK6dUIT7/ivt9yKQdEEnjVS83tG2pHwPi03gYmk/tyuwONnZ+sY+GFFPlWGgCtW1hF9A==
+  dependencies:
+    "@babel/template" "^7.1.2"
+    "@babel/traverse" "^7.1.5"
+    "@babel/types" "^7.2.0"
+
 "@babel/highlight@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
@@ -50,6 +90,11 @@
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.0.tgz#a7cd42cb3c12aec52e24375189a47b39759b783e"
 
+"@babel/parser@^7.2.2", "@babel/parser@^7.2.3":
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.2.3.tgz#32f5df65744b70888d17872ec106b02434ba1489"
+  integrity sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA==
+
 "@babel/template@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.0.tgz#58cc9572e1bfe24fe1537fdf99d839d53e517e22"
@@ -57,6 +102,15 @@
     "@babel/code-frame" "^7.0.0"
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
+
+"@babel/template@^7.1.2", "@babel/template@^7.2.2":
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
+  integrity sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.2.2"
+    "@babel/types" "^7.2.2"
 
 "@babel/traverse@^7.0.0":
   version "7.1.0"
@@ -72,9 +126,33 @@
     globals "^11.1.0"
     lodash "^4.17.10"
 
+"@babel/traverse@^7.1.5", "@babel/traverse@^7.1.6", "@babel/traverse@^7.2.2":
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.2.3.tgz#7ff50cefa9c7c0bd2d81231fdac122f3957748d8"
+  integrity sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.2.2"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/parser" "^7.2.3"
+    "@babel/types" "^7.2.2"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.10"
+
 "@babel/types@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0.tgz#6e191793d3c854d19c6749989e3bc55f0e962118"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.1.6", "@babel/types@^7.2.0", "@babel/types@^7.2.2":
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.2.2.tgz#44e10fc24e33af524488b716cdaee5360ea8ed1e"
+  integrity sha512-fKCuD6UFUMkR541eDWL+2ih/xFZBXPOg/7EQFeTluMDebfqR4jrpaCjLhkWlQS4hT6nRa2PMEgXKbRB5/H2fpg==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
@@ -108,6 +186,19 @@
   resolved "https://registry.yarnpkg.com/@glimmer/resolver/-/resolver-0.4.3.tgz#b1baae5c3291b4621002ccf8d7870466097e841d"
   dependencies:
     "@glimmer/di" "^0.2.0"
+
+"@rancher/ember-api-store@2.8.7":
+  version "2.8.7"
+  resolved "https://registry.yarnpkg.com/@rancher/ember-api-store/-/ember-api-store-2.8.7.tgz#eaf6d59fdcc819a62d00271d727efd34a649f2fe"
+  integrity sha512-HpWfo1O3l5fl8LS/U0OqYGJsBKCkyZhX8wXmlRu9JL+FwsjxEkaErShxuAKdCWF0QCCxfHDDigXKwkTDZYqW2A==
+  dependencies:
+    babel-eslint "^10.0.1"
+    broccoli-file-creator "^2.1.1"
+    ember-auto-import "^1.2.19"
+    ember-cli-babel "^6.18.0"
+    ember-fetch "^5.1.1"
+    eslint "^4.19.1"
+    set-cookie-parser "^2.2.1"
 
 "@types/acorn@^4.0.3":
   version "4.0.3"
@@ -698,6 +789,18 @@ babel-core@^6.24.1, babel-core@^6.26.0, babel-core@^6.26.3:
     private "^0.1.8"
     slash "^1.0.0"
     source-map "^0.5.7"
+
+babel-eslint@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"
+  integrity sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-eslint@^9.0.0:
   version "9.0.0"
@@ -2445,7 +2548,7 @@ continuable-cache@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/continuable-cache/-/continuable-cache-0.3.1.tgz#bd727a7faed77e71ff3985ac93351a912733ad0f"
 
-convert-source-map@^1.5.1:
+convert-source-map@^1.1.0, convert-source-map@^1.5.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   dependencies:
@@ -2622,6 +2725,13 @@ debug@=3.1.0, debug@~3.1.0:
 debug@^3.1.0:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.5.tgz#c2418fbfd7a29f4d4f70ff4cea604d4b64c46407"
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -2822,13 +2932,6 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-ember-api-store@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/ember-api-store/-/ember-api-store-2.7.2.tgz#93d3af6d66a59f2b04ee837c2e61c56fa740698b"
-  dependencies:
-    ember-cli-babel "^6.6.0"
-    ember-fetch "^5.1.1"
-
 ember-asset-loader@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/ember-asset-loader/-/ember-asset-loader-0.4.3.tgz#cb59e1d0631f71046fc6e043a78337fea7f4c0a2"
@@ -2882,6 +2985,36 @@ ember-auto-import@^1.2.13:
     walk-sync "^0.3.2"
     webpack "^4.12.0"
 
+ember-auto-import@^1.2.19:
+  version "1.2.19"
+  resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.2.19.tgz#69a2da0d2c16ab88989c51381c415214e85d1af3"
+  integrity sha512-OT7I3zrIAv/rbbYJFZNqfJi/2HpAscjOWOaBPPUj8VkUnY26HlLO6mSzDIkoUOaTAEWiy2GzjenHGj6b9rivxw==
+  dependencies:
+    "@babel/core" "^7.1.6"
+    "@babel/traverse" "^7.1.6"
+    "@babel/types" "^7.1.6"
+    babel-core "^6.26.3"
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-template "^6.26.0"
+    babylon "^6.18.0"
+    broccoli-debug "^0.6.4"
+    broccoli-plugin "^1.3.0"
+    debug "^3.1.0"
+    ember-cli-babel "^6.6.0"
+    enhanced-resolve "^4.0.0"
+    fs-extra "^6.0.1"
+    fs-tree-diff "^0.5.7"
+    handlebars "^4.0.11"
+    js-string-escape "^1.0.1"
+    lodash "^4.17.10"
+    mkdirp "^0.5.1"
+    pkg-up "^2.0.0"
+    resolve "^1.7.1"
+    rimraf "^2.6.2"
+    symlink-or-copy "^1.2.0"
+    walk-sync "^0.3.3"
+    webpack "^4.12.0"
+
 ember-basic-dropdown@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-1.0.3.tgz#bd785c84ea2b366951e0630f173c84677ed53b6c"
@@ -2897,7 +3030,7 @@ ember-cli-app-version@^3.0.0:
     ember-cli-babel "^6.12.0"
     git-repo-version "^1.0.2"
 
-ember-cli-babel@^5.1.6, ember-cli-babel@^5.2.1, ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.0.0-beta.9, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.1, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
+ember-cli-babel@^5.1.6, ember-cli-babel@^5.2.1, ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.0.0-beta.9, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.18.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.1, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.17.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.17.2.tgz#f0d53d2fb95e70c15d8db84760d045f88f458f69"
   dependencies:
@@ -3705,9 +3838,10 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^4.0.0:
+eslint@^4.0.0, eslint@^4.19.1:
   version "4.19.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
+  integrity sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
@@ -5319,6 +5453,13 @@ json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
+json5@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
+  integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
+  dependencies:
+    minimist "^1.2.0"
+
 jsondiffpatch@^0.3.11:
   version "0.3.11"
   resolved "https://registry.yarnpkg.com/jsondiffpatch/-/jsondiffpatch-0.3.11.tgz#43f9443a0d081b5f79d413fe20f302079e493201"
@@ -6752,7 +6893,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
-path-parse@^1.0.5:
+path-parse@^1.0.5, path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
 
@@ -7342,6 +7483,13 @@ resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0, 
   dependencies:
     path-parse "^1.0.5"
 
+resolve@^1.3.2:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.9.0.tgz#a14c6fdfa8f92a7df1d996cb7105fa744658ea06"
+  integrity sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==
+  dependencies:
+    path-parse "^1.0.6"
+
 restore-cursor@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
@@ -7623,6 +7771,11 @@ serve-static@1.13.2:
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+
+set-cookie-parser@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.2.1.tgz#eae9e36c48667c9b385246ab6f450aade889aaf4"
+  integrity sha1-6unjbEhmfJs4Ukarb0UKreiJqvQ=
 
 set-value@^0.4.3:
   version "0.4.3"


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

S3 was added as an option for RKE cluster etcd backup and config. Users may now select from local or s3 as backup targets. 
Adds new backup's page for clusters to view existing backups
Adds back up now to actions
Adds restore from backup to actions
migrates legacy local etcd backups to new api and format so they are viewable and restorable.

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

New Feature
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#16797

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

N/A 
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
