### PR TITLE
expose APP_NAME environment variable for setting appName

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -167,6 +167,14 @@ module.exports = function(environment) {
     ENV.APP.pl = 'rancher';
   }
 
+  var appName = process.env.APP_NAME;
+
+  if( appName ) 
+  {
+	ENV.APP.appName = appName;
+
+  }
+
   return ENV;
 };
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This allows you to set the appName via environment variable APP_NAME so you can override the default title that is shown on each page. This helps in deciphering between dev and production environments when the user may have multiple rancher enviroments open
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->


