### PR TITLE
Add height to main nav for low-res screen firefox issues.

### DIFF
--- a/app/styles/components/_page-header.scss
+++ b/app/styles/components/_page-header.scss
@@ -49,6 +49,7 @@ $project-nav-active: $dropdown-link-hover-bg !default;
       border-radius: 3px 0 0 3px;
       padding: 0;
       vertical-align: middle;
+      height: 50px;
 
       &.nav-main {
         flex-grow: 1;


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

On low res (non-hidpi) displays with Firefox only the height of the main nav drops to 49px while the user nav always stays at 50. I'm not sure why it only happens on low-res screens only but we can resolve it by setting the height. This doesn't affect other browsers afaikt.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#19101

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
