### PR TITLE
[WIP][2.2.2]Revert "Backport: Fallback to old dashboard view if monitoring is not…

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -62,15 +62,19 @@ export default Resource.extend(Grafana, ResourceUsage, {
     return null;
   }),
 
-  isMonitoringReady: computed('conditions.@each.status', function() {
+  isMonitoringReady: computed('monitoringStatus.@each.conditions', function() {
     if ( !get(this, 'enableClusterMonitoring') ) {
       return false;
     }
-    const conditions = get(this, 'conditions') || [];
+    const conditions = get(this, 'monitoringStatus.conditions') || [];
 
-    const ready = conditions.findBy('type', 'MonitoringEnabled');
+    if ( get(conditions, 'length') > 0 ) {
+      const ready = conditions.filterBy('status', 'True') || [] ;
 
-    return ready && get(ready, 'status') === 'True';
+      return get(ready, 'length') === get(conditions, 'length');
+    }
+
+    return false;
   }),
 
   isReady: computed('conditions.@each.status', function() {

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -46,15 +46,19 @@ export default Resource.extend({
     return labels[SYSTEM_PROJECT_LABEL] === 'true';
   }),
 
-  isMonitoringReady: computed('conditions.@each.status', function() {
-    if ( !get(this, 'enableClusterMonitoring') ) {
+  isMonitoringReady: computed('monitoringStatus.@each.conditions', function() {
+    if ( !get(this, 'enableProjectMonitoring') ) {
       return false;
     }
-    const conditions = get(this, 'conditions') || [];
+    const conditions = get(this, 'monitoringStatus.conditions') || [];
 
-    const ready = conditions.findBy('type', 'MonitoringEnabled');
+    if ( get(conditions, 'length') > 0 ) {
+      const ready = conditions.filterBy('status', 'True') || [] ;
 
-    return ready && get(ready, 'status') === 'True';
+      return get(ready, 'length') === get(conditions, 'length');
+    }
+
+    return false;
   }),
 
   active: computed('scope.currentProject.id', 'id', function() {


### PR DESCRIPTION
Revert https://github.com/rancher/ui/pull/2839/files as backend will not in 2.2.2

Even it is backwards compatible. But we didn't test it a lot. But the old code is tested a lot