### PR TITLE
Fix missed type change of ingress rule paths

### DIFF
--- a/lib/shared/addon/components/form-ingress-rule/component.js
+++ b/lib/shared/addon/components/form-ingress-rule/component.js
@@ -29,7 +29,7 @@ export default Component.extend({
       const rule = EmberObject.create({
         host:  '',
         new:   true,
-        paths: {},
+        paths: [],
       });
 
       get(this, 'rules').pushObject(rule);
@@ -65,7 +65,7 @@ export default Component.extend({
     if (defaultBackend) {
       rules.push({
         defaultBackend: true,
-        paths:          { '': defaultBackend }
+        paths:          [{ '': defaultBackend }]
       });
     }
     set(this, 'rules', rules);


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

We changed the type of rule.paths on ingress workloads from an object to an array in rancher/ui#17129 but we missed where the rules are instantiated.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#17618

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
