### PR TITLE
fix issue for first load custom node driver error

### DIFF
--- a/lib/nodes/addon/components/modal-edit-node-template/component.js
+++ b/lib/nodes/addon/components/modal-edit-node-template/component.js
@@ -125,6 +125,10 @@ export default Component.extend(ModalBase, {
     }
   }),
 
+  availableDriversDidChange: observer('availableDrivers.[]', function() {
+    this.loadCustomUi();
+  }),
+
   availableDrivers: computed('allNodeDrivers.@each.state', 'schemaReloaded', function() {
     const out     = [];
     const drivers = get(this, 'allNodeDrivers').filterBy('state', 'active').sortBy('name');


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
If the custom node driver is added for the first time, after opening the Add Node Template Modal, the scripts and styles related to the custom node driver are not loaded, and the browser console reports an error: `Assertion Failed: Could not find component named "driver-xxxxxx" (no component or template with that name was found)`.

The Add template Modal should listen for changes in the drivers, If there is a new driver and the driver is already active, it should check to see if there are new css and js to pull.


Types of changes
======
Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
https://github.com/rancher/rancher/issues/19034

