### PR TITLE
Add service to access settings in custom-catalog view

### DIFF
--- a/lib/shared/addon/components/custom-catalog/component.js
+++ b/lib/shared/addon/components/custom-catalog/component.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import layout from './template';
+import { inject as service } from '@ember/service';
 import { get, computed } from '@ember/object';
 import C from 'ui/utils/constants';
 
@@ -39,6 +40,7 @@ const headers = [
 ];
 
 export default Component.extend({
+  settings:     service(),
   layout,
   headers,
   tagName:      null,


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Add service to access settings which is used to print `appName`

Types of changes
======
Bugfix

Linked Issues
======
https://github.com/rancher/rancher/issues/19215

Further comments
======

