### PR TITLE
fix default vmwarevsphere vapp properties

### DIFF
--- a/lib/nodes/addon/components/driver-vmwarevsphere/component.js
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/component.js
@@ -53,8 +53,8 @@ const networksToVappProperties = (networks) => {
   return networks.length === 0
     ? []
     : networks.reduce(networkToVappProperties, [
-      `guestinfo.dns.servers=\${ dns:${ networks[0] } }`,
-      `guestinfo.dns.domains=\${ searchPath:${ networks[0] } }`
+      `guestinfo.dns.servers=\${dns:${ networks[0] }}`,
+      `guestinfo.dns.domains=\${searchPath:${ networks[0] }}`
     ]);
 }
 


### PR DESCRIPTION
Proposed changes
======
Fix default vmwarevsphere vapp properties. vSphere doesn't support spaces in expressions.

Types of changes
======
Bugfix

Linked Issues
======
https://github.com/rancher/rancher/issues/15817
https://github.com/rancher/ui/pull/2308

Further comments
======
Bug appeared in 3df948e9ab71b30533a98fd37bb32ce0cf730455 
