### PR TITLE
Fix Fluentd target logging cert disappear after click test button

### DIFF
--- a/lib/logging/addon/components/logging/new-edit/component.js
+++ b/lib/logging/addon/components/logging/new-edit/component.js
@@ -338,14 +338,15 @@ export default Component.extend(NewOrEdit, {
     return url
   },
 
-  doneSaving() {
+  doneSaving(neu) {
     if (get(this, 'targetType') !== 'customTarget') {
       set(this, 'customContent', `<match *>\n</match>`)
     }
 
-    if (this.refreshModel) {
-      this.refreshModel();
-    }
+    setProperties(this, {
+      model:         neu.clone().patch(),
+      originalModel: neu.clone(),
+    })
   },
 
   initCustomContent() {

--- a/lib/logging/addon/logging/controller.js
+++ b/lib/logging/addon/logging/controller.js
@@ -3,10 +3,4 @@ import Controller from '@ember/controller';
 export default Controller.extend({
   queryParams: ['targetType'],
   targetType:  'none',
-
-  actions: {
-    refreshModel() {
-      this.send('refresh');
-    }
-  }
 });

--- a/lib/logging/addon/logging/route.js
+++ b/lib/logging/addon/logging/route.js
@@ -74,12 +74,6 @@ export default Route.extend({
     });
   },
 
-  actions: {
-    refresh() {
-      this.refresh();
-    }
-  },
-
   setDefaultRoute: on('activate', function() {
     set(this, `session.${ get(this, 'pageScope') === 'cluster' ? C.SESSION.CLUSTER_ROUTE : C.SESSION.PROJECT_ROUTE }`, `authenticated.${ get(this, 'pageScope') }.logging`);
   }),

--- a/lib/logging/addon/logging/template.hbs
+++ b/lib/logging/addon/logging/template.hbs
@@ -3,5 +3,4 @@
   originalModel=model.originalLogging
   clusterLogging=model.clusterLogging
   targetType=targetType
-  refreshModel=(action "refreshModel")
 }}


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Remove refresh action after clicking the save button.

Types of changes
======

- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality not to work as expected)

-->

Linked Issues
======

https://github.com/rancher/rancher/issues/17782

<!--

Link any related issues, pull-requests, or commit hashes that are relevant to this pull-request.

If you are opening a PR without a corresponding issue, create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->

When the first time clicks the save button, a model which is created by store changed to a model which found in store.  When the `model()` function begins, the cert disappear. And display after the request respond. In fact, using the responding data instead of request again will be a better solution. So I remove the refresh action.