### PR TITLE
Hide GKE field when upgrade form 2.1

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
@@ -8,6 +8,7 @@ import {
 import { sortableNumericSuffix } from 'shared/utils/util';
 import { reject, all } from 'rsvp';
 import { inject as service } from '@ember/service';
+import { equal } from '@ember/object/computed'
 
 const times = [
   {
@@ -92,6 +93,10 @@ export default Component.extend(ClusterDriver, {
   nodeAdvanced:           false,
   diskTypeContent:        diskType,
   scopeConfig:            {},
+  hideNewField:           false,
+
+  isNew:                  equal('mode', 'new'),
+  editing:                equal('mode', 'edit'),
 
   init() {
     this._super(...arguments);
@@ -143,8 +148,13 @@ export default Component.extend(ClusterDriver, {
       })
     } else {
       const {
-        resourceLabels = [], labels = [], taints = []
+        resourceLabels = [], labels = [], taints = [], imageType
       } = config
+
+      if (!imageType) {
+        set(this, 'hideNewField', true)
+      }
+
       let map = {}
 
       if (resourceLabels) {
@@ -406,6 +416,10 @@ export default Component.extend(ClusterDriver, {
     const serviceAccounts = get(this, 'serviceAccounts')
 
     return serviceAccounts
+  }),
+
+  maintenanceWindowChoice: computed('maintenanceWindowTimes.[]', 'config.maintenanceWindow', function() {
+    return get(this, 'maintenanceWindowTimes').findBy('value', get(this, 'config.maintenanceWindow')) || { label: 'Any Time' };
   }),
 
   fetchZones() {

--- a/lib/shared/addon/components/cluster-driver/driver-googlegke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-googlegke/template.hbs
@@ -44,9 +44,10 @@
       <div class="row">
         <div class="col span-6">
           <label class="acc-label">{{t "clusterNew.googlegke.zone.label"}}</label>
-          {{#if editing}}
-            {{config.zone}}
-          {{else}}
+          {{#input-or-display
+               editable=isNew
+               value=config.zone
+          }}
             {{new-select
                 classNames="form-control select-algin-checkbox"
                 optionValuePath="name"
@@ -55,425 +56,455 @@
                 value=config.zone
                 prompt="clusterNew.googlegke.zone.prompt"
                 localizedPrompt=true
-            }}
-          {{/if}}
-        </div>
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.locations.label"}}</label>
-          {{#each locationContent as |location|}}
-            <div class="checkbox">
-              <label>
-                {{input type="checkbox" checked=location.checked}}
-                {{location.name}}
-              </label>
-            </div>
-          {{/each}}
-        </div>
-      </div>
-
-      <div class="row">
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.masterVersion.label"}}</label>
-          {{form-versions
-              cluster=cluster
-              editing=(eq mode "edit")
-              initialVersion=config.masterVersion
-              value=config.masterVersion
-              versions=versionChoices
-          }}
-        </div>
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.clusterIpv4Cidr.label"}}</label>
-          {{input
-              value=config.clusterIpv4Cidr
-              placeholder=(t "clusterNew.googlegke.clusterIpv4Cidr.placeholder")
-              disabled=editing
-          }}
-        </div>
-      </div>
-      <div class="row">
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.alphaFeatures.label"}}</label>
-          <div class="form-control-static">
-            <label class="mr-20 hand">
-              {{radio-button
-                  selection=config.enableAlphaFeature
-                  value=true
-                  disabled=editing
-              }} {{t "generic.enabled"}}
-            </label>
-            <label class="hand">
-              {{radio-button
-                  selection=config.enableAlphaFeature
-                  value=false
-                  disabled=editing
-              }} {{t "generic.disabled"}}
-            </label>
-          </div>
-        </div>
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.legacyAuth.label"}}</label>
-          <div class="form-control-static">
-            <label class="mr-20 hand">
-              {{radio-button
-                  selection=config.enableLegacyAbac
-                  value=true
-                  disabled=editing
-              }} {{t "generic.enabled"}}
-            </label>
-            <label class="hand">
-              {{radio-button
-                  selection=config.enableLegacyAbac
-                  value=false
-                  disabled=editing
-              }} {{t "generic.disabled"}}
-            </label>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.stackDriverLogging.label"}}</label>
-          <div class="form-control-static">
-            <label class="hand mr-20">
-              {{radio-button
-                  selection=config.enableStackdriverLogging
-                  value=true
-                  disabled=editing
-              }} {{t "generic.enabled"}}
-            </label>
-            <label class="hand">
-              {{radio-button
-                  selection=config.enableStackdriverLogging
-                  value=false
-                  disabled=editing
-              }} {{t "generic.disabled"}}
-            </label>
-          </div>
-        </div>
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.stackdriverMonitor.label"}}</label>
-          <div class="form-control-static">
-            <label class="hand mr-20">
-              {{radio-button
-                  selection=config.enableStackdriverMonitoring
-                  value=true
-                  disabled=editing
-              }} {{t "generic.enabled"}}
-            </label>
-            <label class="hand">
-              {{radio-button
-                  selection=config.enableStackdriverMonitoring
-                  value=false
-                  disabled=editing
-              }} {{t "generic.disabled"}}
-            </label>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.dashboard.label"}}</label>
-          <div class="form-control-static">
-            <label class="mr-20 hand">
-              {{radio-button
-                  selection=config.enableKubernetesDashboard
-                  value=true
-                  disabled=editing
-              }} {{t "generic.enabled"}}
-            </label>
-            <label class="hand">
-              {{radio-button
-                  selection=config.enableKubernetesDashboard
-                  value=false
-                  disabled=editing
-              }} {{t "generic.disabled"}}
-            </label>
-          </div>
-        </div>
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.httpLB.label"}}</label>
-          <div class="form-control-static">
-            <label class="hand mr-20">
-              {{radio-button
-                  selection=config.enableHttpLoadBalancing
-                  value=true
-                  disabled=editing
-              }} {{t "generic.enabled"}}
-            </label>
-            <label class="hand">
-              {{radio-button
-                  selection=config.enableHttpLoadBalancing
-                  value=false
-                  disabled=editing
-              }} {{t "generic.disabled"}}
-            </label>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.enableHorizontalPodAutoscaling.label"}}</label>
-          <div class="form-control-static">
-            <label class="hand mr-20">
-              {{radio-button
-                  selection=config.enableHorizontalPodAutoscaling
-                  value=true
-                  disabled=editing
-              }} {{t "generic.enabled"}}
-            </label>
-            <label class="hand">
-              {{radio-button
-                  selection=config.enableHorizontalPodAutoscaling
-                  value=false
-                  disabled=editing
-              }} {{t "generic.disabled"}}
-            </label>
-          </div>
-        </div>
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.maintenanceWindow.label"}}</label>
-          <div class="form-control-static">
-            {{new-select
-                classNames="form-control"
-                content=maintenanceWindowTimes
-                value=config.maintenanceWindow
-            }}
-
-          </div>
-        </div>
-      </div>
-
-      <div class="row">
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.network.label"}}</label>
-          {{searchable-select
-              content=networkContent
-              classNames="form-control"
-              value=config.network
-              optionValuePath="name"
-              optionLabelPath="name"
-              disabled=editing
-          }}
-        </div>
-
-        {{#if (gt subNetworkContent.length 0)}}
-          <div class="col span-6">
-            <label class="acc-label">{{t "clusterNew.googlegke.subNetwork.label"}}</label>
-            {{searchable-select
-                content=subNetworkContent
-                classNames="form-control"
-                value=config.subNetwork
                 disabled=editing
             }}
+          {{/input-or-display}}
+        </div>
+        {{#unless hideNewField}}
+          <div class="col span-6">
+            <label class="acc-label">{{t "clusterNew.googlegke.locations.label"}}</label>
+            {{#each locationContent as |location|}}
+              <div class="checkbox">
+                <label class={{if editing "text-muted"}}>
+                  {{input type="checkbox" checked=location.checked disabled=editing}}
+                  {{location.name}}
+                </label>
+              </div>
+            {{/each}}
           </div>
-        {{/if}}
+        {{/unless}}
       </div>
 
-      {{#advanced-section advanced=clusterAdvanced}}
-        <h4 class="mt-20 mb-10">{{t "clusterNew.googlegke.header.iPAllocationPolicy"}}</h4>
-        <hr/>
+      {{#unless hideNewField}}
         <div class="row">
           <div class="col span-6">
-            <label class="acc-label">{{t "clusterNew.googlegke.useIpAliases.label"}}</label>
-            <div class="form-control-static">
-              <label class="hand mr-20">
-                {{radio-button
-                    selection=config.useIpAliases
-                    value=true
-                    disabled=editing
-                }}
-                {{t "generic.yes"}}
-              </label>
-              <label class="hand">
-                {{radio-button
-                    selection=config.useIpAliases
-                    value=false
-                    disabled=editing
-                }}
-                {{t "generic.no"}}
-              </label>
-            </div>
+            <label class="acc-label">{{t "clusterNew.googlegke.masterVersion.label"}}</label>
+            {{#input-or-display
+                 editable=isNew
+                 value=config.masterVersion
+            }}
+              {{form-versions
+                  cluster=cluster
+                  disabled=editing
+                  initialVersion=config.masterVersion
+                  value=config.masterVersion
+                  versions=versionChoices
+              }}
+            {{/input-or-display}}
           </div>
-          {{#if config.useIpAliases}}
-            <div class="col span-6">
-              <label class="acc-label">{{t "clusterNew.googlegke.ipPolicyCreateSubnetwork.label"}}</label>
-              <div class="form-control-static">
-                <label class="hand mr-20">
-                  {{radio-button
-                      selection=config.ipPolicyCreateSubnetwork
-                      value=true
-                      disabled=editing
-                  }}
-                  {{t "generic.enabled"}}
-                </label>
-                <label class="hand" class={{concat (if (eq secondaryIpRangeContent.length 0) "text-muted") " hand"}}>
-                  {{radio-button
-                      selection=config.ipPolicyCreateSubnetwork
-                      value=false
-                      disabled=(or editing (eq secondaryIpRangeContent.length 0))
-                  }}
-                  {{t "generic.disabled"}}
-                </label>
-              </div>
-            </div>
-          {{/if}}
-        </div>
-        {{#if config.useIpAliases}}
-          {{#if (and config.ipPolicyCreateSubnetwork config.useIpAliases)}}
-            <div class="row">
-              <div class="col span-6">
-                <label class="acc-label">{{t "clusterNew.googlegke.ipPolicyClusterIpv4CidrBlock.label"}}</label>
-                {{input
-                    value=config.ipPolicyClusterIpv4CidrBlock
-                    placeholder=(t "clusterNew.googlegke.ipPolicyClusterIpv4CidrBlock.placeholder")
-                    disabled=editing
-                }}
-              </div>
-              <div class="col span-6">
-                <label class="acc-label">{{t "clusterNew.googlegke.ipPolicyServicesIpv4CidrBlock.label"}}</label>
-                {{input
-                    value=config.ipPolicyServicesIpv4CidrBlock
-                    placeholder=(t "clusterNew.googlegke.ipPolicyServicesIpv4CidrBlock.placeholder")
-                    disabled=editing
-                }}
-              </div>
-            </div>
-          {{else}}
-            <div class="row">
-              <div class="col span-6">
-                <label class="acc-label">{{t "clusterNew.googlegke.ipPolicyClusterSecondaryRangeName.label"}}</label>
-                {{searchable-select
-                    content=secondaryIpRangeContent
-                    classNames="form-control"
-                    value=config.ipPolicyClusterSecondaryRangeName
-                    disabled=editing
-                }}
-              </div>
-              <div class="col span-6">
-                <label class="acc-label">{{t "clusterNew.googlegke.ipPolicyServicesSecondaryRangeName.label"}}</label>
-                {{searchable-select
-                    content=secondaryIpRangeContent
-                    classNames="form-control"
-                    value=config.ipPolicyServicesSecondaryRangeName
-                    disabled=editing
-                }}
-              </div>
-            </div>
-          {{/if}}
-        {{/if}}
-
-        <h4 class="mt-20 mb-10">{{t "clusterNew.googlegke.header.privateCluster"}}</h4>
-        <hr/>
-        <div class="row">
           <div class="col span-6">
-            <label class="acc-label">{{t "clusterNew.googlegke.enablePrivateNodes.label"}}</label>
-            <div class="form-control-static">
-              <label class={{concat (if (eq config.useIpAliases false) "text-muted") " hand mr-20"}}>
-                {{radio-button
-                    selection=config.enablePrivateNodes
-                    value=true
-                    disabled=(or editing (eq config.useIpAliases false))
-                }}
-                {{t "generic.enabled"}}
-              </label>
-              <label class="hand">
-                {{radio-button
-                    selection=config.enablePrivateNodes
-                    value=false
-                    disabled=editing
-                }}
-                {{t "generic.disabled"}}
-              </label>
-            </div>
-          </div>
-          {{#if config.enablePrivateNodes}}
-            <div class="col span-6">
-              <label class="acc-label">{{t "clusterNew.googlegke.enablePrivateEndpoint.label"}}</label>
-              <div class="form-control-static">
-                <label class="hand mr-20">
-                  {{radio-button
-                      selection=config.enablePrivateEndpoint
-                      value=true
-                      disabled=editing
-                  }}
-                  {{t "generic.enabled"}}
-                </label>
-                <label class="hand">
-                  {{radio-button
-                      selection=config.enablePrivateEndpoint
-                      value=false
-                      disabled=editing
-                  }}
-                  {{t "generic.disabled"}}
-                </label>
-              </div>
-            </div>
-          {{/if}}
-        </div>
-        {{#if config.enablePrivateNodes}}
-          <div class="row">
-            <div class="col span-6">
-              <label class="acc-label">{{t "clusterNew.googlegke.masterIpv4CidrBlock.label"}}</label>
+            <label class="acc-label">{{t "clusterNew.googlegke.clusterIpv4Cidr.label"}}</label>
+            {{#input-or-display
+                 editable=isNew
+                 value=config.clusterIpv4Cidr
+            }}
               {{input
-                  value=config.masterIpv4CidrBlock
-                  placeholder=(t "clusterNew.googlegke.masterIpv4CidrBlock.placeholder")
+                  value=config.clusterIpv4Cidr
+                  placeholder=(t "clusterNew.googlegke.clusterIpv4Cidr.placeholder")
                   disabled=editing
               }}
-            </div>
+            {{/input-or-display}}
           </div>
-        {{/if}}
-
-        <h4 class="mt-20 mb-10">{{t "clusterNew.googlegke.header.masterAuthorizedNetwork"}}</h4>
-        <hr/>
+        </div>
         <div class="row">
           <div class="col span-6">
-            <label class="acc-label">{{t "clusterNew.googlegke.enableMasterAuthorizedNetwork.label"}}</label>
+            <label class="acc-label">{{t "clusterNew.googlegke.alphaFeatures.label"}}</label>
             <div class="form-control-static">
-              <label class="hand mr-20">
+              <label class={{concat (if editing "text-muted") " mr-20 hand"}}>
                 {{radio-button
-                    selection=config.enableMasterAuthorizedNetwork
+                    selection=config.enableAlphaFeature
                     value=true
                     disabled=editing
-                }}
-                {{t "generic.enabled"}}
+                }} {{t "generic.enabled"}}
               </label>
-              <label class="hand">
+              <label class={{concat (if editing "text-muted") " hand"}}>
                 {{radio-button
-                    selection=config.enableMasterAuthorizedNetwork
+                    selection=config.enableAlphaFeature
                     value=false
                     disabled=editing
-                }}
-                {{t "generic.disabled"}}
+                }} {{t "generic.disabled"}}
               </label>
             </div>
           </div>
-          {{#if config.enableMasterAuthorizedNetwork}}
-            <div class="col span-6">
-              {{form-value-array
-                  initialValues=config.masterAuthorizedNetworkCidrBlocks
-                  editing=(or (eq mode "edit") (eq mode "new"))
-                  valueLabel="clusterNew.googlegke.masterAuthorizedNetworkCidrBlocks.label"
-                  valuePlaceholder="clusterNew.googlegke.masterAuthorizedNetworkCidrBlocks.placeholder"
-                  addActionLabel="clusterNew.googlegke.masterAuthorizedNetworkCidrBlocks.addActionLabel"
-                  changed=(action "updateNameservers")
-                  cannotAdd=(gt config.masterAuthorizedNetworkCidrBlocks.length 10)
+          <div class="col span-6">
+            <label class="acc-label">{{t "clusterNew.googlegke.legacyAuth.label"}}</label>
+            <div class="form-control-static">
+              <label class={{concat (if editing "text-muted") " mr-20 hand"}}>
+                {{radio-button
+                    selection=config.enableLegacyAbac
+                    value=true
+                    disabled=editing
+                }} {{t "generic.enabled"}}
+              </label>
+              <label class={{concat (if editing "text-muted") " hand"}}>
+                {{radio-button
+                    selection=config.enableLegacyAbac
+                    value=false
+                    disabled=editing
+                }} {{t "generic.disabled"}}
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col span-6">
+            <label class="acc-label">{{t "clusterNew.googlegke.stackDriverLogging.label"}}</label>
+            <div class="form-control-static">
+              <label class={{concat (if editing "text-muted") " mr-20 hand"}}>
+                {{radio-button
+                    selection=config.enableStackdriverLogging
+                    value=true
+                    disabled=editing
+                }} {{t "generic.enabled"}}
+              </label>
+              <label class={{concat (if editing "text-muted") " hand"}}>
+                {{radio-button
+                    selection=config.enableStackdriverLogging
+                    value=false
+                    disabled=editing
+                }} {{t "generic.disabled"}}
+              </label>
+            </div>
+          </div>
+          <div class="col span-6">
+            <label class="acc-label">{{t "clusterNew.googlegke.stackdriverMonitor.label"}}</label>
+            <div class="form-control-static">
+              <label class={{concat (if editing "text-muted") " mr-20 hand"}}>
+                {{radio-button
+                    selection=config.enableStackdriverMonitoring
+                    value=true
+                    disabled=editing
+                }} {{t "generic.enabled"}}
+              </label>
+              <label class={{concat (if editing "text-muted") " hand"}}>
+                {{radio-button
+                    selection=config.enableStackdriverMonitoring
+                    value=false
+                    disabled=editing
+                }} {{t "generic.disabled"}}
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col span-6">
+            <label class="acc-label">{{t "clusterNew.googlegke.dashboard.label"}}</label>
+            <div class="form-control-static">
+              <label class={{concat (if editing "text-muted") " mr-20 hand"}}>
+                {{radio-button
+                    selection=config.enableKubernetesDashboard
+                    value=true
+                    disabled=editing
+                }} {{t "generic.enabled"}}
+              </label>
+              <label class={{concat (if editing "text-muted") " hand"}}>
+                {{radio-button
+                    selection=config.enableKubernetesDashboard
+                    value=false
+                    disabled=editing
+                }} {{t "generic.disabled"}}
+              </label>
+            </div>
+          </div>
+          <div class="col span-6">
+            <label class="acc-label">{{t "clusterNew.googlegke.httpLB.label"}}</label>
+            <div class="form-control-static">
+              <label class={{concat (if editing "text-muted") " mr-20 hand"}}>
+                {{radio-button
+                    selection=config.enableHttpLoadBalancing
+                    value=true
+                    disabled=editing
+                }} {{t "generic.enabled"}}
+              </label>
+              <label class={{concat (if editing "text-muted") " hand"}}>
+                {{radio-button
+                    selection=config.enableHttpLoadBalancing
+                    value=false
+                    disabled=editing
+                }} {{t "generic.disabled"}}
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col span-6">
+            <label class="acc-label">{{t "clusterNew.googlegke.enableHorizontalPodAutoscaling.label"}}</label>
+            <div class="form-control-static">
+              <label class={{concat (if editing "text-muted") " mr-20 hand"}}>
+                {{radio-button
+                    selection=config.enableHorizontalPodAutoscaling
+                    value=true
+                    disabled=editing
+                }} {{t "generic.enabled"}}
+              </label>
+              <label class={{concat (if editing "text-muted") " hand"}}>
+                {{radio-button
+                    selection=config.enableHorizontalPodAutoscaling
+                    value=false
+                    disabled=editing
+                }} {{t "generic.disabled"}}
+              </label>
+            </div>
+          </div>
+          <div class="col span-6">
+            <label class="acc-label">{{t "clusterNew.googlegke.maintenanceWindow.label"}}</label>
+            <div class="form-control-static">
+              {{#input-or-display
+                   editable=isNew
+                   value=maintenanceWindowChoice.label
               }}
+                {{new-select
+                    classNames="form-control"
+                    content=maintenanceWindowTimes
+                    value=config.maintenanceWindow
+                    disabled=editing
+                }}
+              {{/input-or-display}}
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col span-6">
+            <label class="acc-label">{{t "clusterNew.googlegke.network.label"}}</label>
+            {{#input-or-display
+                 editable=isNew
+                 value=config.network
+            }}
+              {{searchable-select
+                  content=networkContent
+                  classNames="form-control"
+                  value=config.network
+                  optionValuePath="name"
+                  optionLabelPath="name"
+                  readOnly=editing
+              }}
+            {{/input-or-display}}
+          </div>
+
+          {{#if (gt subNetworkContent.length 0)}}
+            <div class="col span-6">
+              <label class="acc-label">{{t "clusterNew.googlegke.subNetwork.label"}}</label>
+              {{#input-or-display
+                   editable=isNew
+                   value=config.subNetwork
+              }}
+                {{searchable-select
+                    content=subNetworkContent
+                    classNames="form-control"
+                    value=config.subNetwork
+                    readOnly=editing
+                }}
+              {{/input-or-display}}
             </div>
           {{/if}}
         </div>
-      {{/advanced-section}}
 
-      <div class="row mt-20">
-        <div class="col span-12 mb-0">
-          <label class="acc-label">{{t "clusterNew.googlegke.clusterLabels.label"}}</label>
-          {{form-key-value
-              initialMap=resourceLabels
-              changed=(action "setLabels")
-              addActionLabel="clusterNew.googlegke.nodeLabels.addAction"
-          }}
+        {{#advanced-section advanced=clusterAdvanced}}
+          <h4 class="mt-20 mb-10">{{t "clusterNew.googlegke.header.iPAllocationPolicy"}}</h4>
+          <hr/>
+          <div class="row">
+            <div class="col span-6">
+              <label class="acc-label">{{t "clusterNew.googlegke.useIpAliases.label"}}</label>
+              <div class="form-control-static">
+                <label class={{concat (if editing "text-muted") " mr-20 hand"}}>
+                  {{radio-button
+                      selection=config.useIpAliases
+                      value=true
+                      disabled=editing
+                  }}
+                  {{t "generic.yes"}}
+                </label>
+                <label class={{concat (if editing "text-muted") " hand"}}>
+                  {{radio-button
+                      selection=config.useIpAliases
+                      value=false
+                      disabled=editing
+                  }}
+                  {{t "generic.no"}}
+                </label>
+              </div>
+            </div>
+            {{#if config.useIpAliases}}
+              <div class="col span-6">
+                <label class="acc-label">{{t "clusterNew.googlegke.ipPolicyCreateSubnetwork.label"}}</label>
+                <div class="form-control-static">
+                  <label class={{concat (if editing "text-muted") " mr-20 hand"}}>
+                    {{radio-button
+                        selection=config.ipPolicyCreateSubnetwork
+                        value=true
+                        disabled=editing
+                    }}
+                    {{t "generic.enabled"}}
+                  </label>
+                  <label class={{concat (if editing "text-muted") " hand"}} class={{concat (if (eq secondaryIpRangeContent.length 0) "text-muted") " hand"}}>
+                    {{radio-button
+                        selection=config.ipPolicyCreateSubnetwork
+                        value=false
+                        disabled=(or editing (eq secondaryIpRangeContent.length 0))
+                    }}
+                    {{t "generic.disabled"}}
+                  </label>
+                </div>
+              </div>
+            {{/if}}
+          </div>
+          {{#if config.useIpAliases}}
+            {{#if (and config.ipPolicyCreateSubnetwork config.useIpAliases)}}
+              <div class="row">
+                <div class="col span-6">
+                  <label class="acc-label">{{t "clusterNew.googlegke.ipPolicyClusterIpv4CidrBlock.label"}}</label>
+                  {{input
+                      value=config.ipPolicyClusterIpv4CidrBlock
+                      placeholder=(t "clusterNew.googlegke.ipPolicyClusterIpv4CidrBlock.placeholder")
+                      disabled=editing
+                  }}
+                </div>
+                <div class="col span-6">
+                  <label class="acc-label">{{t "clusterNew.googlegke.ipPolicyServicesIpv4CidrBlock.label"}}</label>
+                  {{input
+                      value=config.ipPolicyServicesIpv4CidrBlock
+                      placeholder=(t "clusterNew.googlegke.ipPolicyServicesIpv4CidrBlock.placeholder")
+                      disabled=editing
+                  }}
+                </div>
+              </div>
+            {{else}}
+              <div class="row">
+                <div class="col span-6">
+                  <label class="acc-label">{{t "clusterNew.googlegke.ipPolicyClusterSecondaryRangeName.label"}}</label>
+                  {{searchable-select
+                      content=secondaryIpRangeContent
+                      classNames="form-control"
+                      value=config.ipPolicyClusterSecondaryRangeName
+                      disabled=editing
+                  }}
+                </div>
+                <div class="col span-6">
+                  <label class="acc-label">{{t "clusterNew.googlegke.ipPolicyServicesSecondaryRangeName.label"}}</label>
+                  {{searchable-select
+                      content=secondaryIpRangeContent
+                      classNames="form-control"
+                      value=config.ipPolicyServicesSecondaryRangeName
+                      disabled=editing
+                  }}
+                </div>
+              </div>
+            {{/if}}
+          {{/if}}
+
+          <h4 class="mt-20 mb-10">{{t "clusterNew.googlegke.header.privateCluster"}}</h4>
+          <hr/>
+          <div class="row">
+            <div class="col span-6">
+              <label class="acc-label">{{t "clusterNew.googlegke.enablePrivateNodes.label"}}</label>
+              <div class="form-control-static">
+                <label class={{concat (if (eq config.useIpAliases false) "text-muted") " hand mr-20"}}>
+                  {{radio-button
+                      selection=config.enablePrivateNodes
+                      value=true
+                      disabled=(or editing (eq config.useIpAliases false))
+                  }}
+                  {{t "generic.enabled"}}
+                </label>
+                <label class={{concat (if editing "text-muted") " hand"}}>
+                  {{radio-button
+                      selection=config.enablePrivateNodes
+                      value=false
+                      disabled=editing
+                  }}
+                  {{t "generic.disabled"}}
+                </label>
+              </div>
+            </div>
+            {{#if config.enablePrivateNodes}}
+              <div class="col span-6">
+                <label class="acc-label">{{t "clusterNew.googlegke.enablePrivateEndpoint.label"}}</label>
+                <div class="form-control-static">
+                  <label class={{concat (if editing "text-muted") " mr-20 hand"}}>
+                    {{radio-button
+                        selection=config.enablePrivateEndpoint
+                        value=true
+                        disabled=editing
+                    }}
+                    {{t "generic.enabled"}}
+                  </label>
+                  <label class={{concat (if editing "text-muted") " hand"}}>
+                    {{radio-button
+                        selection=config.enablePrivateEndpoint
+                        value=false
+                        disabled=editing
+                    }}
+                    {{t "generic.disabled"}}
+                  </label>
+                </div>
+              </div>
+            {{/if}}
+          </div>
+          {{#if config.enablePrivateNodes}}
+            <div class="row">
+              <div class="col span-6">
+                <label class="acc-label">{{t "clusterNew.googlegke.masterIpv4CidrBlock.label"}}</label>
+                {{input
+                    value=config.masterIpv4CidrBlock
+                    placeholder=(t "clusterNew.googlegke.masterIpv4CidrBlock.placeholder")
+                    disabled=editing
+                }}
+              </div>
+            </div>
+          {{/if}}
+
+          <h4 class="mt-20 mb-10">{{t "clusterNew.googlegke.header.masterAuthorizedNetwork"}}</h4>
+          <hr/>
+          <div class="row">
+            <div class="col span-6">
+              <label class="acc-label">{{t "clusterNew.googlegke.enableMasterAuthorizedNetwork.label"}}</label>
+              <div class="form-control-static">
+                <label class={{concat (if editing "text-muted") " mr-20 hand"}}>
+                  {{radio-button
+                      selection=config.enableMasterAuthorizedNetwork
+                      value=true
+                      disabled=editing
+                  }}
+                  {{t "generic.enabled"}}
+                </label>
+                <label class={{concat (if editing "text-muted") " hand"}}>
+                  {{radio-button
+                      selection=config.enableMasterAuthorizedNetwork
+                      value=false
+                      disabled=editing
+                  }}
+                  {{t "generic.disabled"}}
+                </label>
+              </div>
+            </div>
+            {{#if config.enableMasterAuthorizedNetwork}}
+              <div class="col span-6">
+                {{form-value-array
+                    initialValues=config.masterAuthorizedNetworkCidrBlocks
+                    editing=(or (eq mode "edit") (eq mode "new"))
+                    valueLabel="clusterNew.googlegke.masterAuthorizedNetworkCidrBlocks.label"
+                    valuePlaceholder="clusterNew.googlegke.masterAuthorizedNetworkCidrBlocks.placeholder"
+                    addActionLabel="clusterNew.googlegke.masterAuthorizedNetworkCidrBlocks.addActionLabel"
+                    changed=(action "updateNameservers")
+                    cannotAdd=(gt config.masterAuthorizedNetworkCidrBlocks.length 10)
+                }}
+              </div>
+            {{/if}}
+          </div>
+        {{/advanced-section}}
+
+        <div class="row mt-20">
+          <div class="col span-12 mb-0">
+            <label class="acc-label">{{t "clusterNew.googlegke.clusterLabels.label"}}</label>
+            {{form-key-value
+                initialMap=resourceLabels
+                changed=(action "setLabels")
+                addActionLabel="clusterNew.googlegke.nodeLabels.addAction"
+                editing=isNew
+            }}
+          </div>
         </div>
-      </div>
+      {{/unless}}
     {{/accordion-list-item}}
 
     {{#accordion-list-item
@@ -490,18 +521,6 @@
           <label class="acc-label">{{t "clusterNew.googlegke.nodeCount.label"}}</label>
           {{input-number min=1 value=config.nodeCount}}
         </div>
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.imageType.label"}}</label>
-          {{searchable-select
-              content=imageTypeContent
-              classNames="form-control"
-              value=config.imageType
-              localizedLabel=true
-          }}
-        </div>
-      </div>
-
-      <div class="row">
         <div class="col span-6">
           <label class="acc-label">{{t "clusterNew.googlegke.machineType.label"}}</label>
           {{#if editing}}
@@ -520,118 +539,154 @@
             }}
           {{/if}}
         </div>
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.diskType.label"}}</label>
-          {{searchable-select
-              content=diskTypeContent
-              classNames="form-control"
-              value=config.diskType
-              localizedLabel=true
-          }}
-        </div>
       </div>
+
+      {{#unless hideNewField}}
+        <div class="row">
+          <div class="col span-6">
+            <label class="acc-label">{{t "clusterNew.googlegke.imageType.label"}}</label>
+            {{#input-or-display
+                 editable=isNew
+                 value=config.imageType
+            }}
+              {{searchable-select
+                  content=imageTypeContent
+                  classNames="form-control"
+                  value=config.imageType
+                  localizedLabel=true
+                  readOnly=editing
+              }}
+            {{/input-or-display}}
+          </div>
+          <div class="col span-6">
+            <label class="acc-label">{{t "clusterNew.googlegke.diskType.label"}}</label>
+            {{#input-or-display
+                 editable=isNew
+                 value=config.diskType
+            }}
+              {{searchable-select
+                  content=diskTypeContent
+                  classNames="form-control"
+                  value=config.diskType
+                  localizedLabel=true
+                  readOnly=editing
+              }}
+            {{/input-or-display}}
+          </div>
+        </div>
+      {{/unless}}
 
       <div class="row">
         <div class="col span-6">
           <label class="acc-label">{{t "clusterNew.googlegke.diskSizeGb.label"}}</label>
           <div class="input-group">
             {{#if editing}}
-              {{config.diskSizeGb}}{{t "generic.gigabyte"}}
+              {{config.diskSizeGb}} {{t "generic.gigabyte"}}
             {{else}}
               {{input-number min=1 value=config.diskSizeGb}}
               <span class="input-group-addon bg-default">{{t "generic.gigabyte"}}</span>
             {{/if}}
           </div>
         </div>
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.localSsdCount.label"}}</label>
-          {{input-integer
-              min=0
-              value=config.localSsdCount
-          }}
-        </div>
+        {{#unless hideNewField}}
+          <div class="col span-6">
+            <label class="acc-label">{{t "clusterNew.googlegke.localSsdCount.label"}}</label>
+            <div class="input-group">
+              {{#if editing}}
+                {{config.localSsdCount}} {{t "generic.gigabyte"}}
+              {{else}}
+                {{input-integer
+                    min=0
+                    value=config.localSsdCount
+                }}
+                <span class="input-group-addon bg-default">{{t "generic.gigabyte"}}</span>
+              {{/if}}
+            </div>
+          </div>
+        {{/unless}}
       </div>
 
-      <div class="row">
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.preemptible.label"}}</label>
-          <div class="form-control-static">
-            <label class="hand mr-20">
-              {{radio-button
-                  selection=config.preemptible
-                  value=true
-                  disabled=editing
-              }}
-              {{t "generic.enabled"}}
-            </label>
-            <label class="hand">
-              {{radio-button
-                  selection=config.preemptible
-                  value=false
-                  disabled=editing
-              }}
-              {{t "generic.disabled"}}
-            </label>
+      {{#unless hideNewField}}
+        <div class="row">
+          <div class="col span-6">
+            <label class="acc-label">{{t "clusterNew.googlegke.preemptible.label"}}</label>
+            <div class="form-control-static">
+              <label class={{concat (if editing "text-muted") " mr-20 hand"}}>
+                {{radio-button
+                    selection=config.preemptible
+                    value=true
+                    disabled=editing
+                }}
+                {{t "generic.enabled"}}
+              </label>
+              <label class={{concat (if editing "text-muted") " hand"}}>
+                {{radio-button
+                    selection=config.preemptible
+                    value=false
+                    disabled=editing
+                }}
+                {{t "generic.disabled"}}
+              </label>
+            </div>
+          </div>
+          <div class="col span-6">
+            <label class="acc-label">{{t "clusterNew.googlegke.enableAutoUpgrade.label"}}</label>
+            <div class="form-control-static">
+              <label class={{concat (if editing "text-muted") " mr-20 hand"}}>
+                {{radio-button
+                    selection=config.enableAutoUpgrade
+                    value=true
+                    disabled=editing
+                }}
+                {{t "generic.enabled"}}
+              </label>
+              <label class={{concat (if editing "text-muted") " hand"}}>
+                {{radio-button
+                    selection=config.enableAutoUpgrade
+                    value=false
+                    disabled=editing
+                }}
+                {{t "generic.disabled"}}
+              </label>
+            </div>
           </div>
         </div>
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.enableAutoUpgrade.label"}}</label>
-          <div class="form-control-static">
-            <label class="hand mr-20">
-              {{radio-button
-                  selection=config.enableAutoUpgrade
-                  value=true
-                  disabled=editing
-              }}
-              {{t "generic.enabled"}}
-            </label>
-            <label class="hand">
-              {{radio-button
-                  selection=config.enableAutoUpgrade
-                  value=false
-                  disabled=editing
-              }}
-              {{t "generic.disabled"}}
-            </label>
-          </div>
-        </div>
-      </div>
 
-      <div class="row">
-        <div class="col span-6">
-          <label class="acc-label">{{t "clusterNew.googlegke.enableAutoRepair.label"}}</label>
-          <div class="form-control-static">
-            <label class="hand mr-20">
-              {{radio-button
-                  selection=config.enableAutoRepair
-                  value=true
-                  disabled=editing
-              }}
-              {{t "generic.enabled"}}
-            </label>
-            <label class="hand">
-              {{radio-button
-                  selection=config.enableAutoRepair
-                  value=false
-                  disabled=editing
-              }}
-              {{t "generic.disabled"}}
-            </label>
+        <div class="row">
+          <div class="col span-6">
+            <label class="acc-label">{{t "clusterNew.googlegke.enableAutoRepair.label"}}</label>
+            <div class="form-control-static">
+              <label class={{concat (if editing "text-muted") " mr-20 hand"}}>
+                {{radio-button
+                    selection=config.enableAutoRepair
+                    value=true
+                    disabled=editing
+                }}
+                {{t "generic.enabled"}}
+              </label>
+              <label class={{concat (if editing "text-muted") " hand"}}>
+                {{radio-button
+                    selection=config.enableAutoRepair
+                    value=false
+                    disabled=editing
+                }}
+                {{t "generic.disabled"}}
+              </label>
+            </div>
           </div>
         </div>
-      </div>
-
+      {{/unless}}
+      
       <h4 class="mt-20 mb-10">{{t "clusterNew.googlegke.header.nodePoolAutoscaling"}}</h4>
       <hr/>
       <div class="row">
         <div class="col span-4">
           <label class="acc-label">{{t "clusterNew.googlegke.enableNodepoolAutoscaling.label"}}</label>
           <div class="form-control-static">
-            <label class="hand mr-20">
+            <label class="mr-20 hand">
               {{radio-button
                   selection=config.enableNodepoolAutoscaling
                   value=true
-                  disabled=editing
               }}
               {{t "generic.enabled"}}
             </label>
@@ -639,7 +694,6 @@
               {{radio-button
                   selection=config.enableNodepoolAutoscaling
                   value=false
-                  disabled=editing
               }}
               {{t "generic.disabled"}}
             </label>
@@ -657,22 +711,24 @@
         {{/if}}
       </div>
 
-      {{form-gke-taints
-          taints=taints
-          editable=(eq mode "new")
-      }}
+      {{#unless hideNewField}}
+        {{form-gke-taints
+            taints=taints
+            editable=(eq mode "new")
+        }}
 
-      <div class="row mt-20">
-        <div class="col span-12 mb-0">
-          <label class="acc-label">{{t "clusterNew.googlegke.nodeLabels.label"}}</label>
-          {{form-key-value
-              initialMap=labels
-              changed=(action "setNodeLabels")
-              addActionLabel="clusterNew.googlegke.nodeLabels.addAction"
-              editing=(eq mode "new")
-          }}
+        <div class="row mt-20">
+          <div class="col span-12 mb-0">
+            <label class="acc-label">{{t "clusterNew.googlegke.nodeLabels.label"}}</label>
+            {{form-key-value
+                initialMap=labels
+                changed=(action "setNodeLabels")
+                addActionLabel="clusterNew.googlegke.nodeLabels.addAction"
+                editing=(eq mode "new")
+            }}
+          </div>
         </div>
-      </div>
+      {{/unless}}
     {{/accordion-list-item}}
 
     {{#if (eq mode "new")}}

--- a/lib/shared/addon/components/form-versions/template.hbs
+++ b/lib/shared/addon/components/form-versions/template.hbs
@@ -1,4 +1,5 @@
 {{new-select
     content=versionChoices
     value=value
+    disabled=disabled
 }}


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
kontainer engine framework doesn't support sync configuration back from providers.
For example, if you created a GKE cluster in Rancher UI. Then you go to the GKE console and update a configuration there.
In Rancher, the value for the configuration is still the old one as Rancher will not fetch the current configuration from GKE.

As they are newly added fields and they are not editable in Rancher UI, we can hide those fields in Rancher UI as we don't know the correct values for them.
![image](https://user-images.githubusercontent.com/18737885/53562546-93a47680-3b8c-11e9-8896-18e42e013339.png)

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======


- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

https://github.com/rancher/rancher/issues/18464

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
