### PR TITLE
Load multi-cluster-app principals so member info is ready

### DIFF
--- a/lib/global-admin/addon/multi-cluster-apps/catalog/launch/route.js
+++ b/lib/global-admin/addon/multi-cluster-apps/catalog/launch/route.js
@@ -113,7 +113,10 @@ export default Route.extend({
         membersPromises.push(this.globalStore.find('principal', id));
       });
 
-      return all(membersPromises);
+      return all(membersPromises).catch((/* err */) => {
+        // we fail here when we can't look up a principal (e.g. logged in as local but its an external auth provider principal)
+        return;
+      });
     }
 
     return;

--- a/lib/global-admin/addon/multi-cluster-apps/catalog/launch/route.js
+++ b/lib/global-admin/addon/multi-cluster-apps/catalog/launch/route.js
@@ -1,5 +1,4 @@
-import EmberObject from '@ember/object';
-import { hash } from 'rsvp';
+import { hash, all } from 'rsvp';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { get, set, setProperties } from '@ember/object';
@@ -89,7 +88,7 @@ export default Route.extend({
           })
       }
 
-      return EmberObject.create({
+      return {
         allTemplates:    this.modelFor(get(this, 'parentRoute')).get('catalog'),
         multiClusterApp: neuApp,
         projects:        results.projects,
@@ -100,8 +99,24 @@ export default Route.extend({
         versionLinks:    links,
         versionsArray:   verArr,
         isClone:         get(params, 'clone') ? true : false,
-      });
+      };
     });
+  },
+
+  afterModel(model/* , transition */) {
+    if (get(model, 'multiClusterApp.id') && get(model, 'multiClusterApp.members.length')) {
+      const membersPromises = [];
+
+      get(model, 'multiClusterApp.members').forEach((member) => {
+        let id = get(member, 'userPrincipalId') || get(member, 'groupPrincipalId');
+
+        membersPromises.push(this.globalStore.find('principal', id));
+      });
+
+      return all(membersPromises);
+    }
+
+    return;
   },
 
   resetController(controller, isExiting/* , transition*/) {

--- a/lib/shared/addon/components/form-members-global-access/template.hbs
+++ b/lib/shared/addon/components/form-members-global-access/template.hbs
@@ -3,6 +3,7 @@
     <label class="acc-label">{{t "generic.member"}}</label>
     {{input-identity
       allowTeams=true
+      allowLocal=true
       action=addAuthorizedPrincipal
       onError=gotError
     }}

--- a/lib/shared/addon/components/form-members-global-access/template.hbs
+++ b/lib/shared/addon/components/form-members-global-access/template.hbs
@@ -36,13 +36,13 @@
                 class="form-control"
                 onchange={{action (mut member.accessType) value="target.value"}}
               >
-                {{#unless (eq member.accessType value)}}
+                {{#unless (eq member.accessType "")}}
                   <option value="" selected=true>
                     {{t "formMembersGlobalAccess.table.prompt"}}
                   </option>
                 {{/unless}}
                 {{#each optionsForAccessType as |choice|}}
-                  <option value="{{choice}}" selected={{eq choice value}}>
+                  <option value="{{choice}}" selected={{eq choice member.accessType}}>
                     {{choice}}
                   </option>
                 {{/each}}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Loads all multi-cluster app member principal info to ensure that we can add/remove members without any errors.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#18242
rancher/rancher#18152

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

An additional bug was found while I was working on the fix for this. The API will not allow you to upgrade an app when a member principal id is included that the current user can't view, e.g. logged in as a local user with github auth turned on and a github user present in the members array. This will be harder to validate until the following bug is resolved. IMO it would be safe to validate rancher/rancher#18242 if the multi-cluster app resource in the ui request when saving includes the new members in its member array. The API will likely error out but the UI is sending the correct data and functioning correctly. 

rancher/rancher#18252
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
