### PR TITLE
[2.3]Fix pvc issue

### DIFF
--- a/app/components/cru-persistent-volume-claim/component.js
+++ b/app/components/cru-persistent-volume-claim/component.js
@@ -117,7 +117,7 @@ export default Component.extend(ViewNewEdit, ChildHook, {
         return false;
       }
     } else {
-      set(pr, 'storageClassId', null);
+      set(pr, 'storageClassId', get(pr, 'persistentVolume.storageClassId') || null);
       set(pr, 'resources', { requests: Object.assign({}, get(pr, 'persistentVolume.capacity')), });
     }
 

--- a/app/components/cru-persistent-volume-claim/template.hbs
+++ b/app/components/cru-persistent-volume-claim/template.hbs
@@ -77,7 +77,7 @@
     <div class="row">
       <div class="col span-6">
         <label class="acc-label">
-          {{t "cruPersistentVolumeClaim.pv.label"}}
+          {{t "cruPersistentVolumeClaim.source.label"}}
         </label>
         <div>
           {{t "cruPersistentVolumeClaim.source.pv"}}
@@ -85,7 +85,7 @@
       </div>
       <div class="col span-6">
         <label class="acc-label">
-          {{t "cruPersistentVolumeClaim.storageClass.label"}}
+          {{t "cruPersistentVolumeClaim.pv.label"}}
         </label>
         <div>
           <a href="{{href-to "authenticated.cluster.storage.persistent-volumes.detail.index" scope.currentCluster.id primaryResource.persistentVolume.id}}">

--- a/app/components/cru-volume-claim-template/component.js
+++ b/app/components/cru-volume-claim-template/component.js
@@ -104,7 +104,7 @@ export default Component.extend(ViewNewEdit, ChildHook, {
         return false;
       }
     } else {
-      set(pr, 'storageClassId', null);
+      set(pr, 'storageClassId', get(pr, 'persistentVolume.storageClassId') || null);
       set(pr, 'resources', { requests: Object.assign({}, get(pr, 'persistentVolume.capacity')), });
     }
 


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The problem is rancher when creating the PVC don't set the same storage class name for the PVC as the PV. The storage class name field in the PVC spec is an empty string instead of the correct storage class name. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/19578

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
