### PR TITLE
[2.2] AKS: Don't explode if subnets is null

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-azureaks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-azureaks/component.js
@@ -163,11 +163,11 @@ export default Component.extend(ClusterDriver, {
   }),
 
   filteredVirtualNetworks: computed('config.virtualNetwork', 'virtualNetworks', function() {
-    const vnets = get(this, 'virtualNetworks');
+    const vnets = get(this, 'virtualNetworks') || [];
     const subNets = [];
 
     vnets.forEach( (vnet) => {
-      get(vnet, 'subnets').forEach( (subnet) => {
+      (get(vnet, 'subnets') || []).forEach( (subnet) => {
         subNets.pushObject({
           name:  `${ get(subnet, 'name') } (${ get(subnet, 'addressRange') })`,
           group: get(vnet, 'name'),


### PR DESCRIPTION
Proposed changes
======

The AKS UI dies if a virtual network has `null` subnets

Types of changes
======

Bugfix