### PR TITLE
Don't show empty row when no cluster driver.

### DIFF
--- a/lib/shared/addon/components/cru-cluster/template.hbs
+++ b/lib/shared/addon/components/cru-cluster/template.hbs
@@ -13,111 +13,115 @@
 {{#unless initialProvider}}
 
   <div class="row nav nav-boxes checked-active inline-form">
-    <div class="col span-8 col-inline mb-0">
-      <div>
-        <label class="acc-label">{{t 'clusterNew.driverLabels.cloud'}}</label>
-      </div>
-      {{#each (get providerGroups "cloudGroup") as |choice|}}
-        {{#unless choice.scriptError}}
-          {{#link-to (query-params provider=choice.name) class=(concat "mb-20 mt-10 col span-3 col-inline nav-box-item driver " choice.name)}}
+    <div class="col span-8 col-inline mt-0 mb-0">
+      {{#if (gte providerGroups.cloudGroup.length 1)}}
+        <div class="row nav checked-active inline-form">
+          <div>
+            <label class="acc-label">{{t 'clusterNew.driverLabels.cloud'}}</label>
+          </div>
+          {{#each (get providerGroups "cloudGroup") as |choice|}}
+            {{#unless choice.scriptError}}
+              {{#link-to (query-params provider=choice.name) class=(concat "mb-20 mt-10 col span-3 col-inline nav-box-item driver " choice.name)}}
+                <div class="machine-driver {{choice.name}}"></div>
+                <p class="driver-name">{{driver-name choice.name}}</p>
+                {{#if choice.genericIcon}}
+                  <p class="text-link text-bold">{{driver-name choice.name}}</p>
+                {{/if}}
+              {{/link-to}}
+            {{else}}
+              <div
+                class={{concat "disabled error-loading-driver mb-20 mt-10 col span-3 col-inline nav-box-item driver " choice.name}}>
+                {{#tooltip-element type="tooltip-basic" model=choice.scriptError tooltipTemplate='tooltip-static' aria-describedby="tooltip-base" tooltipFor="tooltipDriverError"}}
+                  <span class="icon icon-alert"></span>
+                {{/tooltip-element}}
+                <div class="machine-driver {{choice.name}}"></div>
+                <p class="driver-name">{{driver-name choice.name}}</p>
+                {{#if choice.genericIcon}}
+                  <p class="text-link text-bold">{{driver-name choice.name}}</p>
+                {{/if}}
+              </div>
+            {{/unless}}
+          {{/each}}
+        </div>
+      {{/if}}
+
+      {{#if (gte providerGroups.rkeGroup.length 1)}}
+        <div class="row">
+          <div>
+            <label class="acc-label">{{t 'clusterNew.driverLabels.infra'}}</label>
+          </div>
+          {{#each (get providerGroups "rkeGroup") as |choice|}}
+            {{#link-to (query-params provider=choice.name) class=(concat "mb-20 mt-10 col span-3 col-inline nav-box-item driver " choice.name)}}
+              <div class="machine-driver {{if choice.genericIcon 'generic'}} {{choice.name}}"></div>
+              <p class="driver-name">{{driver-name choice.name}}</p>
+            {{/link-to}}
+          {{/each}}
+        </div>
+      {{/if}}
+
+      {{#if (gte providerGroups.externalGroup.length 1)}}
+        <div class="row">
+          <div>
+            <label class="acc-label">{{t 'clusterNew.driverLabels.external'}}</label>
+          </div>
+          {{#each (get providerGroups "externalGroup") as |choice|}}
+            {{#unless choice.scriptError}}
+              {{#link-to (query-params provider=choice.name) class=(concat "mb-20 mt-10 col span-3 col-inline nav-box-item driver " choice.name)}}
+                <div class="machine-driver {{choice.name}}"></div>
+                <p class="driver-name">{{driver-name choice.name}}</p>
+                {{#if choice.genericIcon}}
+                  <p class="text-link text-bold">{{driver-name choice.name}}</p>
+                {{/if}}
+              {{/link-to}}
+            {{else}}
+              <div
+                class={{concat "disabled error-loading-driver mb-20 mt-10 col span-3 col-inline nav-box-item driver " choice.name}}>
+                {{#tooltip-element type="tooltip-basic" model=choice.scriptError tooltipTemplate='tooltip-static' aria-describedby="tooltip-base" tooltipFor="tooltipDriverError"}}
+                  <span class="icon icon-alert"></span>
+                {{/tooltip-element}}
+                <div class="machine-driver {{choice.name}}"></div>
+                <p class="driver-name">{{driver-name choice.name}}</p>
+                {{#if choice.genericIcon}}
+                  <p class="text-link text-bold">{{driver-name choice.name}}</p>
+                {{/if}}
+              </div>
+            {{/unless}}
+          {{/each}}
+        </div>
+      {{/if}}
+    </div>
+    <div class="col span-2 col-inline mt-0 mb-0">
+      <div class="row">
+        <div>
+          <label class="acc-label">{{t 'clusterNew.driverLabels.import'}}</label>
+        </div>
+        {{#each (get providerGroups "importGroup") as |choice|}}
+          {{#link-to (query-params provider=choice.name) class=(concat "mb-20 mt-10 col span-12 col-inline nav-box-item driver " choice.name)}}
             <div class="machine-driver {{choice.name}}"></div>
             <p class="driver-name">{{driver-name choice.name}}</p>
             {{#if choice.genericIcon}}
               <p class="text-link text-bold">{{driver-name choice.name}}</p>
             {{/if}}
           {{/link-to}}
-        {{else}}
-          <div class={{concat "disabled error-loading-driver mb-20 mt-10 col span-3 col-inline nav-box-item driver " choice.name}}>
-              {{#tooltip-element type="tooltip-basic" model=choice.scriptError tooltipTemplate='tooltip-static' aria-describedby="tooltip-base" tooltipFor="tooltipDriverError"}}
-                <span class="icon icon-alert"></span>
-              {{/tooltip-element}}
+        {{/each}}
+      </div>
+
+      <div class="row">
+        <div>
+          <label class="acc-label">{{t 'clusterNew.driverLabels.custom'}}</label>
+        </div>
+        {{#each (get providerGroups "customGroup") as |choice|}}
+          {{#link-to (query-params provider=choice.name) class=(concat "mb-20 mt-10 col span-12 col-inline nav-box-item driver " choice.name)}}
             <div class="machine-driver {{choice.name}}"></div>
             <p class="driver-name">{{driver-name choice.name}}</p>
             {{#if choice.genericIcon}}
               <p class="text-link text-bold">{{driver-name choice.name}}</p>
             {{/if}}
-          </div>
-        {{/unless}}
-      {{/each}}
-    </div>
-
-    <div class="col span-2 col-inline mb-0">
-      <div>
-        <label class="acc-label">{{t 'clusterNew.driverLabels.import'}}</label>
-      </div>
-      {{#each (get providerGroups "importGroup") as |choice|}}
-        {{#link-to (query-params provider=choice.name) class=(concat "mb-20 mt-10 col span-12 col-inline nav-box-item driver " choice.name)}}
-          <div class="machine-driver {{choice.name}}"></div>
-          <p class="driver-name">{{driver-name choice.name}}</p>
-          {{#if choice.genericIcon}}
-            <p class="text-link text-bold">{{driver-name choice.name}}</p>
-          {{/if}}
-        {{/link-to}}
-      {{/each}}
-    </div>
-
-  </div>
-
-  <div class="row nav nav-boxes checked-active inline-form">
-    <div class="col span-8 col-inline mt-0">
-      <div>
-        <label class="acc-label">{{t 'clusterNew.driverLabels.infra'}}</label>
-      </div>
-      {{#each (get providerGroups "rkeGroup") as |choice|}}
-        {{#link-to (query-params provider=choice.name) class=(concat "mb-20 mt-10 col span-3 col-inline nav-box-item driver " choice.name)}}
-          <div class="machine-driver {{if choice.genericIcon 'generic'}} {{choice.name}}"></div>
-          <p class="driver-name">{{driver-name choice.name}}</p>
-        {{/link-to}}
-      {{/each}}
-    </div>
-
-    <div class="col span-2 col-inline mt-0">
-      <div>
-        <label class="acc-label">{{t 'clusterNew.driverLabels.custom'}}</label>
-      </div>
-      {{#each (get providerGroups "customGroup") as |choice|}}
-        {{#link-to (query-params provider=choice.name) class=(concat "mb-20 mt-10 col span-12 col-inline nav-box-item driver " choice.name)}}
-          <div class="machine-driver {{choice.name}}"></div>
-          <p class="driver-name">{{driver-name choice.name}}</p>
-          {{#if choice.genericIcon}}
-            <p class="text-link text-bold">{{driver-name choice.name}}</p>
-          {{/if}}
-        {{/link-to}}
-      {{/each}}
-    </div>
-  </div>
-
-  {{#if (gte providerGroups.externalGroup.length 1)}}
-    <div class="row nav nav-boxes checked-active inline-form">
-      <div class="col span-10 col-inline mb-0">
-        <div>
-          <label class="acc-label">{{t 'clusterNew.driverLabels.external'}}</label>
-        </div>
-        {{#each (get providerGroups "externalGroup") as |choice|}}
-          {{#unless choice.scriptError}}
-            {{#link-to (query-params provider=choice.name) class=(concat "mb-20 mt-10 col span-3 col-inline nav-box-item driver " choice.name)}}
-              <div class="machine-driver {{choice.name}}"></div>
-              <p class="driver-name">{{driver-name choice.name}}</p>
-              {{#if choice.genericIcon}}
-                <p class="text-link text-bold">{{driver-name choice.name}}</p>
-              {{/if}}
-            {{/link-to}}
-          {{else}}
-            <div class={{concat "disabled error-loading-driver mb-20 mt-10 col span-3 col-inline nav-box-item driver " choice.name}}>
-              {{#tooltip-element type="tooltip-basic" model=choice.scriptError tooltipTemplate='tooltip-static' aria-describedby="tooltip-base" tooltipFor="tooltipDriverError"}}
-                <span class="icon icon-alert"></span>
-              {{/tooltip-element}}
-              <div class="machine-driver {{choice.name}}"></div>
-              <p class="driver-name">{{driver-name choice.name}}</p>
-              {{#if choice.genericIcon}}
-                <p class="text-link text-bold">{{driver-name choice.name}}</p>
-              {{/if}}
-            </div>
-          {{/unless}}
+          {{/link-to}}
         {{/each}}
       </div>
     </div>
-  {{/if}}
+  </div>
 {{/unless}}
 
 


### PR DESCRIPTION
Proposed changes
======

Don't show empty row when no provider is selected.

Types of changes
======

- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

From:
![rancher2 kube apps thalesdigital io_g_clusters_add](https://user-images.githubusercontent.com/486876/52976151-9a7efc80-33c8-11e9-89e3-297ade48a3f3.png)

To:
![127 0 0 1_8000_g_clusters_add](https://user-images.githubusercontent.com/486876/52976158-a7035500-33c8-11e9-8537-752fb7b7abbb.png)

