### PR TITLE
GDNS Provider - remove secret key param

### DIFF
--- a/lib/global-admin/addon/global-dns/providers/new/controller.js
+++ b/lib/global-admin/addon/global-dns/providers/new/controller.js
@@ -57,6 +57,19 @@ export default Controller.extend(ViewNewEdit, {
     }
   }),
 
+  validate() {
+    const providerConfig = get(this, `config.${ this.activeProvider }ProviderConfig`);
+    const { mode }       = this;
+
+    if (mode === 'edit' && providerConfig && providerConfig.hasOwnProperty('secretKey')) {
+      if (providerConfig.secretKey === '' || providerConfig.secretKey === null) {
+        delete providerConfig.secretKey;
+      }
+    }
+
+    return this._super(...arguments);
+  },
+
   doneSaving() {
     this.send('cancel');
   },

--- a/lib/global-admin/addon/templates/-alidns-dns-provider.hbs
+++ b/lib/global-admin/addon/templates/-alidns-dns-provider.hbs
@@ -45,7 +45,20 @@
         class="acc-label"
         for="alidns-api-key"
       >
-        {{t "globalDnsPage.providersPage.config.secretKey.label"}}{{field-required}}
+        {{t "globalDnsPage.providersPage.config.secretKey.label"}}
+        {{#if (eq mode "edit")}}
+          {{#tooltip-element
+             type="tooltip-basic"
+             model=(t "globalDnsPage.providersPage.config.secretKey.info")
+             tooltipTemplate="tooltip-static"
+             aria-describedby="tooltip-base"
+             tooltipFor="tooltipSecretKey"
+          }}
+            <i class="icon icon-info"></i>
+          {{/tooltip-element}}
+        {{else}}
+          {{field-required}}
+        {{/if}}
       </label>
       {{input
         classNames="form-control"

--- a/lib/global-admin/addon/templates/-route53-dns-provider.hbs
+++ b/lib/global-admin/addon/templates/-route53-dns-provider.hbs
@@ -45,7 +45,20 @@
         class="acc-label"
         for="route53-secret-key"
       >
-        {{t "globalDnsPage.providersPage.config.secretKey.label"}}{{field-required}}
+        {{t "globalDnsPage.providersPage.config.secretKey.label"}}
+        {{#if (eq mode "edit")}}
+          {{#tooltip-element
+             type="tooltip-basic"
+             model=(t "globalDnsPage.providersPage.config.secretKey.info")
+             tooltipTemplate="tooltip-static"
+             aria-describedby="tooltip-base"
+             tooltipFor="tooltipSecretKey"
+          }}
+            <i class="icon icon-info"></i>
+          {{/tooltip-element}}
+        {{else}}
+          {{field-required}}
+        {{/if}}
       </label>
       {{input
         classNames="form-control"

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1176,6 +1176,7 @@ globalDnsPage:
       secretKey:
         label: Secret Key
         placeholder: Your secret key
+        info: Secret key already provided. It is only required when updating the keys themselves.
       apiEmail:
         label: API Email
         placeholder: Your API Email


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. -->
Proposed changes
======

Its okay to not include the secretKey for global dns providers that use this on the update call. This pr adds dropping that key if input was added but then removed.
<!--

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!--

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

https://github.com/rancherlabs/rancher-security/issues/78

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here.

-->

Further comments
======

N/A
<!--

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

-->