### PR TITLE
Prevent Double Load of Generic Icon on MC Apps

### DIFF
--- a/app/components/namespace-app/component.js
+++ b/app/components/namespace-app/component.js
@@ -1,23 +1,11 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import layout from './template';
+import LazyIcon from 'shared/mixins/lazy-icon';
 
-export default Component.extend({
+export default Component.extend(LazyIcon, {
   scope:         service(),
   layout,
   classNames:    ['namespace-app'],
-  srcSet:        false,
   latestVersion: null,
-
-  didRender() {
-    if (!this.get('srcSet')) {
-      this.set('srcSet', true);
-      var $icon = this.$('.catalog-icon > img');
-
-      $icon.attr('src', $icon.data('src'));
-      this.$('img').on('error', () => {
-        $icon.attr('src', `${ this.get('app.baseAssets') }assets/images/generic-catalog.svg`);
-      });
-    }
-  }
 });

--- a/lib/global-admin/addon/components/multi-cluster-app/component.js
+++ b/lib/global-admin/addon/components/multi-cluster-app/component.js
@@ -1,30 +1,12 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import layout from './template';
-import { set } from '@ember/object';
+import LazyIcon from 'shared/mixins/lazy-icon';
 
-export default Component.extend({
+export default Component.extend(LazyIcon, {
   scope:         service(),
   layout,
   classNames:    ['namespace-app'],
   srcSet:        false,
   latestVersion: null,
-
-  didRender() {
-    this.initAppIcon();
-  },
-
-  initAppIcon() {
-    if (!this.get('srcSet')) {
-      set(this, 'srcSet', true);
-
-      const $icon = this.$('.catalog-icon > img');
-
-      $icon.attr('src', $icon.data('src'));
-
-      this.$('img').on('error', () => {
-        $icon.attr('src', `${ this.get('app.baseAssets') }assets/images/generic-catalog.svg`);
-      });
-    }
-  },
 });

--- a/lib/shared/addon/components/catalog-box/component.js
+++ b/lib/shared/addon/components/catalog-box/component.js
@@ -1,9 +1,9 @@
 import Component from '@ember/component';
 import layout from './template';
 import { inject as service } from '@ember/service'
-import { set, get } from '@ember/object';
+import LazyIcon from 'shared/mixins/lazy-icon';
 
-export default Component.extend({
+export default Component.extend(LazyIcon, {
   settings:          service(),
   router:            service(),
   layout,
@@ -17,37 +17,8 @@ export default Component.extend({
   showSource:        false,
   showDescription:   true,
   active:            true,
-  srcSet:            false,
-  genericIconPath:   null,
-
-  init() {
-    this._super(...arguments);
-
-    set(this, 'genericIconPath', `${ get(this, 'app.baseAssets') }assets/images/generic-catalog.svg`);
-  },
 
   didRender() {
-    if (!get(this, 'srcSet')) {
-      set(this, 'srcSet', true);
-
-      var $icon = this.$('.catalog-icon > img');
-      const $srcPath = $icon.attr('src');
-
-      if ($srcPath === this.genericIconPath) {
-        $icon.attr('src', $icon.data('src'));
-
-        this.$('img').on('error', () => {
-          if ( this.isDestroyed || this.isDestroying ) {
-            if (this.$('img')) {
-              this.$('img').off('error');
-            }
-
-            return;
-          }
-
-          $icon.attr('src', this.genericIconPath);
-        });
-      }
-    }
+    this.initAppIcon();
   },
 });

--- a/lib/shared/addon/mixins/lazy-icon.js
+++ b/lib/shared/addon/mixins/lazy-icon.js
@@ -1,0 +1,38 @@
+import Mixin from '@ember/object/mixin';
+import { set, get } from '@ember/object';
+
+export default Mixin.create({
+  srcSet:            false,
+  genericIconPath: null,
+
+  init() {
+    this._super(...arguments);
+
+    set(this, 'genericIconPath', `${ get(this, 'app.baseAssets') }assets/images/generic-catalog.svg`);
+  },
+
+  initAppIcon() {
+    if (!get(this, 'srcSet')) {
+      set(this, 'srcSet', true);
+
+      var $icon = this.$('.catalog-icon > img');
+      const $srcPath = $icon.attr('src');
+
+      if ($srcPath === this.genericIconPath) {
+        $icon.attr('src', $icon.data('src'));
+
+        this.$('img').on('error', () => {
+          if ( this.isDestroyed || this.isDestroying ) {
+            if (this.$('img')) {
+              this.$('img').off('error');
+            }
+
+            return;
+          }
+
+          $icon.attr('src', this.genericIconPath);
+        });
+      }
+    }
+  },
+});

--- a/lib/shared/app/mixins/lazy-icon.js
+++ b/lib/shared/app/mixins/lazy-icon.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/mixins/lazy-icon';


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Refactor the generic icon loading to a mixin to be consumed in multiple components
Only fetch generic icon on render not init to avoid the double load issue as the app moves through states
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#17668
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
