### PR TITLE
Add ui warning about expiring certificates

### DIFF
--- a/app/components/modal-rotate-certificates/component.js
+++ b/app/components/modal-rotate-certificates/component.js
@@ -3,6 +3,7 @@ import { get, set, setProperties } from '@ember/object';
 import Component from '@ember/component';
 import ModalBase from 'shared/mixins/modal-base';
 import layout from './template';
+import { alias } from '@ember/object/computed';
 
 export default Component.extend(ModalBase, {
   growl:            service(),
@@ -13,6 +14,7 @@ export default Component.extend(ModalBase, {
   services:         null,
   selectedServices: null,
   mode:             'single',
+  model:            alias('modalService.modalOpts.model'),
 
   init() {
     this._super(...arguments);
@@ -24,7 +26,38 @@ export default Component.extend(ModalBase, {
   },
 
   didReceiveAttrs() {
-    set(this, 'services', this.modalOpts.serviceDefaults);
+    if (this.model.certsExpiring) {
+      const { expiringCerts } = this.model;
+      let etcdNodes           = (expiringCerts || []).filter((cert) => cert.expiringCertName.includes('etcd'));
+
+      set(this, 'services', this.modalOpts.serviceDefaults.map((cert) => {
+        let expiringCert = null;
+        let expiresIn = null;
+        // this.modalOpts.serviceDefaults;
+
+        if (cert === 'kubelet') {
+          expiringCert = expiringCerts.findBy('expiringCertName', 'kube-node');
+          expiresIn    = expiringCert.daysUntil;
+        } else if (cert === 'etcd'){
+          // there can be multiple etcd nodes with different cert expires, we can grab and alert the soonest expiring cert date since 'rofateCertificates' action will rotates all etcd node certs at the same time.
+          expiringCert = etcdNodes.sortBy('daysUntil').get('firstObject');
+          expiresIn    = expiringCert.daysUntil;
+        } else {
+          expiringCert = expiringCerts.findBy('expiringCertName', cert);
+          expiresIn    = expiringCert.daysUntil;
+        }
+
+        return {
+          label: expiringCert ? `${ cert } (expires in ${ expiresIn } days)` : `${ cert }`,
+          value: cert,
+        }
+      }));
+    } else {
+      set(this, 'services', this.modalOpts.serviceDefaults.map((serv) => ( {
+        label: serv,
+        value: serv
+      } )));
+    }
   },
 
   actions: {

--- a/app/components/modal-rotate-certificates/component.js
+++ b/app/components/modal-rotate-certificates/component.js
@@ -37,32 +37,29 @@ export default Component.extend(ModalBase, {
 
       set(this, 'services', this.modalOpts.serviceDefaults.map((cert) => {
         let expiringCert = null;
-        let expiresIn = null;
+        let expiresIn    = null;
 
         if (cert === 'kubelet') {
           expiringCert = expiringCerts.findBy('expiringCertName', 'kube-node');
         } else if (cert === 'etcd' && etcdNodes.length > 0){
           // there can be multiple etcd nodes with different cert expires, we can grab and alert the soonest expiring cert date since 'rofateCertificates' action will rotates all etcd node certs at the same time.
-          expiringCert = etcdNodes.sortBy('daysUntil').get('firstObject');
+          expiringCert = etcdNodes.sortBy('milliUntil').get('firstObject');
         } else {
           expiringCert = expiringCerts.findBy('expiringCertName', cert);
         }
 
-        if (expiringCert && !isEmpty(expiringCert.daysUntil)) {
-          expiresIn    = expiringCert.daysUntil;
+        if (expiringCert && !isEmpty(expiringCert.exactDateTime)) {
+          expiresIn    = expiringCert.exactDateTime;
 
-          if (expiresIn === 0) {
-            expiresIn = moment(expiringCert.exactDateTime).diff(moment(), 'hours');
-            certLabel = this.intl.t('modalRotateCertificates.expiring.hours', {
+          if (expiringCert.milliUntil > 0) {
+            certLabel = this.intl.t('modalRotateCertificates.expiring.until', {
               cert,
-              expiresIn
+              expiresIn: moment(expiresIn).fromNow(),
             });
-          } else if (expiresIn < 0) {
-            certLabel = this.intl.t('modalRotateCertificates.expiring.expired', { cert });
           } else {
-            certLabel = this.intl.t('modalRotateCertificates.expiring.days', {
+            certLabel = this.intl.t('modalRotateCertificates.expiring.from', {
               cert,
-              expiresIn
+              expiresIn: moment(expiresIn).fromNow(),
             });
           }
         } else {

--- a/app/components/modal-rotate-certificates/template.hbs
+++ b/app/components/modal-rotate-certificates/template.hbs
@@ -8,17 +8,6 @@
 <section class="p-20 pt-0">
   <div class="row">
     <div class="col span-11-of-23">
-      {{!--
-            <div class="radio">
-            <label>
-            {{radio-button
-            selection=mode
-            value="caAndService"
-            }}
-            {{t "modalRotateCertificates.caCerts"}}
-            </label>
-            </div>
-            --}}
       <div class="radio">
         <label>
           {{radio-button
@@ -58,10 +47,10 @@
           {{/unless}}
           {{#each services as |choice|}}
             <option
-              value="{{choice}}"
-              selected={{eq choice value}}
+              value="{{choice.value}}"
+              selected={{eq choice.value value}}
             >
-              {{choice}}
+              {{choice.label}}
             </option>
           {{/each}}
         </select>

--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -214,15 +214,15 @@ export default Resource.extend(Grafana, ResourceUsage, {
       let expKeys = Object.keys(certificatesExpiration);
 
       expKeys.forEach((kee) => {
-        const certDate = get(certificatesExpiration[kee], 'expirationDate');
-        const expirey  = moment(certDate);
-        const diff     = expirey.diff(moment(), 'days');
+        let certDate  = get(certificatesExpiration[kee], 'expirationDate');
+        const expirey = moment(certDate);
+        let diff      = expirey.diff(moment(), 'days');
 
         if (diff < 30) {
           expiringCerts.pushObject({
             expiringCertName: kee,
             daysUntil:        diff,
-            exactDateTime:    expirey.format('YYYY-MM-DD HH:mm:ss')
+            exactDateTime:    expirey
           });
         }
       });

--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -9,6 +9,7 @@ import { equal, alias } from '@ember/object/computed';
 import { resolve } from 'rsvp';
 import C from 'ui/utils/constants';
 import { isEmpty } from '@ember/utils';
+import moment from 'moment';
 
 const FLANNEL = 'flannel';
 const HOST_GW = 'host-gw';
@@ -19,22 +20,23 @@ const BACKEND_VNI = '4096';
 export default Resource.extend(Grafana, ResourceUsage, {
   globalStore: service(),
   growl:       service(),
-  scope:       service(),
-  router:      service(),
   intl:        service(),
+  router:      service(),
+  scope:       service(),
 
-  namespaces:                  hasMany('id', 'namespace', 'clusterId'),
-  projects:                    hasMany('id', 'project', 'clusterId'),
-  nodes:                       hasMany('id', 'node', 'clusterId'),
-  nodePools:                   hasMany('id', 'nodePool', 'clusterId'),
   clusterRoleTemplateBindings: hasMany('id', 'clusterRoleTemplateBinding', 'clusterId'),
   etcdbackups:                 hasMany('id', 'etcdbackup', 'clusterId'),
+  namespaces:                  hasMany('id', 'namespace', 'clusterId'),
+  nodePools:                   hasMany('id', 'nodePool', 'clusterId'),
+  nodes:                       hasMany('id', 'node', 'clusterId'),
+  projects:                    hasMany('id', 'project', 'clusterId'),
+  expiringCerts:               null,
   grafanaDashboardName:        'Cluster',
   isMonitoringReady:           false,
   machines:                    alias('nodes'),
   roleTemplateBindings:        alias('clusterRoleTemplateBindings'),
-  isGKE:                       equal('driver', 'googleKubernetesEngine'),
   isAKS:                       equal('driver', 'azureKubernetesService'),
+  isGKE:                       equal('driver', 'googleKubernetesEngine'),
 
   conditionsDidChange:        on('init', observer('enableClusterMonitoring', 'conditions.@each.status', function() {
     if ( !get(this, 'enableClusterMonitoring') ) {
@@ -199,6 +201,38 @@ export default Resource.extend(Grafana, ResourceUsage, {
     out = projects.objectAt(0);
 
     return out;
+  }),
+
+  certsExpiring: computed('certificatesExpiration', function() {
+    let { certificatesExpiration = {}, expiringCerts } = this;
+
+    if (!expiringCerts) {
+      expiringCerts = [];
+    }
+
+    if (!isEmpty(certificatesExpiration)) {
+      let expKeys = Object.keys(certificatesExpiration);
+
+      expKeys.forEach((kee) => {
+        const certDate = get(certificatesExpiration[kee], 'expirationDate');
+        const expirey  = moment(certDate);
+        const diff     = expirey.diff(moment(), 'days');
+
+        if (diff < 30) {
+          expiringCerts.pushObject({
+            expiringCertName: kee,
+            daysUntil:        diff,
+            exactDateTime:    expirey.format('YYYY-MM-DD HH:mm:ss')
+          });
+        }
+      });
+
+      set(this, 'expiringCerts', expiringCerts);
+
+      return expiringCerts.length > 0;
+    }
+
+    return false;
   }),
 
   availableActions: computed('actionLinks.{rotateCertificates}', function() {

--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -216,13 +216,13 @@ export default Resource.extend(Grafana, ResourceUsage, {
       expKeys.forEach((kee) => {
         let certDate  = get(certificatesExpiration[kee], 'expirationDate');
         const expirey = moment(certDate);
-        let diff      = expirey.diff(moment(), 'days');
+        let diff      = expirey.diff(moment());
 
-        if (diff < 30) {
+        if (diff < 2592000000) { // milliseconds in a month
           expiringCerts.pushObject({
             expiringCertName: kee,
-            daysUntil:        diff,
-            exactDateTime:    expirey
+            milliUntil:       diff,
+            exactDateTime:    certDate
           });
         }
       });

--- a/app/styles/components/_tooltip.scss
+++ b/app/styles/components/_tooltip.scss
@@ -158,6 +158,12 @@
     }
   }
 
+  .tooltip-expire {
+    a {
+      color: $tooltip-link-color;
+    }
+  }
+
 }
 
 .tooltip-warning-container {

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -142,6 +142,7 @@ $dropdown-caret-color                : #000;
 
 //** Tooltip text color
 $tooltip-color                       : white;
+$tooltip-link-color                  : white;
 //** Tooltip background color
 $tooltip-bg                          : rgba($black,.9);
 $tooltip-opacity                     : .9;

--- a/app/styles/themes/_light.scss
+++ b/app/styles/themes/_light.scss
@@ -46,3 +46,5 @@ $footer                              : $light-grey !default;
 $border                              : $light-grey !default;
 
 $shadow                              : rgba($mid-grey, 0.35) !default;
+
+$tooltip-link-color                  : $link-color;

--- a/app/styles/themes/_light.scss
+++ b/app/styles/themes/_light.scss
@@ -47,4 +47,4 @@ $border                              : $light-grey !default;
 
 $shadow                              : rgba($mid-grey, 0.35) !default;
 
-$tooltip-link-color                  : $link-color;
+$tooltip-link-color                  : darken($light-grey, 10);

--- a/lib/global-admin/addon/components/cluster-row/template.hbs
+++ b/lib/global-admin/addon/components/cluster-row/template.hbs
@@ -8,7 +8,20 @@
     {{badge-state model=model}}
   </td>
   <td data-title="{{dt.name}}">
-    {{#link-to-external 'authenticated.cluster' model.id}}{{model.displayName}}{{/link-to-external}}
+    {{#link-to-external "authenticated.cluster" model.id}}
+      {{model.displayName}}
+    {{/link-to-external}}
+    {{#if model.certsExpiring}}
+      {{#tooltip-element
+         type="tooltip-expiring"
+         model=model
+         tooltipTemplate="tooltip-static"
+         aria-describedby="tooltip-base"
+         tooltipFor="tooltipCertExpire"
+      }}
+        <i class="icon icon-alert text-warning" />
+      {{/tooltip-element}}
+    {{/if}}
   </td>
   <td data-title="{{dt.provider}}">
     {{#if model.version.gitVersion}}
@@ -20,11 +33,11 @@
   </td>
   {{#if (eq model.state "inactive")}}
     <td colspan="3" class="text-center">
-      {{t 'clusterRow.noHosts'}}
+      {{t "clusterRow.noHosts"}}
     </td>
   {{else}}
     <td data-title="{{dt.nodes}}">
-      {{#link-to-external 'authenticated.cluster.nodes' model.id}}
+      {{#link-to-external "authenticated.cluster.nodes" model.id}}
         {{model.machines.length}}
       {{/link-to-external}}
     </td>
@@ -34,7 +47,7 @@
         <p class="text-small text-muted m-0">{{model.cpuPercent}}</p>
       {{else}}
         <span class="text-muted">
-          {{t 'generic.na'}}
+          {{t "generic.na"}}
         </span>
       {{/if}}
     </td>
@@ -45,7 +58,7 @@
         <p class="text-small text-muted m-0">{{model.memoryPercent}}</p>
       {{else}}
         <span class="text-muted">
-          {{t 'generic.na'}}
+          {{t "generic.na"}}
         </span>
       {{/if}}
     </td>

--- a/lib/monitoring/addon/components/cluster-dashboard/component.js
+++ b/lib/monitoring/addon/components/cluster-dashboard/component.js
@@ -30,6 +30,9 @@ export default Component.extend(CatalogUpgrade, {
   componentStatuses: alias('scope.currentCluster.componentStatuses'),
 
   actions: {
+    rotate() {
+      this.cluster.send('rotateCertificates');
+    },
     enableMonitoring() {
       get(this, 'router').transitionTo('authenticated.cluster.monitoring.cluster-setting');
     },

--- a/lib/monitoring/addon/components/cluster-dashboard/template.hbs
+++ b/lib/monitoring/addon/components/cluster-dashboard/template.hbs
@@ -1,3 +1,8 @@
+{{#if cluster.certsExpiring}}
+  {{#banner-message color="bg-warning"}}
+    <p>{{~t "tooltipExpire.pre"~}}<a href="#" {{action "rotate"}}>{{~t "tooltipExpire.rotate" ~}}</a>{{~t "tooltipExpire.post"~}}</p>
+  {{/banner-message}}
+{{/if}}
 {{#if showDashboard}}
   {{cluster-basic-info cluster=cluster}}
 

--- a/lib/monitoring/addon/components/cluster-dashboard/template.hbs
+++ b/lib/monitoring/addon/components/cluster-dashboard/template.hbs
@@ -1,6 +1,6 @@
 {{#if cluster.certsExpiring}}
   {{#banner-message color="bg-warning"}}
-    <p>{{~t "tooltipExpire.pre"~}}<a href="#" {{action "rotate"}}>{{~t "tooltipExpire.rotate" ~}}</a>{{~t "tooltipExpire.post"~}}</p>
+    <p>{{t "tooltipExpire.label"}} <a href="#" {{action "rotate"}}>{{t "tooltipExpire.link"}}</a></p>
   {{/banner-message}}
 {{/if}}
 {{#if showDashboard}}

--- a/lib/shared/addon/components/tooltip-expiring/component.js
+++ b/lib/shared/addon/components/tooltip-expiring/component.js
@@ -1,0 +1,17 @@
+import Component from '@ember/component';
+import layout from './template';
+import Tooltip from 'shared/mixins/tooltip';
+import { alias } from '@ember/object/computed';
+
+export default Component.extend(Tooltip, {
+  layout,
+
+  model: alias('tooltipService.tooltipOpts.model'),
+
+  actions: {
+    rotateCertificates() {
+      this.model.send('rotateCertificates')
+      this.tooltipService.hide();
+    }
+  }
+});

--- a/lib/shared/addon/components/tooltip-expiring/template.hbs
+++ b/lib/shared/addon/components/tooltip-expiring/template.hbs
@@ -1,3 +1,8 @@
 <span class="tooltip-expire">
-  {{~t "tooltipExpire.pre"~}}<a href="#" {{action "rotateCertificates"}}>{{~t "tooltipExpire.rotate" ~}}</a>{{~t "tooltipExpire.post"~}}
+  <p class="mb-5">
+    {{t "tooltipExpire.label"}}
+  </p>
+  <a href="#" {{action "rotateCertificates"}}>
+    {{t "tooltipExpire.link"}}
+  </a>
 </span>

--- a/lib/shared/addon/components/tooltip-expiring/template.hbs
+++ b/lib/shared/addon/components/tooltip-expiring/template.hbs
@@ -1,0 +1,3 @@
+<span class="tooltip-expire">
+  {{~t "tooltipExpire.pre"~}}<a href="#" {{action "rotateCertificates"}}>{{~t "tooltipExpire.rotate" ~}}</a>{{~t "tooltipExpire.post"~}}
+</span>

--- a/lib/shared/app/components/tooltip-expiring/component.js
+++ b/lib/shared/app/components/tooltip-expiring/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/tooltip-expiring/component';

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -7269,6 +7269,13 @@ tooltipWarning:
   notConfigured: Access Control Not Configured
   dismiss: Dismiss
 
+tooltipExpire:
+  label: 'This cluster has certs expiring in 30 days or less. Please rotate your certificates now.'
+  button: 'Rotate Certificates'
+  pre: 'This cluster has certs expiring in 30 days or less. Please '
+  rotate: 'rotate'
+  post: ' your certificates now.'
+
 upgradeBtn:
   version:
     current: 'Current'

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -5956,9 +5956,8 @@ modalRotateCertificates:
   select:
     all: Select a service
   expiring:
-    days: '{ cert } (expires in { expiresIn } days)'
-    hours: '{ cert } (expires in { expiresIn } hours)'
-    expired: '{ cert } (expired)'
+    until: '{ cert } (expires { expiresIn })'
+    from: '{ cert } (expired { expiresIn })'
 
 modalRollbackService:
   title: 'Rollback "{instanceName}"'

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -7274,7 +7274,7 @@ tooltipWarning:
 
 tooltipExpire:
   label: 'This cluster has certs that are expiring or have expired.'
-  link: 'Roatate Now'
+  link: 'Rotate Now'
 
 upgradeBtn:
   version:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -5955,6 +5955,10 @@ modalRotateCertificates:
   dropdownLabel: Services
   select:
     all: Select a service
+  expiring:
+    days: '{ cert } (expires in { expiresIn } days)'
+    hours: '{ cert } (expires in { expiresIn } hours)'
+    expired: '{ cert } (expired)'
 
 modalRollbackService:
   title: 'Rollback "{instanceName}"'
@@ -7270,11 +7274,8 @@ tooltipWarning:
   dismiss: Dismiss
 
 tooltipExpire:
-  label: 'This cluster has certs expiring in 30 days or less. Please rotate your certificates now.'
-  button: 'Rotate Certificates'
-  pre: 'This cluster has certs expiring in 30 days or less. Please '
-  rotate: 'rotate'
-  post: ' your certificates now.'
+  label: 'This cluster has certs that are expiring or have expired.'
+  link: 'Roatate Now'
 
 upgradeBtn:
   version:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Adds new logic to expose a warning when clusters certificates will be expiring in 30 days or less.
At the global level when a cluster has certs that are expiring there will be a small warning icon next to the cluster name with a tooltip explanation and link action to open the rotate certs modal. 
At the cluster level on the cluster page you will see a warning banner above your cluster details with the same explanation/link action that opens the rotate certs modal. 
In the rotate certs modal you will see the cert selection dropdown now adds the time in days until expiration. One choice that may confuse but was talked through with @moelsayed affects the etcd service.  Rke alerts us of every etcd node that has a cert expiring. In the UI we only show the date from the earliest etcd service cert that will expire since the rotate action on a cluster rotates ALL the etcd node certs. 

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

New Feature
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#20923
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
