### PR TITLE
[2.2.x]Make alert group recipients as non-required field

### DIFF
--- a/lib/alert/addon/components/alert/form-recipients/component.js
+++ b/lib/alert/addon/components/alert/form-recipients/component.js
@@ -1,4 +1,4 @@
-import { get, set } from '@ember/object';
+import { get, set, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { reads } from '@ember/object/computed';
 import Component from '@ember/component';
@@ -26,19 +26,15 @@ export default Component.extend({
       get(this, 'model.recipients').removeObject(recipient);
     },
   },
-  notifiers: function() {
+  notifiers: computed('clusterId', function() {
     const clusterId = get(this, 'clusterId');
 
     return get(this, 'globalStore').all('notifier').filterBy('clusterId', clusterId);
-  }.property('clusterId'),
+  }),
 
-  disableRemove: function() {
-    return get(this, 'model.recipients.length') <= 1;
-  }.property('model.recipients.length'),
-
-  haveNotifiers: function() {
+  haveNotifiers: computed('notifiers.length', function() {
     return get(this, 'notifiers.length');
-  }.property('notifiers.length'),
+  }),
 
   addNewRecipient() {
     const nue = {

--- a/lib/alert/addon/components/alert/form-recipients/template.hbs
+++ b/lib/alert/addon/components/alert/form-recipients/template.hbs
@@ -8,18 +8,19 @@
 {{/unless}}
 <section class="row">
   <div class="col span-1">
-    <div class="pt-10">
-      {{t 'alertPage.newOrEdit.alert'}}
-    </div>
+    {{#if model.recipients.length}}
+      <div class="pt-10">
+        {{t "alertPage.newOrEdit.alert"}}
+      </div>
+    {{/if}}
   </div>
   <div class="col span-10">
     {{#each model.recipients as |recipient idx|}}
       {{alert/form-recipient-item
-          disableRemove=disableRemove
-          remove="remove"
-          isFirst=(eq idx 0)
-          notifiers=notifiers
-          model=recipient
+        remove=(action "remove")
+        isFirst=(eq idx 0)
+        notifiers=notifiers
+        model=recipient
       }}
     {{/each}}
     <div class="mt-15">

--- a/lib/alert/addon/components/alert/new-edit/component.js
+++ b/lib/alert/addon/components/alert/new-edit/component.js
@@ -42,13 +42,13 @@ export default Component.extend(NewOrEdit, AlertRule, {
         toSaveAlert = get(this, 'alertGroup').clone()
         set(toSaveAlert, 'projectId', get(this, 'scope.currentProject.id'))
       }
-      this.validateRecipients(toSaveAlert, errors)
       set(this, 'errors', errors)
       if (get(this, 'errors') && get(this, 'errors').length > 0) {
         cb();
 
         return;
       }
+      set(toSaveAlert, 'recipients', (get(toSaveAlert, 'recipients') || []).filter((r) => !!r.notifierId));
       set(this, 'primaryResource', toSaveAlert);
       this._super(cb);
     },
@@ -89,17 +89,6 @@ export default Component.extend(NewOrEdit, AlertRule, {
     })
 
     return PromiseAll(alertRules.map((a) => a.save()))
-  },
-
-  validateRecipients(alert, errors) {
-    const recipients = get(alert, 'recipients');
-    const filteredRecipients = recipients.filter((r) => !!r.notifierId);
-
-    if (filteredRecipients.length === 0) {
-      errors.push(['Recipient required']);
-    } else {
-      set(alert, 'recipients', filteredRecipients);
-    }
   },
 
   doneSaving() {

--- a/lib/pipeline/addon/components/pipeline-notifier/component.js
+++ b/lib/pipeline/addon/components/pipeline-notifier/component.js
@@ -118,9 +118,6 @@ export default Component.extend({
   }),
 
 
-  disableRemove: computed('config.recipients.[]', function() {
-    return get(this, 'config.recipients.length') <= 1
-  }),
   addNewRecipient() {
     const nue = {
       notifier:   null,

--- a/lib/pipeline/addon/components/pipeline-notifier/template.hbs
+++ b/lib/pipeline/addon/components/pipeline-notifier/template.hbs
@@ -52,18 +52,19 @@
     {{/unless}}
     <div class="row">
       <div class="col span-2">
-        <div style="padding-top: 12px;">
-          {{t 'pipelineNotification.asMessage'}}
-        </div>
+        {{#if config.recipients.length}}
+          <div style="padding-top: 12px;">
+            {{t "pipelineNotification.asMessage"}}
+          </div>
+        {{/if}}
       </div>
       <div class="col span-9">
         {{#each config.recipients as |recipient idx|}}
           {{form-recipient-item
-              disableRemove=disableRemove
-              remove="remove"
-              isFirst=(eq idx 0)
-              notifiers=notifiers
-              model=recipient
+            remove=(action "remove")
+            isFirst=(eq idx 0)
+            notifiers=notifiers
+            model=recipient
           }}
         {{/each}}
         <div class="mt-15">


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Make alert group recipients as non-required field

Backend PR:https://github.com/rancher/types/pull/792

This UI PR can be merged anytime. But we cannot validate it until backend PR in

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/19614

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
