### PR TITLE
Fix the issue that user cannot select LB in imported cluster

### DIFF
--- a/lib/shared/addon/capabilities/service.js
+++ b/lib/shared/addon/capabilities/service.js
@@ -46,7 +46,8 @@ export default Service.extend({
 
   loadBalancerCapabilites: computed('capabilities.loadBalancerCapabilities.{enabled,healthCheckSupported}', function() {
     return {
-      l4LoadBalancerEnabled: get(this, 'capabilities.loadBalancerCapabilities.enabled'),
+      // `enabled` field is not set for imported clusters
+      l4LoadBalancerEnabled: get(this, 'capabilities.loadBalancerCapabilities.enabled') !== false,
       healthCheckSupported:  get(this, 'capabilities.loadBalancerCapabilities.healthCheckSupported'),
     }
   }),


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Fix the issue that user cannot select LB for port mapping in imported cluster

As `enabled` field is not set in Imported clusters, therefor its nil

However, users should be able to select LB when the `enabled` field is nil
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/17941
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
