### PR TITLE
Fix findAll filter issue in alerting and logging

### DIFF
--- a/app/authenticated/cluster/notifier/index/route.js
+++ b/app/authenticated/cluster/notifier/index/route.js
@@ -12,7 +12,7 @@ export default Route.extend({
     const cs = get(this, 'globalStore');
     const clusterId = transition.params['authenticated.cluster'].cluster_id;
 
-    return hash({ notifiers: cs.findAll('notifier', { filter: { clusterId } }).then(() => cs.all('notifier')), });
+    return hash({ notifiers: cs.find('notifier', null, { filter: { clusterId } }).then(() => cs.all('notifier')) });
   },
 
   setDefaultRoute: on('activate', function() {

--- a/app/models/notifier.js
+++ b/app/models/notifier.js
@@ -134,7 +134,7 @@ export default Resource.extend({
   findAlerts(){
     const globalStore = get(this, 'globalStore');
     const clusterId = get(this, 'clusterId');
-    const clusterAlertGroups = globalStore.findAll('clusterAlertGroup', { filter: { clusterId } });
+    const clusterAlertGroups = globalStore.find('clusterAlertGroup', null, { filter: { clusterId } });
     const projectAlertGroups = globalStore.findAll('projectAlertGroup');
 
     return hash({

--- a/lib/alert/addon/edit-rule/route.js
+++ b/lib/alert/addon/edit-rule/route.js
@@ -67,7 +67,7 @@ export default Route.extend(EditOrClone, {
     }
 
     return hash({
-      nodes:      globalStore.findAll('node', opt),
+      nodes:      globalStore.find('node', null, opt),
       notifiers:  globalStore.findAll('notifier'),
       alertRule:  globalStore.find('clusterAlertRule', ruleId),
       alertGroup:   globalStore.find('clusterAlertGroup', groupId),
@@ -107,10 +107,10 @@ export default Route.extend(EditOrClone, {
 
     return hash({
       pods:         store.find('pod', null),
-      statefulsets: store.findAll('statefulset', opt),
-      daemonsets:   store.findAll('daemonset', opt),
-      deployments:  store.findAll('deployment', opt),
-      notifiers:    globalStore.findAll('notifier', { filter: { clusterId } }),
+      statefulsets: store.find('statefulset', null, opt),
+      daemonsets:   store.find('daemonset', null, opt),
+      deployments:  store.find('deployment', null, opt),
+      notifiers:    globalStore.find('notifier', null, { filter: { clusterId } }),
       metrics,
       alertRule:    globalStore.find('projectAlertRule', ruleId),
       alertGroup:   globalStore.find('projectAlertGroup', groupId),

--- a/lib/alert/addon/edit/route.js
+++ b/lib/alert/addon/edit/route.js
@@ -122,7 +122,7 @@ export default Route.extend({
     }
 
     return hash({
-      nodes:      globalStore.findAll('node', opt),
+      nodes:      globalStore.find('node', null, opt),
       notifiers:  globalStore.findAll('notifier'),
       alertRules: globalStore.find('clusterAlertRule'),
       alertGroup: globalStore.find('clusterAlertGroup', groupId),
@@ -206,10 +206,10 @@ export default Route.extend({
 
     return hash({
       pods:         store.find('pod', null),
-      statefulsets: store.findAll('statefulset', opt),
-      daemonsets:   store.findAll('daemonset', opt),
-      deployments:  store.findAll('deployment', opt),
-      notifiers:    globalStore.findAll('notifier', { filter: { clusterId } }),
+      statefulsets: store.find('statefulset', null, opt),
+      daemonsets:   store.find('daemonset', null, opt),
+      deployments:  store.find('deployment', null, opt),
+      notifiers:    globalStore.find('notifier', null, { filter: { clusterId } }),
       metrics,
       alertRules:   globalStore.find('projectAlertRule'),
       alertGroup:   globalStore.find('projectAlertGroup', groupId),

--- a/lib/alert/addon/index/route.js
+++ b/lib/alert/addon/index/route.js
@@ -38,11 +38,9 @@ export default Route.extend({
     const gs = get(this, 'globalStore');
     // const clusterId = this.modelFor('cluster').get('id');
     const opt = { filter: { clusterId }, };
-    const notifiers = gs.findAll('notifier', opt);
-    const alerts = gs.findAll('clusterAlertRule', opt).then(() => {
-      return gs.all('clusterAlertRule', opt);
-    });
-    const groups = gs.findAll('clusterAlertGroup', opt)
+    const notifiers = gs.find('notifier', null, opt);
+    const alerts = gs.find('clusterAlertRule', null, opt);
+    const groups = gs.find('clusterAlertGroup', null, opt)
 
     return hash({
       alerts,
@@ -52,11 +50,9 @@ export default Route.extend({
   },
   loadProjectResource({ clusterId, projectId }) {
     let gs = get(this, 'globalStore');
-    const notifiers = gs.findAll('notifier', { filter: { clusterId } });
-    const alerts = gs.findAll('projectAlertRule', { filter: { projectId } }).then(() => {
-      return gs.all('projectAlertRule');
-    });
-    const groups = gs.findAll('projectAlertGroup', { filter: { projectId } })
+    const notifiers = gs.find('notifier', null, { filter: { clusterId } });
+    const alerts = gs.find('projectAlertRule', null, { filter: { projectId } });
+    const groups = gs.find('projectAlertGroup', null, { filter: { projectId } })
 
     return hash({
       alerts,

--- a/lib/alert/addon/new-rule/route.js
+++ b/lib/alert/addon/new-rule/route.js
@@ -86,8 +86,8 @@ export default Route.extend(EditOrClone, {
     const opt = { filter: { clusterId } };
 
     return hash({
-      nodes:      globalStore.findAll('node', opt),
-      notifiers:  globalStore.findAll('notifier', opt),
+      nodes:      globalStore.find('node', null, opt),
+      notifiers:  globalStore.find('notifier', null, opt),
       alertRule:  newAlert,
       alertGroup: globalStore.find('clusterAlertGroup', groupId),
     }).then((hash) => {
@@ -153,9 +153,9 @@ export default Route.extend(EditOrClone, {
     const opt = { filter: { projectId } };
 
     return hash({
-      pods:       store.findAll('pod', opt),
-      workloads:  store.findAll('workload', opt),
-      notifiers:  globalStore.findAll('notifier', { filter: { clusterId } }),
+      pods:       store.find('pod', null, opt),
+      workloads:  store.find('workload', null, opt),
+      notifiers:  globalStore.find('notifier', null, { filter: { clusterId } }),
       alertRule:  newAlert,
       alertGroup: globalStore.find('projectAlertGroup', groupId),
     }).then(({

--- a/lib/alert/addon/new/route.js
+++ b/lib/alert/addon/new/route.js
@@ -68,8 +68,8 @@ export default Route.extend({
     const opt = { filter: { clusterId } };
 
     return hash({
-      nodes:      globalStore.findAll('node', opt),
-      notifiers:  globalStore.findAll('notifier', opt),
+      nodes:      globalStore.find('node', null, opt),
+      notifiers:  globalStore.find('notifier', null, opt),
       alertRules: this.getNewClusterAlert(),
       alertGroup: globalStore.createRecord({ type: 'clusterAlertGroup' }),
     }).then((hash) => {
@@ -120,9 +120,9 @@ export default Route.extend({
     const opt = { filter: { projectId } };
 
     return hash({
-      pods:       store.findAll('pod', opt),
-      workloads:  store.findAll('workload', opt),
-      notifiers:  globalStore.findAll('notifier', { filter: { clusterId } }),
+      pods:       store.find('pod', null, opt),
+      workloads:  store.find('workload', null, opt),
+      notifiers:  globalStore.find('notifier', null, { filter: { clusterId } }),
       alertRules: this.getNewProjectAlert(),
       alertGroup: globalStore.createRecord({ type: 'projectAlertGroup' }),
     }).then(({

--- a/lib/logging/addon/logging/route.js
+++ b/lib/logging/addon/logging/route.js
@@ -24,7 +24,7 @@ export default Route.extend({
       const clusterId = cluster.get('id');
       const opt = { filter: { clusterId, }, };
 
-      return globalStore.findAll('clusterlogging', opt).then((loggings) => {
+      return globalStore.find('clusterlogging', null, opt).then((loggings) => {
         let logging = loggings.filterBy('clusterId', clusterId).get('firstObject');
 
         if (!logging) {
@@ -45,8 +45,8 @@ export default Route.extend({
       const projectOpt = { filter: { projectId, }, };
 
       return hash({
-        clusterLoggings: globalStore.findAll('clusterlogging', clusterOpt),
-        projectLoggings: globalStore.findAll('projectlogging', projectOpt),
+        clusterLoggings: globalStore.find('clusterlogging', null, clusterOpt),
+        projectLoggings: globalStore.find('projectlogging', null, projectOpt),
       }).then((hash) => {
         let logging = hash.projectLoggings.filterBy('projectId', projectId).get('firstObject');
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
In alerting and logging module, `findAll` is not used correctly in some cases.
We should use `find` instead of `findAll` if you would like to use `filter` option.

Many places are trying to do something like `findAll('notifier', { filter: { clusterId } })`

However, `findAll` will always returns `all`. So filter stuff won't work sometimes. For example, you will see this https://github.com/rancher/rancher/issues/19599#issuecomment-486828724

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/19599

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
