### PR TITLE
Add colon to templates that utilize generic.restarts and generic.podRestarts

### DIFF
--- a/app/components/accordion-container/template.hbs
+++ b/app/components/accordion-container/template.hbs
@@ -34,7 +34,7 @@
         <td data-title="{{dt.image}}">
           {{inst.image}}
         </td>
-        <td data-title="{{dt.restarts}}">
+        <td data-title="{{dt.restarts}}:">
           {{inst.restarts}}
         </td>
         <td data-title="{{dt.actions}}" class="actions">

--- a/app/components/accordion-pod/template.hbs
+++ b/app/components/accordion-pod/template.hbs
@@ -44,7 +44,7 @@
             {{#if inst.displayIp}}
               {{inst.displayIp}} /
             {{/if}}
-            {{t 'generic.createdDate' date=(date-from-now inst.created) htmlSafe=true}} / {{t 'generic.restarts'}} {{inst.restarts}}
+            {{t 'generic.createdDate' date=(date-from-now inst.created) htmlSafe=true}} / {{t 'generic.restarts'}}: {{inst.restarts}}
           </p>
         </td>
         <td data-title="{{dt.node}}">

--- a/app/components/pod-row/template.hbs
+++ b/app/components/pod-row/template.hbs
@@ -42,7 +42,7 @@
         <a class="text-vertical-top" href="{{href-to "authenticated.cluster.monitoring.node-detail" scope.currentCluster.id model.node.id}}">{{model.node.displayName}}</a> /
       {{/if}}
       {{t 'generic.createdDate' date=(date-from-now model.created) htmlSafe=true}} /
-      {{t 'generic.restarts'}} {{model.restarts}}
+      {{t 'generic.restarts'}}: {{model.restarts}}
     </p>
   </td>
   {{#if scalePlaceholder}}

--- a/app/components/workload-row/template.hbs
+++ b/app/components/workload-row/template.hbs
@@ -44,7 +44,7 @@
           date=(date-from-now model.created)
           htmlSafe=true
         }} /
-        {{t "generic.podRestarts"}} {{model.restarts}}
+        {{t "generic.podRestarts"}}: {{model.restarts}}
       </p>
     </td>
   {{/if}}

--- a/app/pod/template.hbs
+++ b/app/pod/template.hbs
@@ -78,7 +78,7 @@
   <div class="vertical-middle">
     <label class="acc-label vertical-middle p-0">{{t "generic.created"}}:</label>
     {{date-calendar model.created}}
-    <div class="text-muted text-small">{{t "generic.restarts"}} {{model.restarts}}</div>
+    <div class="text-muted text-small">{{t "generic.restarts"}}: {{model.restarts}}</div>
   </div>
 </div>
 

--- a/app/workload/template.hbs
+++ b/app/workload/template.hbs
@@ -124,7 +124,7 @@
       </label>
       {{date-calendar service.created}}
       <div class="text-muted text-small">
-        {{t "generic.podRestarts"}} {{service.restarts}}
+        {{t "generic.podRestarts"}}: {{service.restarts}}
       </div>
     </div>
   </div>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -82,7 +82,7 @@ generic:
   owner: Owner
   paste: Paste
   pod: pod
-  podRestarts: 'Pod Restarts:'
+  podRestarts: Pod Restarts
   port: Port
   ports: Ports
   prefix: prefix
@@ -91,7 +91,7 @@ generic:
   persistentVolume: persistent volume
   random: Random
   remove: Remove
-  restarts: 'Restarts:'
+  restarts: Restarts
   role: Role
   save: Save
   saved: Saved

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -82,7 +82,7 @@ generic:
   owner: Owner
   paste: Paste
   pod: pod
-  podRestarts: Pod Restarts
+  podRestarts: 'Pod Restarts:'
   port: Port
   ports: Ports
   prefix: prefix
@@ -91,7 +91,7 @@ generic:
   persistentVolume: persistent volume
   random: Random
   remove: Remove
-  restarts: Restarts
+  restarts: 'Restarts:'
   role: Role
   save: Save
   saved: Saved


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->
Add a colon to the end of "Pod Restarts" and "Restarts" (generic.podRestarts, generic.restarts) for improved formatting and readability. One template has this but they all should where needed.

Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->
Bugfix, non-breaking

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 
https://github.com/rancher/rancher/issues/17891

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
Adds a colon in these areas:
![Screen Shot 2019-04-30 at 2 34 34 PM](https://user-images.githubusercontent.com/45179589/56994850-1b8b0a80-6b55-11e9-81a9-cf3ff3bb6ba3.png)
![Screen Shot 2019-04-30 at 2 33 52 PM](https://user-images.githubusercontent.com/45179589/56994854-1e85fb00-6b55-11e9-97a6-467e670feee5.png)

Pod Restarts > Pod Restarts:
Restarts > Restarts: