### PR TITLE
Add UpCloud node driver

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -5966,6 +5966,7 @@ nodeDriver:
     rackspace: RackSpace
     softlayer: SoftLayer
     tencenttke: Tencent TKE
+    upcloud: UpCloud
     vmwarevsphere: vSphere
     zstack: ZStack
   driverOptions: "{driver} Options"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->
Add the properly cased name for `UpCloud` node driver.

There's already a working [UI Driver](https://github.com/montel-ig/ui-driver-upcloud) and [`docker-machine` driver](https://github.com/montel-ig/docker-machine-driver-upcloud).

Types of changes
======
- New feature


Further comments
======
It could be useful to have a way to override the default _capitalized_ display name provided by the [`node-driver` model](https://github.com/rancher/ui/blob/master/app/models/nodedriver.js#L49). I'm not entirely familiar with Ember, but maybe a way to override the computed variable?