### PR TITLE
Resolve typo issue 'pileine'

### DIFF
--- a/lib/pipeline/translations/en-us.yaml
+++ b/lib/pipeline/translations/en-us.yaml
@@ -365,7 +365,7 @@ buildDetailPage:
   stillRunning: Still Running
   log:
     title: Detailed Log
-    detail: The detailed log of the current pileine run.
+    detail: The detailed log of the current pipeline run.
     waiting: Waiting...
     loading: Loading...
 


### PR DESCRIPTION
https://github.com/rancher/ui/blob/master/lib/pipeline/translations/en-us.yaml#L368

Related issue: [#17513](https://github.com/rancher/rancher/issues/17513 "#17513")

Changes:

- Fix typo:
`pileine` -> `pipeline`