### PR TITLE
[master]UI should load js and ccs files only for active cluster drivers

### DIFF
--- a/lib/global-admin/addon/clusters/new/route.js
+++ b/lib/global-admin/addon/clusters/new/route.js
@@ -59,7 +59,7 @@ export default Route.extend({
     // show the driver in the ui, greyed out, and possibly add error text "can not load comonent from url [put url here]"
 
     let { kontainerDrivers } = model;
-    let externalDrivers      = kontainerDrivers.filter( (d) => d.uiUrl !== '');
+    let externalDrivers      = kontainerDrivers.filter( (d) => d.uiUrl !== '' && d.state === 'active');
     let promises = {};
 
     externalDrivers.forEach( (d) => {


### PR DESCRIPTION
Proposed changes
======
1. UI should load js and ccs files only for active cluster drivers

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======

https://github.com/rancher/rancher/issues/21108
