### PR TITLE
Support valuesYaml for catalog

### DIFF
--- a/app/apps-tab/detail/template.hbs
+++ b/app/apps-tab/detail/template.hbs
@@ -67,8 +67,12 @@
         {{form-key-value
           editing=false
           initialMap=model.app.answers
+          showNoneLabel=(not model.app.valuesYaml)
           keyLabel='appDetailPage.answers.variable'
         }}
+        {{#if model.app.valuesYaml}}
+          {{code-block code=model.app.valuesYaml language="yaml"}}
+        {{/if}}
     {{/accordion-list-item}}
 
     {{#accordion-list-item

--- a/app/components/new-catalog/component.js
+++ b/app/components/new-catalog/component.js
@@ -335,11 +335,13 @@ export default Component.extend(NewOrEdit, CatalogApp, {
 
   didSave(neu) {
     let app = get(this, 'catalogApp');
+    const yaml = get(this, 'selectedTemplateModel.valuesYaml');
 
     if (get(app, 'id')) {
       return app.doAction('upgrade', {
         externalId:   get(this, 'selectedTemplateModel.externalId'),
-        answers:      get(app, 'answers'),
+        answers:      yaml ? {} : get(app, 'answers'),
+        valuesYaml:   yaml ? yaml : null,
         forceUpgrade: get(this, 'forceUpgrade'),
       }).then((resp) => resp)
         .catch((err) => err);
@@ -350,6 +352,8 @@ export default Component.extend(NewOrEdit, CatalogApp, {
         targetNamespace: requiredNamespace ? requiredNamespace : neu.name,
         externalId:      get(this, 'selectedTemplateModel.externalId'),
         projectId:       get(neu, 'projectId'),
+        answers:         yaml ? {} : get(app, 'answers'),
+        valuesYaml:      yaml ? yaml : null,
       });
 
       return app.save().then(() => get(this, 'primaryResource'));

--- a/app/components/new-catalog/template.hbs
+++ b/app/components/new-catalog/template.hbs
@@ -1,9 +1,9 @@
 {{#if showHeader}}
   <section class="header clearfix">
     {{#if editing}}
-      <h1>{{t 'newCatalog.upgrade'}} <span style="font-weight: normal">{{catalogApp.displayName}}</span></h1>
+      <h1>{{t "newCatalog.upgrade"}} <span style="font-weight: normal">{{catalogApp.displayName}}</span></h1>
     {{else}}
-      <h1>{{#link-to parentRoute}}{{t 'newCatalog.catalog'}} {{templateResource.displayName}}{{/link-to}}</h1>
+      <h1>{{#link-to parentRoute}}{{t "newCatalog.catalog"}} {{templateResource.displayName}}{{/link-to}}</h1>
     {{/if}}
   </section>
 {{/if}}
@@ -28,8 +28,8 @@
         </h1>
         <p>{{templateResource.description}}</p>
         <div class="row">
-          <button class="btn btn-sm bg-transparent pl-0" {{action 'toogleDetailedDescriptions'}}>
-            {{t 'newCatalog.seeMore'}}
+          <button class="btn btn-sm bg-transparent pl-0" {{action "toogleDetailedDescriptions"}}>
+            {{t "newCatalog.seeMore"}}
           </button>
         </div>
       {{/if}}
@@ -39,8 +39,8 @@
 
 {{#accordion-list as |al expandFn|}}
   {{#accordion-list-item
-      title=(t 'newCatalog.appInfo')
-      detail=(t 'newCatalog.appInfoDetail')
+      title=(t "newCatalog.appInfo")
+      detail=(t "newCatalog.appInfoDetail")
       expandAll=al.expandAll
       expand=(action expandFn)
       expanded=detailExpanded
@@ -61,8 +61,8 @@
 
 
   {{#accordion-list-item
-    title=(t (if selectedTemplateModel.questions 'inputAnswers.config' 'newCatalog.helm.label'))
-    detail=(t (if selectedTemplateModel.questions 'inputAnswers.protip' 'newCatalog.helm.protip'))
+    title=(t (if selectedTemplateModel.questions "inputAnswers.config" "newCatalog.helm.label"))
+    detail=(t (if selectedTemplateModel.questions "inputAnswers.protip" "newCatalog.helm.protip"))
     expandAll=al.expandAll
     expandOnInit=true
     expand=(action expandFn)
@@ -80,7 +80,7 @@
         }}
       </div>
       <div class="col span-6" style="padding-top: 6px;"> {{!-- matches styles of form-name-description --}}
-        <label for="" class="acc-label">{{t 'newCatalog.templateVersion'}}</label>
+        <label for="" class="acc-label">{{t "newCatalog.templateVersion"}}</label>
         {{new-select
             classNames="form-control"
             content=sortedVersions
@@ -97,10 +97,10 @@
     <div class="row">
       {{#unless (or customizeNamespace (not selectedTemplateModel))}}
         <div class="col span-12">
-          {{t 'newCatalog.customizeNamespace' namespaceId=(if requiredNamespace requiredNamespace primaryResource.name) htmlSafe=true}}
+          {{t "newCatalog.customizeNamespace" namespaceId=(if requiredNamespace requiredNamespace primaryResource.name) htmlSafe=true}}
           {{#unless (or editing requiredNamespace)}}
-            <button class="btn btn-sm bg-transparent pl-0" {{action 'toogleNamespace'}}>
-              {{t 'generic.customize'}}
+            <button class="btn btn-sm bg-transparent pl-0" {{action "toogleNamespace"}}>
+              {{t "generic.customize"}}
             </button>
           {{/unless}}
         </div>
@@ -131,12 +131,16 @@
           <div class="col span-12">
             {{#if selectedTemplateModel.questions}}
               {{input-answers
+                  app=catalogApp
                   selectedTemplate=selectedTemplateModel
                   showHeader=false
                   namespaceId=(if requiredNamespace requiredNamespace primaryResource.name)
               }}
             {{else}}
-              {{input-custom-answers app=catalogApp}}
+              {{input-custom-answers
+                  app=catalogApp
+                  selectedTemplate=selectedTemplateModel
+              }}
             {{/if}}
           </div>
         {{/if}}
@@ -149,13 +153,13 @@
 {{#if (and selectedTemplateModel (not getTemplate.isRunning))}}
   {{#if showPreview}}
     <section>
-      <div class="over-hr hand no-select"><span {{action "togglePreview"}}>{{t 'newCatalog.preview'}} <i class="icon {{if previewOpen 'icon-chevron-up' 'icon-chevron-down'}}"></i></span></div>
+      <div class="over-hr hand no-select"><span {{action "togglePreview"}}>{{t "newCatalog.preview"}} <i class="icon {{if previewOpen "icon-chevron-up" "icon-chevron-down"}}"></i></span></div>
 
       {{#if previewOpen}}
         <div class="tabs">
           <div class="tab-header row">
             <div class="col span-4">
-              <label class="acc-label">{{t 'newCatalog.templateFiles'}}</label>
+              <label class="acc-label">{{t "newCatalog.templateFiles"}}</label>
               {{searchable-select
                   content=filenames
                   value=previewTab
@@ -172,7 +176,7 @@
                 </div>
               </section>
             {{else}}
-              {{#if (eq  previewTab 'answers')}}
+              {{#if (eq  previewTab "answers")}}
                 {{code-block code=answersString language="yaml"}}
               {{else}}
                 {{code-block code=selectedFileContetnt language="yaml"}}
@@ -188,7 +192,7 @@
     <div class="checkbox pt-10">
       <label>
         {{input type="checkbox" checked=forceUpgrade}}
-        {{t 'newCatalog.forceUpgrade'}}
+        {{t "newCatalog.forceUpgrade"}}
       </label>
     </div>
   {{/if}}
@@ -196,7 +200,7 @@
     <div class="banner bg-warning">
       <div class="banner-icon"><span class="icon icon-alert"></span></div>
       <div class="banner-message">
-        <p>{{t 'ingressPage.gkeIngressWarning'}}</p>
+        <p>{{t "ingressPage.gkeIngressWarning"}}</p>
       </div>
     </div>
   {{/if}}
@@ -216,6 +220,6 @@
   </div>
 {{else}}
   <div class="footer-actions">
-    <button {{action "cancel"}} class="btn bg-transparent">{{t 'saveCancel.cancel'}}</button>
+    <button {{action "cancel"}} class="btn bg-transparent">{{t "saveCancel.cancel"}}</button>
   </div>
 {{/if}}

--- a/lib/global-admin/addon/components/new-multi-cluster-app/template.hbs
+++ b/lib/global-admin/addon/components/new-multi-cluster-app/template.hbs
@@ -241,13 +241,16 @@
           <div class="col span-12">
             {{#if selectedTemplateModel.questions}}
               {{input-answers
+                app=multiClusterApp
                 selectedTemplate=selectedTemplateModel
                 showHeader=false
+                isMultiClusterApp=true
               }}
             {{else}}
               {{input-custom-answers
                 app=multiClusterApp
                 isMultiClusterApp=true
+                selectedTemplate=selectedTemplateModel
               }}
             {{/if}}
           </div>

--- a/lib/shared/addon/components/form-key-value/component.js
+++ b/lib/shared/addon/components/form-key-value/component.js
@@ -72,6 +72,7 @@ export default Component.extend(Upload, {
   addInitialEmptyRow:   false,
   allowMultilineValue:  true,
   base64Value:          false,
+  showNoneLabel:        true,
   concealValue:         false,
   editing:              true,
   kvSeparator:          '=',

--- a/lib/shared/addon/components/form-key-value/template.hbs
+++ b/lib/shared/addon/components/form-key-value/template.hbs
@@ -64,7 +64,7 @@
     {{/each}}
     </tbody>
   </table>
-{{else}}
+{{else if showNoneLabel}}
   {{#unless editing}}
     <div>{{t 'generic.none'}}</div>
   {{/unless}}

--- a/lib/shared/addon/components/input-answers/component.js
+++ b/lib/shared/addon/components/input-answers/component.js
@@ -7,6 +7,7 @@ import { evaluate } from 'shared/utils/evaluate';
 import { inject as service } from '@ember/service';
 import layout from './template';
 import YAML from 'yamljs';
+import convertDotAnswersToYaml from 'shared/utils/convert-yaml';
 
 const HIDDEN = 'Hidden';
 
@@ -14,14 +15,26 @@ export default Component.extend({
   growl: service(),
 
   layout,
-  pasteOrUpload:   false,
-  accept:          '.yml, .yaml',
-  showHeader:      true,
-  answerSections:  null,
+  pasteOrUpload:     false,
+  isMultiClusterApp: false,
+  accept:            '.yml, .yaml',
+  showHeader:        true,
+  answerSections:    null,
 
-  originQuestions: alias('selectedTemplate.questions'),
   questions:       alias('selectedTemplate.allQuestions'),
-  customAnswers:   alias('selectedTemplate.customAnswers'),
+  valuesYaml:      alias('selectedTemplate.valuesYaml'),
+
+  init() {
+    this._super(...arguments);
+
+    const { isMultiClusterApp } = this;
+
+    if ( isMultiClusterApp ) {
+      set(this, 'pasteOrUpload', !!get(this, 'app.answers.firstObject.valuesYaml'));
+    } else {
+      set(this, 'pasteOrUpload', !!get(this, 'app.valuesYaml'));
+    }
+  },
 
   actions: {
     upload() {
@@ -31,34 +44,51 @@ export default Component.extend({
       set(this, 'pasteOrUpload', true);
     },
     cancel() {
+      set(this, 'valuesYaml', null);
       set(this, 'pasteOrUpload', false);
     }
   },
 
   pastedAnswers: computed('pasteOrUpload', {
     get( /* key */ ) {
-      const questions = get(this, 'questions');
-      const answers = get(this, 'customAnswers') || {};
-      const out = {};
+      let valuesYaml;
 
-      questions.forEach((q) => {
-        out[q.variable] = q.answer || q.default || '';
-      });
+      const { isMultiClusterApp } = this;
 
-      Object.keys(answers).forEach((key) => {
-        if ( typeof out[key] === 'undefined' ) {
-          out[key] = answers[key];
-        }
-      });
+      if ( isMultiClusterApp ) {
+        valuesYaml = get(this, 'app.answers.firstObject.valuesYaml') || '';
+      } else {
+        valuesYaml = get(this, 'app.valuesYaml') || '';
+      }
 
-      return YAML.stringify(out);
+      let yaml;
+
+      if ( valuesYaml ) {
+        yaml = valuesYaml;
+      } else {
+        const questions = get(this, 'questions');
+        const input = {};
+
+        questions.forEach((q) => {
+          if ( q.answer !== undefined && q.answer !== null ) {
+            input[q.variable] = q.answer;
+          } else if ( q.default !== undefined && q.default !== null ) {
+            input[q.variable] = q.default;
+          } else {
+            input[q.variable] = '';
+          }
+        });
+
+        yaml = convertDotAnswersToYaml(input);
+      }
+      set(this, 'valuesYaml', yaml);
+
+      return yaml;
     },
 
     set(key, value) {
-      let qa;
-
       try {
-        qa = YAML.parse(value);
+        YAML.parse(value);
       } catch ( err ) {
         set(this, 'yamlErrors', [`YAML Parse Error: ${ err.snippet } - ${ err.message }`]);
 
@@ -66,22 +96,7 @@ export default Component.extend({
       }
 
       set(this, 'yamlErrors', []);
-
-      let questions = get(this, 'questions');
-      const answers = {};
-
-      if (qa) {
-        Object.keys(qa).forEach((q) => {
-          const question = questions.findBy('variable', q);
-
-          if ( question ) {
-            set(question, 'answer', qa[q]);
-          } else {
-            answers[q] = qa[q];
-          }
-        });
-      }
-      set(this, 'customAnswers', answers);
+      set(this, 'valuesYaml', value);
 
       return value;
     }

--- a/lib/shared/addon/components/input-answers/template.hbs
+++ b/lib/shared/addon/components/input-answers/template.hbs
@@ -1,16 +1,16 @@
-<form class="{{if getTemplate.isRunning 'hide'}}">
+<form class="{{if getTemplate.isRunning "hide"}}">
   <div class="btn-group  pull-right">
     {{#if pasteOrUpload}}
-      <button class="btn btn-sm" {{action 'cancel'}}>{{t 'inputAnswers.editAsForm'}}</button>
-    {{else}}
-      <button class="btn btn-sm bg-primary" {{action 'showPaste'}}>{{t 'inputAnswers.yaml'}} <span class="icon icon-copy"></span></button>
+      <button class="btn btn-sm" {{action "cancel"}}>{{t "inputAnswers.editAsForm"}}</button>
+      <button class="btn btn-sm bg-primary" {{action "upload"}}>{{t "uploadFile.label"}} <span class="icon icon-upload"></span></button>
+    {{else if (not isMultiClusterApp)}}
+      <button class="btn btn-sm bg-primary" {{action "showPaste"}}>{{t "inputAnswers.yaml"}} <span class="icon icon-copy"></span></button>
     {{/if}}
-    <button class="btn btn-sm bg-primary" {{action 'upload'}}>{{t 'uploadFile.label'}} <span class="icon icon-upload"></span></button>
   </div>
   <div>
     {{#if showHeader}}
-      <h4 class="mb-0">{{t 'inputAnswers.config'}}</h4>
-      <span class="protip">{{t 'inputAnswers.protip'}}</span>
+      <h4 class="mb-0">{{t "inputAnswers.config"}}</h4>
+      <span class="protip">{{t "inputAnswers.protip"}}</span>
     {{/if}}
     &nbsp;
   </div>
@@ -46,7 +46,7 @@
           </div>
         {{/each}}
      {{else}}
-        <span class="text-muted">{{t 'inputAnswers.noConfig'}}</span>
+        <span class="text-muted">{{t "inputAnswers.noConfig"}}</span>
      {{/each}}
     {{/if}}
   </div>

--- a/lib/shared/addon/components/input-custom-answers/component.js
+++ b/lib/shared/addon/components/input-custom-answers/component.js
@@ -1,28 +1,9 @@
 import Component from '@ember/component';
 import { computed, get, set } from '@ember/object';
 import { isSafari } from 'ui/utils/platform';
-import { next } from '@ember/runloop';
 import { inject as service } from '@ember/service';
-import json2yaml from 'json2yaml';
 import layout from './template';
 import YAML from 'yamljs';
-
-var dotObject = null;
-
-function convertKey(key) {
-  let out = '';
-  const splits = key.split('.');
-
-  splits.forEach((split, index) => {
-    if ( /^\d+$/.test(split) ) {
-      out += `[${ split }]`;
-    } else {
-      out += index === 0 ? split : `.${ split }`;
-    }
-  })
-
-  return out;
-}
 
 export default Component.extend({
   intl:  service(),
@@ -30,7 +11,6 @@ export default Component.extend({
 
   layout,
   pasteOrUpload:     false,
-  showInput:         true,
   accept:            '.yml, .yaml',
   app:               null,
   isMultiClusterApp: false,
@@ -39,7 +19,6 @@ export default Component.extend({
   init() {
     this._super(...arguments);
 
-    this.initLazyModules();
     this.initInitialAnswerMap();
   },
 
@@ -54,6 +33,7 @@ export default Component.extend({
 
     cancel() {
       set(this, 'pasteOrUpload', false);
+      set(this, 'selectedTemplate.valuesYaml', null);
     },
 
     updateAnswers(answers) {
@@ -77,34 +57,18 @@ export default Component.extend({
 
   pastedAnswers: computed('pasteOrUpload', {
     get() {
-      const input = get(this, 'app.answers');
-      const obj = {};
+      const { isMultiClusterApp } = this;
 
-      Object.keys(input).forEach((key) => {
-        const value = input[key];
-
-        key = key.replace(/\]\[/g, '.').replace(/\]\./g, '.')
-          .replace(/\[/g, '.');
-
-        if ( key.startsWith('.') ) {
-          key = key.substr(1, key.length);
-        }
-
-        if ( key.endsWith(']') ) {
-          key = key.substr(0, key.length - 1);
-        }
-        dotObject.str(key, value, obj);
-      });
-
-      return Object.keys(obj).length > 0 ? json2yaml.stringify(obj) : `# ${ get(this, 'intl').t('inputAnswers.yamlProtip') }\n`;
+      if (isMultiClusterApp) {
+        return get(this, 'app.answers.firstObject.valuesYaml') || '';
+      } else {
+        return get(this, 'app.valuesYaml') || '';
+      }
     },
 
     set(key, value) {
-      const out = {};
-      let json;
-
       try {
-        json = YAML.parse(value);
+        YAML.parse(value);
       } catch ( err ) {
         set(this, 'yamlErrors', [`YAML Parse Error: ${ err.snippet } - ${ err.message }`]);
 
@@ -112,28 +76,7 @@ export default Component.extend({
       }
 
       set(this, 'yamlErrors', []);
-
-      if ( json && typeof json === 'object' ) {
-        const dot = {};
-
-        dotObject.dot(json, dot);
-        Object.keys(dot).forEach((key) => {
-          const value = (typeof dot[key] === 'object') ? JSON.stringify(dot[key]) : dot[key];
-
-          key = convertKey(key);
-
-          out[key] = value
-        });
-      } else {
-        return value;
-      }
-
-      set(this, 'showInput', false);
-      set(this, 'app.answers', out);
-
-      next(() => {
-        set(this, 'showInput', true);
-      });
+      set(this, 'selectedTemplate.valuesYaml', value);
 
       return value;
     }
@@ -171,8 +114,14 @@ export default Component.extend({
 
     if (isMultiClusterApp) {
       answers = this.getInitialMultiClusterAnswerMap();
+      if ( get(this, 'app.answers.firstObject.valuesYaml') ) {
+        set(this, 'pasteOrUpload', true);
+      }
     } else {
       answers = this.getInitialMap();
+      if ( get(this, 'app.valuesYaml') ) {
+        set(this, 'pasteOrUpload', true);
+      }
     }
 
     set(this, 'intialAnswerMap', answers);
@@ -184,13 +133,5 @@ export default Component.extend({
 
   getInitialMap() {
     return get(this, 'app.answers');
-  },
-
-  initLazyModules() {
-    if (!dotObject) {
-      import('dot-object').then( (module) => {
-        dotObject = module.default;
-      });
-    }
   },
 });

--- a/lib/shared/addon/components/input-custom-answers/template.hbs
+++ b/lib/shared/addon/components/input-custom-answers/template.hbs
@@ -6,7 +6,14 @@
     >
       {{t "inputAnswers.editAsForm"}}
     </button>
-  {{else}}
+    <button
+      class="btn btn-sm bg-primary"
+      {{action "upload"}}
+    >
+      {{t "uploadFile.label"}}
+      <i class="icon icon-upload"></i>
+    </button>
+  {{else if (not isMultiClusterApp)}}
     <button
       class="btn btn-sm bg-primary"
       {{action "showPaste"}}
@@ -15,13 +22,6 @@
       <i class="icon icon-copy"></i>
     </button>
   {{/if}}
-  <button
-    class="btn btn-sm bg-primary"
-    {{action "upload"}}
-  >
-    {{t "uploadFile.label"}}
-    <i class="icon icon-upload"></i>
-  </button>
 </div>
 <div class="mt-25">
   {{#if pasteOrUpload}}
@@ -41,7 +41,7 @@
       }}
     </div>
     {{top-errors errors=yamlErrors}}
-  {{else if showInput}}
+  {{else}}
     {{form-key-value
       initialMap=intialAnswerMap
       changed="updateAnswers"

--- a/lib/shared/addon/utils/convert-yaml.js
+++ b/lib/shared/addon/utils/convert-yaml.js
@@ -1,0 +1,24 @@
+import json2yaml from 'json2yaml';
+import dotObject from 'dot-object';
+
+export default function convertDotAnswersToYaml(answers) {
+  const obj = {};
+
+  Object.keys(answers).forEach((key) => {
+    const value = answers[key];
+
+    key = key.replace(/\]\[/g, '.').replace(/\]\./g, '.')
+      .replace(/\[/g, '.');
+
+    if ( key.startsWith('.') ) {
+      key = key.substr(1, key.length);
+    }
+
+    if ( key.endsWith(']') ) {
+      key = key.substr(0, key.length - 1);
+    }
+    dotObject.str(key, value, obj);
+  });
+
+  return json2yaml.stringify(obj);
+}

--- a/lib/shared/app/utils/convert-yaml.js
+++ b/lib/shared/app/utils/convert-yaml.js
@@ -1,0 +1,1 @@
+export { convertDotAnswersToYaml } from 'shared/utils/convert-yaml';


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Now catalog supports `valuesYaml` field. It means users can pass real yaml to backend.

> For multi-cluster apps:

As it doesn't support `valuesYaml` field in backend. So we need to hide the edit yaml button for it now. It will not impact the existing function.

> For normal catalog app:

- UI will send either `answers` or `valuesYaml` to backend. 
- If it is in YAML mode, it will send `valuesYaml` to backend only.
- If it is in form mode, it will send `answers` only.
- If there is a password type question and the value is a number, it will fallback to use `valuesYaml` even it is in form mode

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
- New feature (non-breaking change which adds functionality)
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#13158
rancher/rancher#16680
rancher/rancher#17605
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
