### PR TITLE
Fix click save button again, logging config disappear

### DIFF
--- a/lib/logging/addon/components/logging/new-edit/component.js
+++ b/lib/logging/addon/components/logging/new-edit/component.js
@@ -283,11 +283,14 @@ export default Component.extend(NewOrEdit, {
 
       let formatConfig = get(model, `${ targetType }.config`)
 
+      // In case of type is `/v3/schema/${ targetType }Config`
+      set(formatConfig, 'type', `${ targetType }Config`)
+
       setProperties(model, {
         outputFlushInterval:       get(model, `${ targetType }.outputFlushInterval`),
         outputTags:                get(model, `${ targetType }.outputTags`),
         dockerRoot:                get(model, `${ targetType }.dockerRoot`),
-        [`${ targetType }Config`]: formatConfig,
+        [`${ targetType }Config`]: get(this, 'globalStore').createRecord(formatConfig),
         includeSystemComponent:    get(model, `${ targetType }.includeSystemComponent`),
       })
 


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Fix click save button again, logging config disappear.

Types of changes
======

- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

https://github.com/rancher/rancher/issues/21426

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
The fluentForwarderConfig is null when the second save.  So reset a type which can be found in the schema and `createRecord` can fix the issue.
