### PR TITLE
[master]Location and Size fields can not display correctly for newly added node driver in node template list page

### DIFF
--- a/app/models/nodetemplate.js
+++ b/app/models/nodetemplate.js
@@ -99,7 +99,7 @@ export default Resource.extend({
 
       this.registerDynamicComputedProperty('displayLocation', computedKeys, location.getDisplayProperty);
     } else {
-      set(this, 'displayLocation', 'N/A');
+      set(this, 'displayLocation', get(this, 'config.region') || 'N/A');
     }
   },
 
@@ -112,7 +112,7 @@ export default Resource.extend({
 
       this.registerDynamicComputedProperty('displaySize', computedKeys, size.getDisplayProperty);
     } else {
-      set(this, 'displaySize', 'N/A');
+      set(this, 'displaySize', get(this, 'config.size') || 'N/A');
     }
   },
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Location and Size fields can not display correctly for newly added node driver in node template list page.

We don't want to change Rancher UI code for a new custom node driver.

Add default displayLocation key (config.region) and displaySize key (config.size) in nodetemplate.js file for Node Template Table

If a custom node driver has these two keys, we can show them correctly in node template list page.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
https://github.com/rancher/rancher/issues/21277