### PR TITLE
ignore temp Dockerfile.dapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ GTAGS
 
 *.org
 yarn-error.log
+!Dockerfile.dapper
+Dockerfile.dapper*


### PR DESCRIPTION
ignore temp files left by dapper to avoid failing check for uncommitted changes