### PR TITLE
[2.2.3] refactor private registry to simplify UX

### DIFF
--- a/lib/shared/addon/components/cru-private-registry/component.js
+++ b/lib/shared/addon/components/cru-private-registry/component.js
@@ -1,69 +1,58 @@
 import Component from '@ember/component';
 import layout from './template';
-import { get, set, observer } from '@ember/object';
-import { alias } from '@ember/object/computed';
+import { get, set, setProperties, observer } from '@ember/object';
+import { alias, gt } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-
-
-const headers = [
-  {
-    name:           'url',
-    classNames:     ['text-center'],
-    translationKey: 'cruPrivateRegistry.registry.url.label',
-  },
-  {
-    name:           'user',
-    classNames:     ['text-center'],
-    translationKey: 'cruPrivateRegistry.registry.user.label',
-  },
-  {
-    name:           'password',
-    classNames:     ['text-center'],
-    sort:           false,
-    translationKey: 'cruPrivateRegistry.registry.password.label',
-  },
-  {
-    name:           'default',
-    classNames:     ['text-center'],
-    translationKey: 'cruPrivateRegistry.registry.default.label',
-    width:          250,
-  },
-  {
-    name:           'remove',
-    sort:           false,
-    classNames:     ['text-center'],
-    width:          50,
-  }
-];
 
 export default Component.extend({
   globalStore:       service(),
 
   layout,
-  headers,
 
   configName:        'rancherKubernetesEngineConfig',
-  cluster:           null,
-  config:            null,
-  editing:           true,
-  urlInvalid:        null,
-  urlWarning:        null,
-  urlError:          null,
+  cluster:               null,
+  config:                null,
+  editing:               true,
+  urlInvalid:            null,
+  urlWarning:            null,
+  urlError:              null,
 
-  privateRegistries: alias('config.privateRegistries'),
+  enablePrivateRegistry: false,
+  privateRegistry:       null,
+  privateRegistries:     alias('config.privateRegistries'),
+  multipleRegistries:    gt('privateRegistries.length', 1),
 
   init() {
     this._super(...arguments);
 
     set(this, 'config', get(this, `cluster.${ get(this, 'configName') }`));
+
+    if (this.config.privateRegistries) {
+      if ( this.config.privateRegistries.length >= 1 ) {
+        setProperties(this, {
+          privateRegistry:       get(this, 'config.privateRegistries.firstObject'),
+          enablePrivateRegistry: true,
+        });
+      }
+    }
   },
 
   actions: {
     addRegistry() {
-      this.addRegistry(this.newPrivateRegistry());
+      this.addRegistry(set(this, 'privateRegistry', this.newPrivateRegistry()));
     },
 
     removeRegistry(registry) {
+      let match = null;
+
+      if (this.multipleRegistries) {
+        let prWithout = this.privateRegistries.without(registry);
+
+        match = prWithout.length >= 1 ? prWithout.firstObject : null;
+      }
+
+      set(this, 'privateRegistry', match)
+
       this.removeRegistry(registry);
     },
   },
@@ -75,6 +64,14 @@ export default Component.extend({
       set(this, 'hasDefault', true);
     } else {
       set(this, 'hasDefault', false);
+    }
+  }),
+
+  enablePrivateRegistryChanged: observer('enablePrivateRegistry', function() {
+    if (this.enablePrivateRegistry) {
+      this.send('addRegistry');
+    } else {
+      this.send('removeRegistry', this.privateRegistry);
     }
   }),
 

--- a/lib/shared/addon/components/cru-private-registry/template.hbs
+++ b/lib/shared/addon/components/cru-private-registry/template.hbs
@@ -1,72 +1,180 @@
-{{#sortable-table
-     body=privateRegistries
-     bulkActions=false
-     classNames="grid sortable-table"
-     descending=false
-     headers=headers
-     pagingLabel="pagination.nodePool"
-     rowActions=false
-     search=false
-     as |sortable kind reg dt|
-}}
-  {{#if (eq kind "row")}}
-    <tr class="main-row">
-      <td data-title="{{dt.url}}" class="text-center pr-5 pt-5">
-        {{#input-or-display
+<div class="row">
+  <div class="col span-6">
+    <label class="acc-label">
+      {{t "cruPrivateRegistry.title.label"}}
+    </label>
+    <div class="radio">
+      <label>
+        {{radio-button
+          selection=enablePrivateRegistry
+          value=false
+          disabled=(if multipleRegistries true false)
+        }}
+        {{t "generic.disabled"}}
+      </label>
+    </div>
+    <div class="radio">
+      <label>
+        {{radio-button
+          selection=enablePrivateRegistry
+          value=true
+          disabled=(if multipleRegistries true false)
+        }}
+        {{t "generic.enabled"}}
+      </label>
+    </div>
+  </div>
+</div>
+
+{{#if enablePrivateRegistry}}
+  <div class="row">
+    <div class="col {{if multipleRegistries "span-3" "span-4"}}">
+      <label class="acc-label" for="cru-private-registry-url">
+        {{t "cruPrivateRegistry.registry.url.label"}}
+      </label>
+      {{#input-or-display
+         editable=editing
+         value=privateRegistry.url
+      }}
+        {{input-url
+          id="cru-private-registry-url"
+          classNames="form-control input-sm"
+          isInvalid=(action (mut urlInvalid))
+          urlWarning=(action (mut urlWarning))
+          urlError=(action (mut urlError))
+          value=privateRegistry.url
+          stripScheme=false
+        }}
+      {{/input-or-display}}
+    </div>
+    <div class="col {{if multipleRegistries "span-3" "span-4"}}">
+      <label class="acc-label" for="cru-private-registry-username">
+        {{t "cruPrivateRegistry.registry.user.label"}}
+      </label>
+      {{#input-or-display
+         editable=editing
+         value=privateRegistry.user
+      }}
+        {{input
+          id="cru-private-registry-username"
+          class="input-sm"
+          type="text"
+          value=privateRegistry.user
+        }}
+      {{/input-or-display}}
+    </div>
+    <div class="col {{if multipleRegistries "span-3" "span-4"}}">
+      <label class="acc-label" for="cru-private-registry-password">
+        {{t "cruPrivateRegistry.registry.password.label"}}
+      </label>
+      {{#input-or-display
+         id="cru-private-registry-password"
+         editable=editing
+         obfuscate=true
+         value=privateRegistry.password
+      }}
+        {{input
+          class="conceal input-sm"
+          type="password"
+          value=privateRegistry.password
+        }}
+      {{/input-or-display}}
+    </div>
+    {{#if multipleRegistries}}
+      <div class="col span-2">
+        <label class="acc-label">
+          {{t "cruPrivateRegistry.registry.default.label"}}
+        </label>
+        <div class="text-center m-5">
+          {{input
+            type="checkbox"
+            checked=privateRegistry.isDefault
+            disabled=(and (not privateRegistry.isDefault) hasDefault)
+          }}
+        </div>
+      </div>
+      <div class="col span-1">
+        <button class="btn bg-primary btn-sm mt-25" {{action "removeRegistry" privateRegistry}}>
+          <i class="icon icon-minus"/>
+        </button>
+      </div>
+    {{/if}}
+  </div>
+{{/if}}
+
+{{!-- this really shouldn't happen but its in place to handle multiple sys reg added in api level which isn't current suuported by the UI --}}
+{{#if multipleRegistries}}
+  {{#each privateRegistries as |reg idx|}}
+    {{!-- skip the first item as its above --}}
+    {{#if (gt idx 0)}}
+      <div class="row">
+        <div class="col span-3">
+          <label class="acc-label">
+            {{t "cruPrivateRegistry.registry.url.label"}}
+          </label>
+          {{#input-or-display
              editable=editing
              value=reg.url
-        }}
-          {{input-url
+          }}
+            {{input-url
               classNames="form-control input-sm"
               isInvalid=(action (mut urlInvalid))
               urlWarning=(action (mut urlWarning))
               urlError=(action (mut urlError))
               value=reg.url
               stripScheme=false
-          }}
-        {{/input-or-display}}
-      </td>
-      <td data-title="{{dt.user}}" class="text-center pr-5 pt-5">
-        {{#input-or-display
+            }}
+          {{/input-or-display}}
+        </div>
+        <div class="col span-3">
+          <label class="acc-label">
+            {{t "cruPrivateRegistry.registry.user.label"}}
+          </label>
+          {{#input-or-display
              editable=editing
              value=reg.user
-        }}
-          {{input
+          }}
+            {{input
               class="input-sm"
               type="text"
               value=reg.user
-          }}
-        {{/input-or-display}}
-      </td>
-      <td data-title="{{dt.password}}" class="text-center pr-5 pt-5">
-        {{#input-or-display
+            }}
+          {{/input-or-display}}
+        </div>
+        <div class="col span-3">
+          <label class="acc-label">
+            {{t "cruPrivateRegistry.registry.password.label"}}
+          </label>
+          {{#input-or-display
              editable=editing
              obfuscate=true
              value=reg.password
-        }}
-          {{input
+          }}
+            {{input
               class="conceal input-sm"
               type="password"
               value=reg.password
-          }}
-        {{/input-or-display}}
-      </td>
-      <td data-title="{{dt.default}}" class="text-center">
-        <label>
-          {{input
+            }}
+          {{/input-or-display}}
+        </div>
+        <div class="col span-2">
+          <label class="acc-label">
+            {{t "cruPrivateRegistry.registry.default.label"}}
+          </label>
+          <div class="text-center m-5">
+            {{input
               type="checkbox"
               checked=reg.isDefault
               disabled=(and (not reg.isDefault) hasDefault)
-          }}
-        </label>
-      </td>
-      <td data-title="{{dt.remove}}" class="text-center">
-        <button class="btn bg-primary btn-sm" {{action "removeRegistry" reg}}><i class="icon icon-minus"/></button>
-      </td>
-    </tr>
-  {{else if (eq kind "norows")}}
-    <tr><td colspan="{{sortable.fullColspan}}" class="text-center text-muted pt-40 pb-40">{{t 'cruPrivateRegistry.noData'}}</td></tr>
-  {{/if}}
-{{/sortable-table}}
-
-<button class="btn bg-primary mt-20" {{action "addRegistry"}}><i class="icon icon-plus"/><span class="ml-10">{{t 'cruPrivateRegistry.add.label'}}</span></button>
+            }}
+          </div>
+        </div>
+        <div class="col span-1">
+          <button class="btn bg-primary btn-sm mt-25" {{action "removeRegistry" reg}}>
+            <i class="icon icon-minus"/>
+          </button>
+        </div>
+      </div>
+    {{/if}}
+  {{/each}}
+{{/if}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1074,7 +1074,7 @@ cruVolumeClaimTemplate:
 cruPrivateRegistry:
   title:
     label: Private Registries
-    detail: Add private registries to this cluster
+    detail: Configure a default private registry for this cluster. When enabled, all images required for cluster provisioning and system add-ons startup will be pulled from this registry.
   noData: This cluster does not have any private registries defined
   defaultError: You must designate one private registry as the default
   add:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

The UX for the previous iteration of private registry at the cluster level was confusing as it was not quite clear what effect adding private registry did. The UX was simplified to only support a single private registry at this time. 

* You can only add one private registry to the cluster through the UI via `enable` / `disabled`
* The registry is defaulted to `isDefault` true and this is not configurable from the UI
* The copy in the accordion has been updated to add clarity as to what a private registry does at the cluster level. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Refactor
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#19345

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
