### PR TITLE
[2.2.5]UI should load js and ccs files only for active cluster drivers

### DIFF
--- a/lib/global-admin/addon/clusters/new/route.js
+++ b/lib/global-admin/addon/clusters/new/route.js
@@ -68,7 +68,7 @@ export default Route.extend({
     // show the driver in the ui, greyed out, and possibly add error text "can not load comonent from url [put url here]"
 
     let { kontainerDrivers } = model;
-    let externalDrivers      = kontainerDrivers.filter( (d) => d.uiUrl !== '');
+    let externalDrivers      = kontainerDrivers.filter( (d) => d.uiUrl !== '' && d.state === 'active');
     let promises = {};
 
     externalDrivers.forEach( (d) => {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
rancher/rancher:v2.2.4

Steps:

Do not enable Baidu cluster driver
Click Add Cluster
Check the network tab in Chrome.
Results:

UI will load js files even for inactive cluster drivers

Expected:

UI should load js and ccs files only for active cluster drivers

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
https://github.com/rancher/rancher/issues/21109