### PR TITLE
Provide UX feedback after backup now action is fired on cluster

### DIFF
--- a/app/styles/abstracts/_variables.scss
+++ b/app/styles/abstracts/_variables.scss
@@ -106,3 +106,14 @@ $table-bg-selected     : lighten($info, 32)!default;
 $table-border-color    : lighten($mid-grey, 30)!default;
 $table-body-separation : 25px;
 $group-row-height      : 50px;
+
+// banners
+$banner-default                      : lighten($light-grey, 5) !default;
+$banner-disabled                     : lighten($mid-grey, 35) !default;
+$banner-primary                      : lighten($primary, 63) !default;
+$banner-secondary                    : lighten($secondary, 65) !default;
+$banner-success                      : lighten($success, 55) !default;
+$banner-info                         : lighten($info, 30) !default;
+$banner-warning                      : lighten($warning, 45) !default;
+$banner-error                        : lighten($error, 35) !default;
+$banner-color                        : $secondary !default;

--- a/app/styles/components/_banners.scss
+++ b/app/styles/components/_banners.scss
@@ -1,14 +1,3 @@
-// banners
-$banner-default                      : lighten($light-grey, 5) !default;
-$banner-disabled                     : lighten($mid-grey, 35) !default;
-$banner-primary                      : lighten($primary, 63) !default;
-$banner-secondary                    : lighten($secondary, 65) !default;
-$banner-success                      : lighten($success, 55) !default;
-$banner-info                         : lighten($info, 30) !default;
-$banner-warning                      : lighten($warning, 45) !default;
-$banner-error                        : lighten($error, 35) !default;
-$banner-color                        : $secondary !default;
-
 .banner {
   display: table;
   position: relative;

--- a/app/styles/components/_growl.scss
+++ b/app/styles/components/_growl.scss
@@ -34,6 +34,10 @@
     @extend .bg-error;
   }
 
+  .success {
+    @extend .bg-success;
+  }
+
   .message {
     border: 1px solid #FF9494;
     background: repeating-linear-gradient(

--- a/lib/shared/addon/growl/service.js
+++ b/lib/shared/addon/growl/service.js
@@ -1,14 +1,27 @@
 import Service, { inject as service } from '@ember/service';
 import Errors from 'ui/utils/errors';
 import 'jgrowl';
+import { setProperties } from '@ember/object';
+import { htmlSafe } from '@ember/string';
 
 export default Service.extend({
   app:  service(),
+  intl: service(),
+
+
   init() {
-    $.jGrowl.defaults.pool = 6;
-    $.jGrowl.defaults.closeTemplate = '<i class="icon icon-x"></i>';
-    $.jGrowl.defaults.closerTemplate = '<div><button type="button" class="btn bg-info btn-xs btn-block">Dismiss All Notifications</button></div>';
+    this.initjGrowlDefaults();
     this._super(...arguments);
+  },
+
+  initjGrowlDefaults() {
+    let { defaults } = $.jGrowl;
+
+    setProperties(defaults, {
+      pool:           6,
+      closeTemplate:  htmlSafe('<i class="icon icon-x"></i>'),
+      closerTemplate: htmlSafe(`<div><button type="button" class="btn bg-info btn-xs btn-block">${ this.intl.t('growl.dismiss') }</button></div>`),
+    })
   },
 
   close() {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -6742,6 +6742,10 @@ action:
   addContainer: Deploy Pod
   addSidekick: Add a Sidecar
   backupEtcd: Backup Now
+  backupEtcdMessage:
+    success:
+      title: Backup successful
+      message: "{ clusterId } has been backed up to { backupType } provider"
   restoreFromEtcdBackup: Restore From Backup
   clone: Clone
   console: Open Console
@@ -6894,6 +6898,7 @@ model:
       loadBalancer: L4 Balancer
 
 growl:
+  dismiss: Dismiss All Notifications
   webSocket:
     connecting:
       title: Error connecting to WebSocket


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

The UI was not providing any feedback to the user after a backup action was performed on the fly. From the backup action I added success and error checks that provide UX feedback via the Growl functionality.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#17504
rancher/rancher#17557

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
