### PR TITLE
Global Menu Open After Transition

### DIFF
--- a/lib/shared/addon/components/hover-dropdown/component.js
+++ b/lib/shared/addon/components/hover-dropdown/component.js
@@ -4,8 +4,10 @@ import { cancel, later } from '@ember/runloop';
 import { oneWay } from '@ember/object/computed';
 import { get, set } from '@ember/object';
 import calculatePosition from 'shared/utils/calculate-position';
+import { inject as service } from '@ember/service'
 
 export default Component.extend({
+  router:     service(),
   layout,
   delay:      200,
   openDelay:  oneWay('delay'),
@@ -14,8 +16,9 @@ export default Component.extend({
   actions: {
 
     open(forContent, dropdown) {
-      if (get(this, 'closeTimer')) {
+      if (get(this, 'closeTimer') || this.isTransitioning()) {
         cancel(get(this, 'closeTimer'));
+
         set(this, 'closeTimer', null);
       } else {
         let openFn = () => {
@@ -47,8 +50,9 @@ export default Component.extend({
     },
 
     close(forContent, dropdown) {
-      if (this.openTimer) {
+      if (this.openTimer || this.isTransitioning()) {
         cancel(this.openTimer);
+
         set(this, 'openTimer', null);
       } else {
         let closeFn = () => {
@@ -85,5 +89,13 @@ export default Component.extend({
     },
 
     calculatePosition,
+  },
+
+  isTransitioning() {
+    if (this.router._routerMicrolib.activeTransition && this.router._routerMicrolib.activeTransition.isTransition) {
+      return true
+    }
+
+    return false;
   },
 });


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Added `isTransitioning` check to page-header-project and hover-dropdown components. We shouldn't open the dropdown if we're in the middle of a transition but the main culprit are the JQ events that are set on the dom to open and close the page header menu which also shouldn't open if we're in the middle of a transition. Created my own transition check because its not available in the router service and because the component is at the top level it never gets destroyed we can't use the events on the component class. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#19300

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
