### PR TITLE
Fix aliyun hosted k8s version issue

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-aliyunkcs/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-aliyunkcs/component.js
@@ -12,8 +12,18 @@ const PAGE_SIZE = 50;
 const K8S_1_11_5 = '1.11.5';
 const K8S_1_12_4_1 = '1.12.4-aliyun.1';
 
-const VERSIONS = [K8S_1_11_5];
-const MANAGED_VERSIONS = [K8S_1_12_4_1];
+const VERSIONS = [
+  {
+    value: K8S_1_11_5,
+    label: K8S_1_11_5
+  }
+];
+const MANAGED_VERSIONS = [
+  {
+    value: K8S_1_12_4_1,
+    label: K8S_1_12_4_1
+  }
+];
 const KUBERNETES = 'Kubernetes';
 const MANAGED = 'ManagedKubernetes'
 
@@ -298,6 +308,14 @@ export default Component.extend(ClusterDriver, {
       'config.name':        get(this, 'cluster.name'),
       'config.displayName': get(this, 'cluster.name')
     })
+  }),
+
+  clusterTypeDidChange: observer('config.clusterType', function() {
+    if ( get(this, 'config.clusterType') === KUBERNETES  ) {
+      set(this, 'config.kubernetesVersion', get(VERSIONS, 'firstObject.value'));
+    } else {
+      set(this, 'config.kubernetesVersion', get(MANAGED_VERSIONS, 'firstObject.value'));
+    }
   }),
 
   minNumOfNodes: computed('config.clusterType', function() {

--- a/lib/shared/addon/components/cluster-driver/driver-aliyunkcs/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-aliyunkcs/template.hbs
@@ -72,23 +72,21 @@
         <div class="col span-4">
           <label class="acc-label">{{t "clusterNew.aliyunkcs.version.label"}}</label>
           {{#if (and (eq step 2) (eq config.clusterType "Kubernetes"))}}
-            {{form-versions
-                cluster=cluster
-                editing=(eq mode "edit")
+            {{searchable-select
+                allowCustom=true
                 value=config.kubernetesVersion
-                versions=versionChoices
-                initialVersion=config.version
+                content=versionChoices
             }}
           {{else if (and (eq step 2) (eq config.clusterType "ManagedKubernetes"))}}
-            {{form-versions
-                cluster=cluster
-                editing=(eq mode "edit")
+            {{searchable-select
+                allowCustom=true
                 value=config.kubernetesVersion
-                versions=managedVersionChoices
-                initialVersion=config.version
+                content=managedVersionChoices
             }}
+          {{else if config.kubernetesVersion}}
+            <div>{{config.kubernetesVersion}}</div>
           {{else}}
-            <div>{{config.version}}</div>
+            <div>{{t "generic.default"}}</div>
           {{/if}}
         </div>
         <div class="col span-4">


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
We would like to fall back to use `searchable-select` for the k8s version on Aliyun hosted k8s 
Aliyun doesn't provide the api to get the available versions. 

We will move the aliyun cluster driver ui out of rancher ui as a long time solution.
Now we would like to support user input a k8s version which is not in the list.
So if Aliyun removed the current available k8s versions in Aliyun side. Rancher users can specify to use the new version without upgrading Rancher.

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/17827

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
