### PR TITLE
Fix vSphere node template size display issue

### DIFF
--- a/lib/shared/addon/mixins/node-driver.js
+++ b/lib/shared/addon/mixins/node-driver.js
@@ -7,6 +7,7 @@ import ManageLabels from 'shared/mixins/manage-labels';
 import { addAction } from 'ui/utils/add-view-action';
 import { get, set, computed, setProperties } from '@ember/object';
 import { ucFirst } from 'shared/utils/util';
+import { formatSi } from 'shared/utils/parse-unit';
 import C from 'ui/utils/constants';
 
 // Map of driverName -> [string | function]
@@ -38,7 +39,9 @@ const DISPLAY_SIZES = {
   rackspace:    'config.flavorId',
 
   vmwarevsphere() {
-    return `${ get(this, 'config.memorySize') } GiB, ${ get(this, 'config.cpuCount')  } Core`;
+    const size = formatSi(get(this, 'config.memorySize') * 1048576, 1024, 'iB');
+
+    return `${ size }, ${ get(this, 'config.cpuCount')  } Core`;
   },
 }
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Create a vShpere node template with memory 2048mb
But it shows 2048 GB in node template list

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/18856
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
