### PR TITLE
[1.6] Add additional AWS instance types

### DIFF
--- a/app/components/machine/driver-amazonec2/component.js
+++ b/app/components/machine/driver-amazonec2/component.js
@@ -414,11 +414,11 @@ let INSTANCE_TYPES = [
   },
   {
     group: 'R5 - High Memory Optimized',
-    name:  'r5.12xlarge	'
+    name:  'r5.12xlarge'
   },
   {
     group: 'R5 - High Memory Optimized',
-    name:  'r5.24xlarge	'
+    name:  'r5.24xlarge'
   },
 
   {
@@ -464,11 +464,11 @@ let INSTANCE_TYPES = [
   },
   {
     group: 'R5a - High Memory Optimized AMD Epyc',
-    name:  'r5a.12xlarge	'
+    name:  'r5a.12xlarge'
   },
   {
     group: 'R5a - High Memory Optimized AMD Epyc',
-    name:  'r5a.24xlarge	'
+    name:  'r5a.24xlarge'
   },
   
   {

--- a/app/components/machine/driver-amazonec2/component.js
+++ b/app/components/machine/driver-amazonec2/component.js
@@ -218,23 +218,23 @@ let INSTANCE_TYPES = [
   
   {
     group: 'M5ad - General Purpose SSD AMD Epyc',
-    name:  'm5a.large'
+    name:  'm5ad.large'
   },
   {
     group: 'M5ad - General Purpose SSD AMD Epyc',
-    name:  'm5a.xlarge'
+    name:  'm5ad.xlarge'
   },
   {
     group: 'M5ad - General Purpose SSD AMD Epyc',
-    name:  'm5a.2xlarge'
+    name:  'm5ad.2xlarge'
   },
   {
     group: 'M5ad - General Purpose SSD AMD Epyc',
-    name:  'm5a.4xlarge'
+    name:  'm5ad.4xlarge'
   },
   {
     group: 'M5ad - General Purpose SSD AMD Epyc',
-    name:  'm5a.12xlarge'
+    name:  'm5ad.12xlarge'
   },
   {
     group: 'M5ad - General Purpose SSD AMD Epyc',
@@ -420,31 +420,6 @@ let INSTANCE_TYPES = [
     group: 'R5 - High Memory Optimized',
     name:  'r5.24xlarge	'
   },
-  
-  {
-    group: 'R5a - High Memory Optimized AMD Epyc',
-    name:  'r5a.large'
-  },
-  {
-    group: 'R5a - High Memory Optimized AMD Epyc',
-    name:  'r5a.xlarge'
-  },
-  {
-    group: 'R5a - High Memory Optimized AMD Epyc',
-    name:  'r5a.2xlarge'
-  },
-  {
-    group: 'R5a - High Memory Optimized AMD Epyc',
-    name:  'r5a.4xlarge'
-  },
-  {
-    group: 'R5a - High Memory Optimized AMD Epyc',
-    name:  'r5a.12xlarge	'
-  },
-  {
-    group: 'R5a - High Memory Optimized AMD Epyc',
-    name:  'r5a.24xlarge	'
-  },
 
   {
     group: 'R5d - High Memory Optimized & Local Storage',
@@ -469,6 +444,31 @@ let INSTANCE_TYPES = [
   {
     group: 'R5d - High Memory Optimized & Local Storage',
     name:  'r5d.24xlarge'
+  },
+  
+  {
+    group: 'R5a - High Memory Optimized AMD Epyc',
+    name:  'r5a.large'
+  },
+  {
+    group: 'R5a - High Memory Optimized AMD Epyc',
+    name:  'r5a.xlarge'
+  },
+  {
+    group: 'R5a - High Memory Optimized AMD Epyc',
+    name:  'r5a.2xlarge'
+  },
+  {
+    group: 'R5a - High Memory Optimized AMD Epyc',
+    name:  'r5a.4xlarge'
+  },
+  {
+    group: 'R5a - High Memory Optimized AMD Epyc',
+    name:  'r5a.12xlarge	'
+  },
+  {
+    group: 'R5a - High Memory Optimized AMD Epyc',
+    name:  'r5a.24xlarge	'
   },
   
   {

--- a/app/components/machine/driver-amazonec2/component.js
+++ b/app/components/machine/driver-amazonec2/component.js
@@ -447,52 +447,52 @@ let INSTANCE_TYPES = [
   },
 
   {
-    group: 'R5D - High Memory Optimized & Local Storage',
+    group: 'R5d - High Memory Optimized & Local Storage',
     name:  'r5d.large'
   },
   {
-    group: 'R5D - High Memory Optimized & Local Storage',
+    group: 'R5d - High Memory Optimized & Local Storage',
     name:  'r5d.xlarge'
   },
   {
-    group: 'R5D - High Memory Optimized & Local Storage',
+    group: 'R5d - High Memory Optimized & Local Storage',
     name:  'r5d.2xlarge'
   },
   {
-    group: 'R5D - High Memory Optimized & Local Storage',
+    group: 'R5d - High Memory Optimized & Local Storage',
     name:  'r5d.4xlarge'
   },
   {
-    group: 'R5D - High Memory Optimized & Local Storage',
+    group: 'R5d - High Memory Optimized & Local Storage',
     name:  'r5d.12xlarge'
   },
   {
-    group: 'R5D - High Memory Optimized & Local Storage',
+    group: 'R5d - High Memory Optimized & Local Storage',
     name:  'r5d.24xlarge'
   },
   
   {
-    group: 'R5AD - High Memory Optimized & Local Storage AMD Epyc',
+    group: 'R5ad - High Memory Optimized & Local Storage AMD Epyc',
     name:  'r5ad.large'
   },
   {
-    group: 'R5AD - High Memory Optimized & Local Storage AMD Epyc',
+    group: 'R5ad - High Memory Optimized & Local Storage AMD Epyc',
     name:  'r5ad.xlarge'
   },
   {
-    group: 'R5AD - High Memory Optimized & Local Storage AMD Epyc',
+    group: 'R5ad - High Memory Optimized & Local Storage AMD Epyc',
     name:  'r5ad.2xlarge'
   },
   {
-    group: 'R5AD - High Memory Optimized & Local Storage AMD Epyc',
+    group: 'R5ad - High Memory Optimized & Local Storage AMD Epyc',
     name:  'r5ad.4xlarge'
   },
   {
-    group: 'R5AD - High Memory Optimized & Local Storage AMD Epyc',
+    group: 'R5ad - High Memory Optimized & Local Storage AMD Epyc',
     name:  'r5ad.12xlarge'
   },
   {
-    group: 'R5AD - High Memory Optimized & Local Storage AMD Epyc',
+    group: 'R5ad - High Memory Optimized & Local Storage AMD Epyc',
     name:  'r5ad.24xlarge'
   },
 

--- a/app/components/machine/driver-amazonec2/component.js
+++ b/app/components/machine/driver-amazonec2/component.js
@@ -113,31 +113,31 @@ let INSTANCE_TYPES = [
   },
   
   {
-    group: 'T3a - Burstable AMD CPU',
+    group: 'T3a - Burstable AMD Epyc',
     name:  't3a.nano'
   },
   {
-    group: 'T3a - Burstable AMD CPU',
+    group: 'T3a - Burstable AMD Epyc',
     name:  't3a.micro'
   },
   {
-    group: 'T3a - Burstable AMD CPU',
+    group: 'T3a - Burstable AMD Epyc',
     name:  't3a.small'
   },
   {
-    group: 'T3a - Burstable AMD CPU',
+    group: 'T3a - Burstable AMD Epyc',
     name:  't3a.medium'
   },
   {
-    group: 'T3a - Burstable AMD CPU',
+    group: 'T3a - Burstable AMD Epyc',
     name:  't3a.large'
   },
   {
-    group: 'T3a - Burstable AMD CPU',
+    group: 'T3a - Burstable AMD Epyc',
     name:  't3a.xlarge'
   },
   {
-    group: 'T3a - Burstable AMD CPU',
+    group: 'T3a - Burstable AMD Epyc',
     name:  't3a.2xlarge'
   },
 
@@ -164,6 +164,81 @@ let INSTANCE_TYPES = [
   {
     group: 'M5 - General Purpose',
     name:  'm5.24xlarge'
+  },
+  
+  {
+    group: 'M5d - General Purpose SSD',
+    name:  'm5d.large'
+  },
+  {
+    group: 'M5d - General Purpose SSD',
+    name:  'm5d.xlarge'
+  },
+  {
+    group: 'M5d - General Purpose SSD',
+    name:  'm5d.2xlarge'
+  },
+  {
+    group: 'M5d - General Purpose SSD',
+    name:  'm5d.4xlarge'
+  },
+  {
+    group: 'M5d - General Purpose SSD',
+    name:  'm5d.12xlarge'
+  },
+  {
+    group: 'M5d - General Purpose SSD',
+    name:  'm5d.24xlarge'
+  },
+  
+  {
+    group: 'M5a - General Purpose AMD Epyc',
+    name:  'm5a.large'
+  },
+  {
+    group: 'M5a - General Purpose AMD Epyc',
+    name:  'm5a.xlarge'
+  },
+  {
+    group: 'M5a - General Purpose AMD Epyc',
+    name:  'm5a.2xlarge'
+  },
+  {
+    group: 'M5a - General Purpose AMD Epyc',
+    name:  'm5a.4xlarge'
+  },
+  {
+    group: 'M5a - General Purpose AMD Epyc',
+    name:  'm5a.12xlarge'
+  },
+  {
+    group: 'M5a - General Purpose AMD Epyc',
+    name:  'm5a.24xlarge'
+  },
+  
+  {
+    group: 'M5ad - General Purpose SSD AMD Epyc',
+    name:  'm5a.large'
+  },
+  {
+    group: 'M5ad - General Purpose SSD AMD Epyc',
+    name:  'm5a.xlarge'
+  },
+  {
+    group: 'M5ad - General Purpose SSD AMD Epyc',
+    name:  'm5a.2xlarge'
+  },
+  {
+    group: 'M5ad - General Purpose SSD AMD Epyc',
+    name:  'm5a.4xlarge'
+  },
+  {
+    group: 'M5ad - General Purpose SSD AMD Epyc',
+    name:  'm5a.12xlarge'
+  },
+  {
+    group: 'M5ad - General Purpose SSD AMD Epyc',
+    name:  'm5ad.24xlarge'
   },
 
   {
@@ -345,6 +420,31 @@ let INSTANCE_TYPES = [
     group: 'R5 - High Memory Optimized',
     name:  'r5.24xlarge	'
   },
+  
+  {
+    group: 'R5a - High Memory Optimized AMD Epyc',
+    name:  'r5a.large'
+  },
+  {
+    group: 'R5a - High Memory Optimized AMD Epyc',
+    name:  'r5a.xlarge'
+  },
+  {
+    group: 'R5a - High Memory Optimized AMD Epyc',
+    name:  'r5a.2xlarge'
+  },
+  {
+    group: 'R5a - High Memory Optimized AMD Epyc',
+    name:  'r5a.4xlarge'
+  },
+  {
+    group: 'R5a - High Memory Optimized AMD Epyc',
+    name:  'r5a.12xlarge	'
+  },
+  {
+    group: 'R5a - High Memory Optimized AMD Epyc',
+    name:  'r5a.24xlarge	'
+  },
 
   {
     group: 'R5D - High Memory Optimized & Local Storage',
@@ -369,6 +469,31 @@ let INSTANCE_TYPES = [
   {
     group: 'R5D - High Memory Optimized & Local Storage',
     name:  'r5d.24xlarge'
+  },
+  
+  {
+    group: 'R5AD - High Memory Optimized & Local Storage AMD Epyc',
+    name:  'r5ad.large'
+  },
+  {
+    group: 'R5AD - High Memory Optimized & Local Storage AMD Epyc',
+    name:  'r5ad.xlarge'
+  },
+  {
+    group: 'R5AD - High Memory Optimized & Local Storage AMD Epyc',
+    name:  'r5ad.2xlarge'
+  },
+  {
+    group: 'R5AD - High Memory Optimized & Local Storage AMD Epyc',
+    name:  'r5ad.4xlarge'
+  },
+  {
+    group: 'R5AD - High Memory Optimized & Local Storage AMD Epyc',
+    name:  'r5ad.12xlarge'
+  },
+  {
+    group: 'R5AD - High Memory Optimized & Local Storage AMD Epyc',
+    name:  'r5ad.24xlarge'
   },
 
   {

--- a/app/components/machine/driver-amazonec2/component.js
+++ b/app/components/machine/driver-amazonec2/component.js
@@ -111,6 +111,35 @@ let INSTANCE_TYPES = [
     group: 'T3 - Burstable',
     name:  't3.2xlarge'
   },
+  
+  {
+    group: 'T3a - Burstable AMD CPU',
+    name:  't3a.nano'
+  },
+  {
+    group: 'T3a - Burstable AMD CPU',
+    name:  't3a.micro'
+  },
+  {
+    group: 'T3a - Burstable AMD CPU',
+    name:  't3a.small'
+  },
+  {
+    group: 'T3a - Burstable AMD CPU',
+    name:  't3a.medium'
+  },
+  {
+    group: 'T3a - Burstable AMD CPU',
+    name:  't3a.large'
+  },
+  {
+    group: 'T3a - Burstable AMD CPU',
+    name:  't3a.xlarge'
+  },
+  {
+    group: 'T3a - Burstable AMD CPU',
+    name:  't3a.2xlarge'
+  },
 
   {
     group: 'M5 - General Purpose',


### PR DESCRIPTION
Proposed changes
======

This adds T3a, M5a, M5ad, R5a, R5d, and R5ad AWS instance types



Types of changes
======

New feature (non-breaking change which adds functionality)

Linked Issues
======

 https://github.com/rancher/rancher/issues/19826

Further comments
======
The `a` and `ad` instance types are new and less expensive options for their counterparts.
Full details for each type are located at the pages below.
https://aws.amazon.com/ec2/instance-types/t3/
https://aws.amazon.com/ec2/instance-types/m5/
https://aws.amazon.com/ec2/instance-types/r3/
