### PR TITLE
[2.2.5] Add custom CA option to s3 backup config for rke clusters

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -320,7 +320,7 @@
 
           </div>
           <div class="row">
-            <div class="col span-6">
+            <div class="col span-12">
 
               <label class="acc-label">{{t "clusterNew.rke.etcd.location.label"}}</label>
               <div>
@@ -378,7 +378,6 @@
             </div>
 
             <div class="row">
-
               <div class="col span-3">
                 <label class="acc-label">{{t "clusterNew.rke.etcd.backupConfig.accessKey.label"}}</label>
                 {{input
@@ -400,7 +399,24 @@
                   value=cluster.rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.secretKey
                 }}
               </div>
-
+            </div>
+            <div class="row">
+              <div class="col span-7">
+                <label class="acc-label" for="s3-config-custom-ca">
+                  {{t "clusterNew.rke.etcd.backupConfig.customCa.label"}}
+                </label>
+                {{input-text-file
+                  accept="application/x-x509-ca-cert,text/plain,.pem,.crt"
+                  canChangeName=false
+                  classNames="box"
+                  id="s3-config-custom-ca"
+                  minHeight=60
+                  multiple=true
+                  placeholder="clusterNew.rke.etcd.backupConfig.customCa.placeholder"
+                  shouldChangeName=false
+                  value=cluster.rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.customCa
+                }}
+              </div>
             </div>
           {{/unless}}
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -2845,6 +2845,9 @@ clusterNew:
         endpoint:
           label: S3 Region Endpoint
           placeholder: "s3.us-west-2.amazonaws.com"
+        customCa:
+          label: Custom CA Certificate
+          placeholder: "Paste in the certificate and any necessary chain certificates, starting with -----BEGIN CERTIFICATE-----"
         accessKey:
           label: S3 Access Key
           placeholder: Your AWS access key


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Enhancement
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#21104
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

QA:
New field is located in Advanced Cluster Options -> etcd Snapshot Backup Target = s3 -> Custom CA Certificate or `rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.customCa` via the api.
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
