### PR TITLE
Fix backupConfig is undefined when upgrade form 2.1.7

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -963,7 +963,7 @@ export default InputTextFile.extend(ClusterDriver, {
         this.migrateLegacyEtcdSnapshotSettings();
       } else if (etcd.backupConfig && etcd.backupConfig.s3BackupConfig) {
         set(this, 'backupStrategy', 's3');
-      } else {
+      } else if (!etcd.snapshot && !etcd.backupConfig) {
         const backupConfig = get(this, 'globalStore').createRecord({
           enabled: false,
           type:    'backupConfig',


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Only when !etcd.snapshot && !etcd.backupConfig meaning upgrade from 2.1.7.




Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

https://github.com/rancher/rancher/issues/19122

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
