### PR TITLE
Fix GKE cluster goes to updating after edit with no changes

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
@@ -333,6 +333,17 @@ export default Component.extend(ClusterDriver, {
     }
   }),
 
+  enablePrivateNodesChange: observer('config.enablePrivateNodes', function() {
+    const config = get(this, 'config')
+
+    if (!get(config, 'enablePrivateNodes')) {
+      setProperties(config, {
+        enablePrivateEndpoint: false,
+        masterIpv4CidrBlock:   '',
+      })
+    }
+  }),
+
   zoneChoices: computed('zones.[]', function() {
     let out = (get(this, 'zones') || []).slice();
 
@@ -608,44 +619,13 @@ export default Component.extend(ClusterDriver, {
 
     if (!get(config, 'enableNodepoolAutoscaling')) {
       setProperties(config, {
-        minNodeCount: null,
-        maxNodeCount: null,
+        minNodeCount: 0,
+        maxNodeCount: 0,
       })
     }
 
-    if (!get(this, 'config.useIpAliases')) {
-      setProperties(config, {
-        ipPolicyCreateSubnetwork:           false,
-        ipPolicyClusterSecondaryRangeName:  null,
-        ipPolicyClusterIpv4CidrBlock:       null,
-        ipPolicyServicesSecondaryRangeName: null,
-        ipPolicyServicesIpv4CidrBlock:      null,
-        enablePrivateNodes:                 false,
-      })
-    } else {
-      if (!get(config, 'ipPolicyCreateSubnetwork')) {
-        setProperties(config, {
-          ipPolicyClusterIpv4CidrBlock:  null,
-          ipPolicyServicesIpv4CidrBlock: null,
-        })
-      } else {
-        setProperties(config, {
-          ipPolicyClusterSecondaryRangeName:  null,
-          ipPolicyServicesSecondaryRangeName: null,
-          subNetwork:                         null,
-        })
-
-        if (get(config, 'ipPolicyClusterIpv4CidrBlock')) {
-          set(config, 'clusterIpv4Cidr', null)
-        }
-      }
-
-      if (!get(config, 'enablePrivateNodes')) {
-        setProperties(config, {
-          enablePrivateEndpoint: false,
-          masterIpv4CidrBlock:   null,
-        })
-      }
+    if (get(this, 'config.useIpAliases') && get(config, 'ipPolicyCreateSubnetwork') && get(config, 'ipPolicyClusterIpv4CidrBlock')) {
+      set(config, 'clusterIpv4Cidr', '')
     }
 
     if (!get(config, 'enableMasterAuthorizedNetwork')) {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

1. Cannot pass null to the backend.
2. Some field can pass to GKE driver directory because GKE will ignore. For example:
![image](https://user-images.githubusercontent.com/18737885/54271914-783e6000-45bd-11e9-9de5-f764bf6773a5.png)

3. `nodeCount` default value is `1`, so it needs reset to `0`.
4. According to `The IP address range for the cluster pod IPs. If this field set, then cluster.cluster_ipv4_cidr must be left blank.`, `clusterIpv4Cidr` needs to reset.


<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

https://github.com/rancher/rancher/issues/18853

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
