### PR TITLE
[2.2.4] Expose Secret Ref for Cinder Persistent Volumes

### DIFF
--- a/app/authenticated/cluster/storage/persistent-volumes/detail/edit/controller.js
+++ b/app/authenticated/cluster/storage/persistent-volumes/detail/edit/controller.js
@@ -3,7 +3,7 @@ import Controller from '@ember/controller';
 export default Controller.extend({
   actions: {
     back() {
-      this.send('goToPrevious', 'authenticated.cluster.storage.classes');
+      this.send('goToPrevious', 'authenticated.cluster.storage.persistent-volumes');
     },
   },
 });

--- a/app/components/cru-persistent-volume/component.js
+++ b/app/components/cru-persistent-volume/component.js
@@ -76,6 +76,13 @@ export default Component.extend(ViewNewEdit, {
     return out.sortBy('priority', 'label');
   }),
 
+  sourceDisplayName: computed('sourceName', 'sourceChoices.[]', function() {
+    const { sourceChoices, sourceName } = this;
+    const match = sourceChoices.findBy('name', sourceName);
+
+    return match ? get(match, 'label') : '';
+  }),
+
   sourceComponent: computed('sourceName', function() {
     const name = get(this, 'sourceName');
     const sources = getSources('persistent');

--- a/app/components/cru-persistent-volume/template.hbs
+++ b/app/components/cru-persistent-volume/template.hbs
@@ -59,15 +59,21 @@
 {{else}}
   <div class="row">
     <div class="col span-6">
-      <label class="acc-label">{{t 'cruPersistentVolume.source.label'}}{{field-required editing=editing}}</label>
-      {{new-select
-        content=sourceChoices
-        prompt="cruPersistentVolume.source.prompt"
-        localizedPrompt=true
-        optionValuePath="name"
-        value=sourceName
-        readOnly=isView
+      <label class="acc-label">
+        {{t "cruPersistentVolume.source.label"}}{{field-required editing=editing}}
+      </label>
+      {{#input-or-display
+         editable=isNew
+         value=sourceDisplayName
       }}
+        {{new-select
+          content=sourceChoices
+          prompt="cruPersistentVolume.source.prompt"
+          localizedPrompt=true
+          optionValuePath="name"
+          value=sourceName
+        }}
+      {{/input-or-display}}
     </div>
     <div class="col span-6">
       <label class="acc-label">{{t 'cruPersistentVolume.capacity.label'}}{{field-required editing=editing}}</label>
@@ -95,7 +101,7 @@
       {{component sourceComponent
         volume=model
         sourceStore=clusterStore
-        editing=notView
+        editing=isNew
       }}
     {{else}}
       <p class="text-muted">{{t 'cruVolume.sourcePrompt'}}</p>
@@ -154,8 +160,8 @@
     </div>
     <div class="row mt-20">
       <label class="acc-label">{{t 'cruPersistentVolume.nodeAffinity.label'}}</label>
-      {{form-node-affinity 
-        model=model.nodeAffinity.required 
+      {{form-node-affinity
+        model=model.nodeAffinity.required
         editing=notView
         changed=(action "updateNodeAffinities")
       }}

--- a/app/components/volume-source/source-cinder/template.hbs
+++ b/app/components/volume-source/source-cinder/template.hbs
@@ -1,35 +1,104 @@
-  <div class="row mb-20">
-    <div class="col span-6">
-      <label class="acc-label">{{t 'cruPersistentVolume.cinder.volumeID.label'}}</label>
-      {{#input-or-display editable=editing value=config.volumeID}}
-        {{input type="text" value=config.volumeID classNames="form-control" placeholder=(t 'cruPersistentVolume.cinder.volumeID.placeholder')}}
-      {{/input-or-display}}
-    </div>
-
-    <div class="col span-6">
-      <label class="acc-label">{{t 'cruPersistentVolume.cinder.fsType.label'}}</label>
-      {{#input-or-display editable=editing value=config.fsType}}
-        {{input type="text" value=config.fsType classNames="form-control" placeholder=(t 'cruPersistentVolume.cinder.fsType.placeholder')}}
-      {{/input-or-display}}
-    </div>
+<div class="row mb-20">
+  <div class="col span-6">
+    <label class="acc-label" for="volume-source-cinder-volume-id">
+      {{t "cruPersistentVolume.cinder.volumeID.label"}}
+    </label>
+    {{#input-or-display
+       editable=editing
+       value=config.volumeID
+    }}
+      {{input
+        type="text"
+        value=config.volumeID
+        classNames="form-control"
+        placeholder=(t "cruPersistentVolume.cinder.volumeID.placeholder")
+        id="volume-source-cinder-volume-id"
+      }}
+    {{/input-or-display}}
   </div>
 
-  <div class="row">
-    <div class="col span-6">
-      <label class="acc-label">{{t 'cruPersistentVolume.cinder.readOnly.label'}}</label>
-      {{#if editing}}
-        <div class="text-muted">
-          <label>
-            {{radio-button selection=config.readOnly value=true}} {{t 'generic.yes'}}
-          </label>
-          <label>
-            {{radio-button selection=config.readOnly value=false}} {{t 'generic.no'}}
-          </label>
-        </div>
-      {{else}}
-        <div class="text-muted">
-          {{config.readOnly}}
-        </div>
-      {{/if}}
-    </div>
+  <div class="col span-6">
+    <label class="acc-label" for="volume-source-cinder-fs-type">
+      {{t "cruPersistentVolume.cinder.fsType.label"}}
+    </label>
+    {{#input-or-display
+       editable=editing
+       value=config.fsType
+    }}
+      {{input
+        type="text"
+        value=config.fsType
+        classNames="form-control"
+        placeholder=(t "cruPersistentVolume.cinder.fsType.placeholder")
+        id="volume-source-cinder-fs-type"
+      }}
+    {{/input-or-display}}
   </div>
+</div>
+
+<div class="row mb-20">
+  <div class="col span-6">
+    <label class="acc-label" for="volume-source-cinder-secret-ref">
+      {{t "cruPersistentVolume.cinder.secretRef.name.label"}}
+    </label>
+    {{#input-or-display
+       editable=editing
+       value=config.secretRef.name
+    }}
+      {{input
+        type="text"
+        value=config.secretRef.name
+        classNames="form-control"
+        placeholder=(t "cruPersistentVolume.cinder.secretRef.name.placeholder")
+        id="volume-source-cinder-secret-ref"
+      }}
+    {{/input-or-display}}
+  </div>
+
+  <div class="col span-6">
+    <label class="acc-label" for="volume-source-cinder-secret-namespace">
+      {{t "cruPersistentVolume.cinder.secretRef.namespace.label"}}
+    </label>
+    {{#input-or-display
+       editable=editing
+       value=config.secretRef.namespace
+    }}
+      {{input
+        type="text"
+        value=config.secretRef.namespace
+        classNames="form-control"
+        placeholder=(t "cruPersistentVolume.cinder.secretRef.namespace.placeholder")
+        id="volume-source-cinder-secret-namespace"
+      }}
+    {{/input-or-display}}
+  </div>
+</div>
+
+<div class="row">
+  <div class="col span-6">
+    <label class="acc-label">
+      {{t "cruPersistentVolume.cinder.readOnly.label"}}
+    </label>
+    {{#input-or-display
+       editable=editing
+       value=config.readOnly
+    }}
+      <div class="text-muted">
+        <label for="volume-source-cinder-readonly-true">
+          {{radio-button
+            selection=config.readOnly
+            value=true
+            id="volume-source-cinder-readonly-true"
+          }} {{t "generic.yes"}}
+        </label>
+        <label for="volume-source-cinder-readonly-false">
+          {{radio-button
+            selection=config.readOnly
+            value=false
+            id="volume-source-cinder-readonly-false"
+          }} {{t "generic.no"}}
+        </label>
+      </div>
+    {{/input-or-display}}
+  </div>
+</div>

--- a/lib/shared/addon/components/input-or-display/component.js
+++ b/lib/shared/addon/components/input-or-display/component.js
@@ -2,21 +2,28 @@ import { computed } from '@ember/object';
 import Component from '@ember/component';
 import SafeStyle from 'shared/mixins/safe-style';
 import layout from './template';
+import { isEmpty } from '@ember/utils';
 
 
 export default Component.extend(SafeStyle, {
   layout,
+
   tagName:           'span',
   value:             null,
   editable:          true,
   classesForInput:   'form-control',
   classesForDisplay: '',
   obfuscate:         false,
+
   obfuscatedValue:   computed('value', function() {
     let val = this.get('value') || '';
     let count = val.length;
     let obChar = '*';
 
     return new Array(count + 1).join(obChar);
-  })
+  }),
+
+  hasValue: computed('value', function() {
+    return !isEmpty(this.value);
+  }),
 });

--- a/lib/shared/addon/components/input-or-display/template.hbs
+++ b/lib/shared/addon/components/input-or-display/template.hbs
@@ -1,13 +1,19 @@
 {{#if editable}}
   {{yield}}
 {{else}}
-  {{#if value}}
+  {{#if hasValue}}
     {{#if obfuscate}}
-      <div class={{classesForDisplay}}>{{obfuscatedValue}}</div>
+      <div class={{classesForDisplay}}>
+        {{obfuscatedValue}}
+      </div>
     {{else}}
-      <div class={{classesForDisplay}}>{{value}}</div>
+      <div class={{classesForDisplay}}>
+        {{value}}
+      </div>
     {{/if}}
   {{else}}
-    <div class="{{classesForDisplay}} text-muted">{{t 'generic.na'}}</div>
+    <div class="{{classesForDisplay}} text-muted">
+      {{t "generic.na"}}
+    </div>
   {{/if}}
 {{/if}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1043,6 +1043,9 @@ cruPersistentVolumeClaim:
   storageClass:
     label: Storage Class
     prompt: Use the default class
+  secretRequired:
+    name: Secret Name
+    namespace: Secret Namespace
 
 cruVolumeClaimTemplate:
   title:
@@ -3381,6 +3384,14 @@ cruPersistentVolume:
     volumeID:
       label: Volume ID
       placeholder: "e.g. vol"
+    secretRef:
+      name:
+        label: Secret Name
+        placeholder: "e.g. abc"
+      namespace:
+        label: Secret Namespace
+        placeholder: "e.g. default"
+      label: Secret Name
   photonPersistentDisk:
     fsType:
       label: Filesystem Type


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Openstack Cinder volumes were updated in a previous release and the secret ref was never exposed with the schema update. This pr exposes the new ref. It also passes the correct "editing" mode to the components so they may display the inputs correctly in new vs edit. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#19237
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
