### PR TITLE
Filter projects without clusters from MC apps targets

### DIFF
--- a/lib/shared/addon/components/form-project-targets/component.js
+++ b/lib/shared/addon/components/form-project-targets/component.js
@@ -35,13 +35,13 @@ export default Component.extend({
   }),
 
   allProjectsGroupedByCluster: computed('projects.[]', 'targets.@each.projectId', function() {
-    return get(this, 'projects').map( (p) => {
-      const clusterDisplayNameOrNa =  get(p, 'cluster.displayName') || this.intl.t('generic.na');
+    return get(this, 'projects').filter((p) => get(p, 'cluster')).map( (p) => {
+      const clusterDisplayName =  get(p, 'cluster.displayName');
 
       const out = {
         name:    get(p, 'name'),
         value:   get(p, 'id'),
-        cluster: clusterDisplayNameOrNa
+        cluster: clusterDisplayName
       };
 
       if (get(this, 'targets').findBy('projectId', p.id)) {


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

`form-project-targets` was calling the `intl` service when it was not being included. This was causing a `uncaught type` error that would prevent the user from selecting a project. I removed the service and filtered out projects without clusters from the target dropdown. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#20698

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

Why we have projects without clusters is being investigated by the backend team but we have no ticket right now.
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
