### PR TITLE
add Linode cloud credential

### DIFF
--- a/app/models/cloudcredential.js
+++ b/app/models/cloudcredential.js
@@ -13,13 +13,15 @@ const cloudCredential = Resource.extend({
   isAmazon: notEmpty('amazonec2credentialConfig'),
   isAzure:  notEmpty('azurecredentialConfig'),
   isDo:     notEmpty('digitaloceancredentialConfig'),
+  isLinode: notEmpty('linodecredentialConfig'),
   isVMware: notEmpty('vmwarevspherecredentialConfig'),
 
-  displayType: computed('amazonec2credentialConfig', 'azurecredentialConfig', 'digitaloceancredentialConfig', 'vmwarevspherecredentialConfig', function() {
+  displayType: computed('amazonec2credentialConfig', 'azurecredentialConfig', 'digitaloceancredentialConfig', 'linodecredentialConfig', 'vmwarevspherecredentialConfig', function() {
     const {
       isAmazon,
       isAzure,
       isDo,
+      isLinode,
       isVMware
     } = this;
 
@@ -29,6 +31,8 @@ const cloudCredential = Resource.extend({
       return 'Azure';
     } else if (isDo) {
       return 'Digital Ocean';
+    } else if (isLinode) {
+      return 'Linode';
     } else if (isVMware) {
       return 'VMware vSphere';
     }

--- a/lib/global-admin/addon/components/cru-cloud-credential/component.js
+++ b/lib/global-admin/addon/components/cru-cloud-credential/component.js
@@ -132,9 +132,9 @@ export default Component.extend(ViewNewEdit, {
       switch (this.cloudCredentialType) {
       case 'amazon':
       case 'digitalOcean':
+      case 'linode':
         return 'modalAddCloudKey.saving.validating';
       case 'azure':
-      case 'linode':
       case 'vmware':
       default:
         return 'saveCancel.saving';
@@ -170,7 +170,7 @@ export default Component.extend(ViewNewEdit, {
     }
 
     const { cloudCredentialType }      = this;
-    const keysThatWeCanValidate = ['amazon', 'digitalOcean'];
+    const keysThatWeCanValidate = ['amazon', 'digitalOcean', 'linode'];
     const auth                  = {
       type:  'validate',
       token: null,
@@ -178,6 +178,28 @@ export default Component.extend(ViewNewEdit, {
 
     if (keysThatWeCanValidate.includes(cloudCredentialType)) {
       set(this, 'validatingKeys', true);
+
+      if (cloudCredentialType === 'linode') {
+        set(auth, 'token', get(this, 'config.token'));
+
+        const headers = { Authorization: `Bearer ${ auth.token }` };
+
+        return new Promise((resolve, reject) => {
+          fetch('https://api.linode.com/v4/profile', { headers }).then((res) => {
+            if (!res.ok ) {
+              reject(res);
+            }
+
+            return resolve();
+          });
+        }).then(() => {
+          set(this, 'validatingKeys', false);
+
+          return true;
+        }).catch((err) => {
+          return this.setError(`${ err.status } ${ err.statusText }`);
+        })
+      }
 
       if (cloudCredentialType === 'digitalOcean') {
         set(auth, 'token', get(this, 'config.accessToken'));

--- a/lib/global-admin/addon/components/cru-cloud-credential/component.js
+++ b/lib/global-admin/addon/components/cru-cloud-credential/component.js
@@ -27,6 +27,12 @@ const CRED_CONFIG_CHOICES = [
     configField: 'digitaloceancredentialConfig',
   },
   {
+    name:        'linode',
+    displayName: 'Linode',
+    driver:      'linode',
+    configField: 'linodecredentialConfig',
+  },
+  {
     name:        'vmware',
     displayName: 'VMware vSphere',
     driver:      'vmwarevsphere',
@@ -94,7 +100,7 @@ export default Component.extend(ViewNewEdit, {
     },
   },
 
-  config: computed('cloudCredentialType', 'model.{amazonec2credentialConfig,azurecredentialConfig,digitaloceancredentialConfig,vmwarevspherecredentialConfig}', function() {
+  config: computed('cloudCredentialType', 'model.{amazonec2credentialConfig,azurecredentialConfig,digitaloceancredentialConfig,linodecredentialConfig,vmwarevspherecredentialConfig}', function() {
     const { model }   = this;
     const configField = this.getConfigField();
 
@@ -128,6 +134,7 @@ export default Component.extend(ViewNewEdit, {
       case 'digitalOcean':
         return 'modalAddCloudKey.saving.validating';
       case 'azure':
+      case 'linode':
       case 'vmware':
       default:
         return 'saveCancel.saving';

--- a/lib/global-admin/addon/components/cru-cloud-credential/template.hbs
+++ b/lib/global-admin/addon/components/cru-cloud-credential/template.hbs
@@ -155,18 +155,18 @@
     {{else if (eq cloudCredentialType "linode")}}
       <div class="row">
         <div class="col span-6">
-          <label class="acc-label" for="linode-accessToken">
-            {{t "modalAddCloudKey.linode.accessToken.label"}}
+          <label class="acc-label" for="linode-token">
+            {{t "modalAddCloudKey.linode.token.label"}}
           </label>
           {{input
             type="password"
-            value=config.accessToken
+            value=config.token
             classNames="form-control"
-            placeholder=(t "modalAddCloudKey.linode.accessToken.placeholder")
-            id="linode-accessToken"
+            placeholder=(t "modalAddCloudKey.linode.token.placeholder")
+            id="linode-token"
           }}
           <p class="text-info">
-            {{t "modalAddCloudKey.linode.accessToken.help" htmlSafe=true}}
+            {{t "modalAddCloudKey.linode.token.help" htmlSafe=true}}
           </p>
         </div>
       </div>

--- a/lib/global-admin/addon/components/cru-cloud-credential/template.hbs
+++ b/lib/global-admin/addon/components/cru-cloud-credential/template.hbs
@@ -152,6 +152,24 @@
           </p>
         </div>
       </div>
+    {{else if (eq cloudCredentialType "linode")}}
+      <div class="row">
+        <div class="col span-6">
+          <label class="acc-label" for="linode-accessToken">
+            {{t "modalAddCloudKey.linode.accessToken.label"}}
+          </label>
+          {{input
+            type="password"
+            value=config.accessToken
+            classNames="form-control"
+            placeholder=(t "modalAddCloudKey.linode.accessToken.placeholder")
+            id="linode-accessToken"
+          }}
+          <p class="text-info">
+            {{t "modalAddCloudKey.linode.accessToken.help" htmlSafe=true}}
+          </p>
+        </div>
+      </div>
     {{else if (eq cloudCredentialType "vmware")}}
       <div class="row">
         <div class="col span-6">

--- a/lib/shared/addon/mixins/node-driver.js
+++ b/lib/shared/addon/mixins/node-driver.js
@@ -247,6 +247,11 @@ export default Mixin.create(NewOrEdit, ManageLabels, {
           return cc;
         }
         break;
+      case 'linode':
+        if (get(cc, 'isLinode')) {
+          return cc;
+        }
+        break;
       case 'vmwarevsphere':
         if (get(cc, 'isVMware')) {
           return cc;
@@ -313,7 +318,7 @@ export default Mixin.create(NewOrEdit, ManageLabels, {
   },
 
   validateCloudCredentials() {
-    const driversToValidate   = ['amazonec2', 'azure', 'digitalocean', 'vmwarevsphere'];
+    const driversToValidate   = ['amazonec2', 'azure', 'digitalocean', 'linode', 'vmwarevsphere'];
     let { driverName }        = this;
     let { cloudCredentialId } = this.model;
     let valid                 = false;

--- a/lib/shared/addon/mixins/node-driver.js
+++ b/lib/shared/addon/mixins/node-driver.js
@@ -11,7 +11,7 @@ import { formatSi } from 'shared/utils/parse-unit';
 import C from 'ui/utils/constants';
 import { isArray } from '@ember/array';
 
-class DynamicDependentKeysProperty {
+export class DynamicDependentKeysProperty {
   constructor(property) {
     const {
       driver, keyOrKeysToWatch, getDisplayProperty

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -5480,6 +5480,7 @@ modalAddCloudKey:
       help: |
         Paste in a Personal Access Token from the Linode
         <a href="https://cloud.linode.com/profile/tokens" target="_blank" rel="nofollow noreferrer noopener">API Tokens</a> screen
+    authAccountButton: 'Next: Configure Instance'
   vmwarevsphere:
     password:
       label: Password

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -5473,6 +5473,13 @@ modalAddCloudKey:
       help: |
         Paste in a Personal Access Token from the DigitalOcean
         <a href="https://cloud.digitalocean.com/settings/api/tokens" target="_blank" rel="nofollow noreferrer noopener">Applications & API</a> screen
+  linode:
+    accessToken:
+      label: Access Token
+      placeholder: Your Linode API access token
+      help: |
+        Paste in a Personal Access Token from the Linode
+        <a href="https://cloud.linode.com/profile/tokens" target="_blank" rel="nofollow noreferrer noopener">API Tokens</a> screen
   vmwarevsphere:
     password:
       label: Password

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -5474,7 +5474,7 @@ modalAddCloudKey:
         Paste in a Personal Access Token from the DigitalOcean
         <a href="https://cloud.digitalocean.com/settings/api/tokens" target="_blank" rel="nofollow noreferrer noopener">Applications & API</a> screen
   linode:
-    accessToken:
+    token:
       label: Access Token
       placeholder: Your Linode API access token
       help: |


### PR DESCRIPTION
This PR seeks to add support for storing Linode Cloud Credentials

This may be incomplete in its current state and may warrant more discussion about what to do for external node drivers.  A Linode Cloud Credential will also be usable for Linode Global DNS options, which other PRs will begin to address.

Depends on rancher/rancher#20281