### PR TITLE
[2.2.3] Remove redundant storage option for azure disk storage class

### DIFF
--- a/lib/shared/addon/components/storage-class/provisioner-azure-disk/component.js
+++ b/lib/shared/addon/components/storage-class/provisioner-azure-disk/component.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import layout from './template';
 import StorageClassProvisioner from 'shared/mixins/storage-class-provisioner';
-import { get, set, setProperties } from '@ember/object';
+import { set, setProperties } from '@ember/object';
 
 const KIND_OPTIONS = [
   {
@@ -21,65 +21,40 @@ const KIND_OPTIONS = [
 export default Component.extend(StorageClassProvisioner, {
   layout,
 
-  provisioner: 'azure-disk',
-  kindOptions: KIND_OPTIONS,
+  kindOptions:        KIND_OPTIONS,
 
-  volumeType:         'new',
   skuName:            null,
   location:           null,
   storageAccount:     null,
   storageaccounttype: null,
+
   kind:               'shared',
+  provisioner:        'azure-disk',
 
   didReceiveAttrs() {
     const changes = {};
-    const skuName = get(this, 'parameters.skuName') || '';
-    const location = get(this, 'parameters.location') || '';
-    const storageAccount = get(this, 'parameters.storageAccount') || '';
+    let { parameters = {} }                            = this;
+    const { storageaccounttype = '', kind = 'shared' } = parameters;
 
-    const storageaccounttype = get(this, 'parameters.storageaccounttype') || '';
-    const kind = get(this, 'parameters.kind') || 'shared';
+    changes['storageaccounttype'] = storageaccounttype;
+    changes['kind']               = kind;
 
-    if (skuName || location || storageAccount) {
-      changes['skuName'] = skuName;
-      changes['location'] = location;
-      changes['storageAccount'] = storageAccount;
-      changes['volumeType'] = 'unmanaged';
-    } else {
-      changes['storageaccounttype'] = storageaccounttype;
-      changes['kind'] = kind;
-      changes['volumeType'] = 'new';
-    }
     setProperties(this, changes);
   },
 
+  // registered in the StorageClassProvisioner mixin
   updateParams() {
-    const type = get(this, 'volumeType');
-    const skuName = get(this, 'skuName');
-    const location = get(this, 'location');
-    const storageAccount = get(this, 'storageAccount');
-    const storageaccounttype = get(this, 'storageaccounttype');
-    const kind = get(this, 'kind');
+    const {
+      storageaccounttype,
+      kind,
+      out = {}
+    } = this;
 
-    const out = {};
-
-    if (type === 'unmanaged') {
-      if (skuName) {
-        out['skuName'] = skuName;
-      }
-      if (location) {
-        out['location'] = location;
-      }
-      if (storageAccount) {
-        out['storageAccount'] = storageAccount;
-      }
-    } else {
-      if (storageaccounttype) {
-        out['storageaccounttype'] = storageaccounttype;
-      }
-      if (kind) {
-        out['kind'] = kind;
-      }
+    if (storageaccounttype) {
+      out['storageaccounttype'] = storageaccounttype;
+    }
+    if (kind) {
+      out['kind'] = kind;
     }
 
     set(this, 'parameters', out);

--- a/lib/shared/addon/components/storage-class/provisioner-azure-disk/template.hbs
+++ b/lib/shared/addon/components/storage-class/provisioner-azure-disk/template.hbs
@@ -1,69 +1,33 @@
-<div class="row">
-  {{#if editing}}
-    <div class="radio">
-      <label>
-        {{radio-button selection=volumeType value='unmanaged'}}
-        {{t 'cruStorageClass.azure-disk.unmanaged'}}
-      </label>
-    </div>
-    <div class="radio">
-      <label>
-        {{radio-button selection=volumeType value='new'}}
-        {{t 'cruStorageClass.azure-disk.new'}}
-      </label>
-    </div>
-  {{else if (eq volumeType 'unmanaged')}}
-    {{t 'cruStorageClass.azure-disk.unmanaged'}}
-  {{else}}
-    {{t 'cruStorageClass.azure-disk.new'}}
-  {{/if}}
+<div class="row mb-20">
+  <div class="col span-4">
+    <label class="acc-label">
+      {{t (concat "cruStorageClass." provisioner ".storageaccounttype.label")}}
+    </label>
+    {{#input-or-display editable=editing value=storageaccounttype}}
+      {{input
+        type="text"
+        value=storageaccounttype
+        classNames="form-control"
+        placeholder=(t (concat "cruStorageClass." provisioner ".storageaccounttype.placeholder"))
+      }}
+    {{/input-or-display}}
+  </div>
+  <div class="col span-4">
+    <label class="acc-label">
+      {{t (concat "cruStorageClass." provisioner ".kind.label")}}
+    </label>
+    {{#if editing}}
+      {{new-select
+        classNames="form-control"
+        content=kindOptions
+        value=kind
+        optionLabelPath="translationKey"
+        localizedLabel=true
+      }}
+    {{else}}
+      <div class="text-muted">
+        {{kind}}
+      </div>
+    {{/if}}
+  </div>
 </div>
-
-{{#if (eq volumeType 'unmanaged')}}
-  <div class="row mb-20">
-    <div class="col span-4">
-      <label class="acc-label">{{t (concat 'cruStorageClass.' provisioner '.skuName.label')}}</label>
-      {{#input-or-display editable=editing value=skuName}}
-        {{input type="text" value=skuName classNames="form-control" placeholder=(t (concat 'cruStorageClass.' provisioner '.skuName.placeholder'))}}
-      {{/input-or-display}}
-    </div>
-    <div class="col span-4">
-      <label class="acc-label">{{t (concat 'cruStorageClass.' provisioner '.location.label')}}</label>
-      {{#input-or-display editable=editing value=location}}
-        {{input type="text" value=location classNames="form-control" placeholder=(t (concat 'cruStorageClass.' provisioner '.location.placeholder'))}}
-      {{/input-or-display}}
-    </div>
-    <div class="col span-4">
-      <label class="acc-label">{{t (concat 'cruStorageClass.' provisioner '.storageAccount.label')}}</label>
-      {{#input-or-display editable=editing value=storageAccount}}
-        {{input type="text" value=storageAccount classNames="form-control" placeholder=(t (concat 'cruStorageClass.' provisioner '.storageAccount.placeholder'))}}
-      {{/input-or-display}}
-    </div>
-  </div>
-{{else}}
-  <div class="row mb-20">
-    <div class="col span-4">
-      <label class="acc-label">{{t (concat 'cruStorageClass.' provisioner '.storageaccounttype.label')}}</label>
-      {{#input-or-display editable=editing value=storageaccounttype}}
-        {{input type="text" value=storageaccounttype classNames="form-control" placeholder=(t (concat 'cruStorageClass.' provisioner '.storageaccounttype.placeholder'))}}
-      {{/input-or-display}}
-    </div>
-    <div class="col span-4">
-      <label class="acc-label">{{t (concat 'cruStorageClass.' provisioner '.kind.label')}}</label>
-
-      {{#if editing}}
-        {{new-select
-          classNames="form-control"
-          content=kindOptions
-          value=kind
-          optionLabelPath="translationKey"
-          localizedLabel=true
-        }}
-      {{else}}
-        <div class="text-muted">
-          {{kind}}
-        </div>
-      {{/if}}
-    </div>
-  </div>
-{{/if}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3474,6 +3474,7 @@ cruPersistentVolume:
     volumePath:
       label: Volume Path
       placeholder: "e.g. /"
+
 cruStorageClass:
   name:
     placeholder: e.g. storage
@@ -3569,7 +3570,6 @@ cruStorageClass:
       placeholder: "e.g. 20"
   azure-disk:
     new: New Azure Disk
-    unmanaged: Azure Unmanaged Disk
     skuName:
       label: Sku Name
       placeholder: "e.g. Standard_LRS"
@@ -3584,8 +3584,8 @@ cruStorageClass:
       placeholder: "e.g. Standard_LRS"
     kind:
       label: Kind
-      shared: Shared
-      dedicated: Dedicated
+      shared: Shared (unmanaged disk)
+      dedicated: Dedicated (unmanaged disk)
       managed: Managed
       placeholder: "e.g. Shared"
   azure-file:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

"Unmanaged" disk has become redundant for Azure Disk based storage classes. Both  "kind: shared" and "kind: dedicated" options are unmanaged disk options. Added this indication to the labels in the dropdown so it is clear to the user. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#19863

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
