### PR TITLE
All users to select project or mc app on gdns entry edit

### DIFF
--- a/app/models/globaldns.js
+++ b/app/models/globaldns.js
@@ -2,6 +2,7 @@ import Resource from '@rancher/ember-api-store/models/resource';
 import { get, set, computed, setProperties } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { reference } from '@rancher/ember-api-store/utils/denormalize';
+import { next } from '@ember/runloop';
 
 export default Resource.extend({
   router: service(),
@@ -44,14 +45,16 @@ export default Resource.extend({
       let match = allProjects.findBy('id', projectId);
 
       if (match) {
-        set(match, 'accessible', true);
+        next(() => {
+          set(match, 'accessible', true);
+        });
 
         myProjects.pushObject(match);
       } else {
         myProjects.pushObject({
           id:         projectId,
           accessible: false,
-        })
+        });
       }
     });
 

--- a/lib/global-admin/addon/components/global-dns-entry-row/template.hbs
+++ b/lib/global-admin/addon/components/global-dns-entry-row/template.hbs
@@ -42,8 +42,8 @@
       </div>
     {{/each}}
   {{else}}
-    {{#each entry.linkedProjects as |project|}}
-      {{#if project.accessible}}
+    {{#each linkedProjects as |project|}}
+      {{#if (and project.cluster.displayName project.displayName)}}
         {{#link-to-external
            "authenticated.project"
            project.id

--- a/lib/global-admin/addon/global-dns/entries/new/controller.js
+++ b/lib/global-admin/addon/global-dns/entries/new/controller.js
@@ -1,5 +1,7 @@
 import Controller from '@ember/controller';
-import { get, computed, set, setProperties } from '@ember/object';
+import {
+  get, computed, set, setProperties, observer
+} from '@ember/object';
 import { inject as service } from '@ember/service';
 import ViewNewEdit from 'shared/mixins/view-new-edit';
 import { alias } from '@ember/object/computed';
@@ -33,6 +35,7 @@ export default Controller.extend(ViewNewEdit, {
   projectsToAddOnUpgrade:    null,
   projectsToRemoveOnUpgrade: null,
   errors:                    null,
+  originalModel:             null,
   recordType:                'multi',
 
   headers:                   HEADERS,
@@ -44,29 +47,32 @@ export default Controller.extend(ViewNewEdit, {
       const select          = event.target;
       const options         = Array.prototype.slice.call(select.options, 0);
       const selectedOptions = [];
-      let { projectsToAddOnUpgrade, projectsToRemoveOnUpgrade } = this;
-      let { isEdit } = this;
-      let current = get(this, 'primaryResource.projectIds') || [];
+      let current           = get(this, 'primaryResource.projectIds') || [];
+
+      let {
+        projectsToAddOnUpgrade, projectsToRemoveOnUpgrade, orignalModel = {}
+      }                                                                 = this;
+      let { isEdit }                                                    = this;
 
       options.filter((project) => {
         if (project.selected) {
           if (isEdit) {
             if (projectsToAddOnUpgrade && !projectsToAddOnUpgrade.includes(project.value)) {
-              projectsToAddOnUpgrade.push(project.value);
+              projectsToAddOnUpgrade.pushObject(project.value);
             } else {
               projectsToAddOnUpgrade = [project.value];
             }
           }
 
-          selectedOptions.push(project.value);
+          selectedOptions.pushObject(project.value);
         } else {
-          if (isEdit && current.length >= 1) {
+          if (isEdit && current.length >= 1 && !( get(orignalModel, 'projectIds') || []).includes(project.value)) {
             let match = current.find((p) => p === project.value);
 
             if (match) {
               if (projectsToRemoveOnUpgrade) {
                 if (!projectsToRemoveOnUpgrade.includes(match)) {
-                  projectsToRemoveOnUpgrade.push(match);
+                  projectsToRemoveOnUpgrade.pushObject(match);
                 }
               } else {
                 projectsToRemoveOnUpgrade = [match];
@@ -86,7 +92,7 @@ export default Controller.extend(ViewNewEdit, {
     cancel() {
       set(this, 'id', null);
 
-      this.router.transitionTo('global-admin.global-dns.entries.index');
+      this.transitionToRoute('global-dns.entries.index');
     },
 
     addAuthorizedPrincipal(principal) {
@@ -109,9 +115,35 @@ export default Controller.extend(ViewNewEdit, {
 
   },
 
+  recordTypeChanged: observer('recordType', function() {
+    const { recordType, primaryResource = {} } = this;
+    const { multiClusterAppId, projectIds }    = primaryResource;
+    let { projectsToRemoveOnUpgrade }          = this;
+
+    if (!projectsToRemoveOnUpgrade) {
+      projectsToRemoveOnUpgrade = [];
+    }
+
+    switch (recordType) {
+    case 'multi':
+      if (projectIds && projectIds.length) {
+        set(primaryResource, 'projectIds', null);
+        set(this, 'projectsToRemoveOnUpgrade', projectsToRemoveOnUpgrade.pushObjects(projectIds));
+      }
+      break;
+    case 'project':
+      if (multiClusterAppId) {
+        set(primaryResource, 'multiClusterAppId', null);
+      }
+      break;
+    default:
+      break;
+    }
+  }),
+
   providers: computed('model.providers.[]', function() {
-    let { providerId }    = this.primaryResource;
-    let { providers } = this.model;
+    let { providerId } = this.primaryResource;
+    let { providers }  = this.model;
 
     if (providers.length) {
       if (providerId) {
@@ -145,7 +177,7 @@ export default Controller.extend(ViewNewEdit, {
   }),
 
   multiClusterApps: computed('model.multiClusterApps.[]', function() {
-    let { multiClusterApps } = this.model;
+    let { multiClusterApps }  = this.model;
     let { multiClusterAppId } = this.primaryResource;
 
     if (multiClusterApps.length) {
@@ -240,50 +272,35 @@ export default Controller.extend(ViewNewEdit, {
     });
   },
 
-  willSave() {
-    set(this, 'errors', []);
-
-    const ok          = this.validate();
-    const { isEdit } = this;
-
-    if (!ok) {
-      // Validation failed
-      return false;
-    }
-
-    if (isEdit) {
-      return this.doProjectActions();
-    } else {
-      return true;
-    }
-  },
-
   doProjectActions() {
-    const { primaryResource } = this;
+    const { primaryResource }                                   = this;
     const { projectsToAddOnUpgrade, projectsToRemoveOnUpgrade } = this;
-    const promises = [];
+    const promises                                              = [];
 
-    if (projectsToAddOnUpgrade) {
+    if (projectsToAddOnUpgrade && projectsToAddOnUpgrade.length > 0) {
       promises.push(primaryResource.doAction('addProjects', { projectIds: projectsToAddOnUpgrade  }));
     }
 
-    if (projectsToRemoveOnUpgrade) {
+    if (projectsToRemoveOnUpgrade && projectsToRemoveOnUpgrade.length > 0) {
       promises.push(primaryResource.doAction('removeProjects', { projectIds: projectsToRemoveOnUpgrade  }));
     }
 
     if (promises.length > 0) {
-      return all(promises)
-        .then(() => {
-          return true;
-        })
-        .catch((/* handled by growl error */) => {
-          return false;
-        });
+      return all(promises);
     } else {
       return true;
     }
   },
 
+  didSave(neu) {
+    const { isEdit } = this;
+
+    if (isEdit) {
+      return this.doProjectActions();
+    } else {
+      return neu;
+    }
+  },
 
   doneSaving() {
     this.send('cancel');

--- a/lib/global-admin/addon/global-dns/entries/new/route.js
+++ b/lib/global-admin/addon/global-dns/entries/new/route.js
@@ -51,16 +51,27 @@ export default Route.extend({
   },
 
   setupController(controller, model) {
-    if (get(model, 'globaldns.id')) {
-      controller.set('mode', 'edit');
-    } else {
-      controller.set('mode', 'new');
-    }
+    let recordType    = 'multi';
+    let originalModel = null;
+    let mode          = 'new';
 
     if (get(model, 'globaldns.projectIds.length') > 0) {
-      controller.set('recordType', 'project');
+      recordType = 'project';
     }
-    // Call _super for default behavior
+
+    if (get(model, 'globaldns.id')) {
+      mode          = 'edit';
+      originalModel = get(model, 'globaldns').clone();
+    }
+
+    controller.setProperties({
+      projectsToAddOnUpgrade:    [],
+      projectsToRemoveOnUpgrade: [],
+      mode,
+      originalModel,
+      recordType,
+    });
+
     this._super(controller, model);
   },
 

--- a/lib/global-admin/addon/global-dns/entries/new/template.hbs
+++ b/lib/global-admin/addon/global-dns/entries/new/template.hbs
@@ -113,7 +113,6 @@
                 optionValuePath="id"
                 prompt="globalDnsPage.entriesPage.config.multiCluster.placeholder"
                 value=primaryResource.multiClusterAppId
-                disabled=(gte primaryResource.projectIds.length 1)
               }}
             {{else}}
               {{#if primaryResource.multiClusterAppId}}
@@ -148,7 +147,6 @@
                 class="form-control select-cap-add"
                 multiple="true"
                 onchange={{action "modifyProjectIds"}}
-                disabled={{if primaryResource.multiClusterAppId true false}}
               >
                 {{#each groupedClustersProjects as |cluster|}}
                   <optgroup label="{{cluster.displayName}}">


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Prior to this we did not allow users to change the GDNS entry targets from MC app to Project and visa versa. The backend was updated to allow this. The ui will allow the user to move between the two on edit. It should null the multiClusterAppId when moving to project targets and vice versa. If the `addProject` action fails the UI will stay on the edit page with the error allowing the user to select a different project. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#18366

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
