### PR TITLE
Fix port form issue

### DIFF
--- a/app/components/container/form-ports/template.hbs
+++ b/app/components/container/form-ports/template.hbs
@@ -95,7 +95,7 @@
 
             <td>
               {{#if editing}}
-                <button class="btn bg-primary btn-sm" {{action "removePort" port}}>
+                <button type="button" class="btn bg-primary btn-sm" {{action "removePort" port}}>
                   <i class="icon icon-minus"/><span class="sr-only">{{t 'generic.remove'}}</span>
                 </button>
               {{/if}}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Select a workload and edit service (must had a port mapping)
Focus on docker image box and Press enter
Port mapping disappear
If users don't notice and press upgrade button, the service breaks.

This is kind of a HTML feature. When you press enter.
To improve the user experience, we should make `Add Port` be triggered when users press enter instead of `Remove Port`.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/19109

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
