### PR TITLE
Cluster Template Enforcement

### DIFF
--- a/lib/global-admin/addon/cluster-templates/new-revision/controller.js
+++ b/lib/global-admin/addon/cluster-templates/new-revision/controller.js
@@ -4,9 +4,14 @@ import { set } from '@ember/object';
 export default Controller.extend({
   queryParams: ['revision'],
 
-  revision: null,
+  revision:    null,
+
+  parentRoute: 'global-admin.cluster-templates.index',
 
   actions: {
+    cancel() {
+      this.send('goToPrevious', this.parentRoute);
+    },
     updateTemplateId(template) {
       set(this, 'revision', template.id);
     },

--- a/lib/global-admin/addon/cluster-templates/new-revision/template.hbs
+++ b/lib/global-admin/addon/cluster-templates/new-revision/template.hbs
@@ -11,4 +11,5 @@
   @clusterTemplateRevisionId={{model.clusterTemplateRevisionId}}
   @psps={{model.psps}}
   @mode="edit"
+  @cancel={{action "cancel"}}
 />

--- a/lib/global-admin/addon/clusters/index/controller.js
+++ b/lib/global-admin/addon/clusters/index/controller.js
@@ -46,22 +46,23 @@ const headers = [
 ];
 
 export default Controller.extend({
-  modalService: service('modal'),
-  access:       service(),
-  scope:             service(),
-  settings:          service(),
-  prefs:        service(),
-  router:       service(),
+  modalService:       service('modal'),
+  access:             service(),
+  scope:              service(),
+  settings:           service(),
+  prefs:              service(),
+  router:             service(),
 
-  application:  controller(),
-  queryParams:  ['mode'],
-  mode:         'grouped',
+  application:        controller(),
+  queryParams:        ['mode'],
+  mode:               'grouped',
 
   headers,
-  extraSearchFields: ['version.gitVersion'],
-  sortBy:            'name',
-  searchText:        null,
-  bulkActions:       true,
+  extraSearchFields:  ['version.gitVersion'],
+  sortBy:             'name',
+  searchText:         null,
+  bulkActions:        true,
+  disabledAddCluster: false,
 
   actions: {
     launchOnCluster(model) {

--- a/lib/global-admin/addon/clusters/index/route.js
+++ b/lib/global-admin/addon/clusters/index/route.js
@@ -5,6 +5,7 @@ import { hash } from 'rsvp';
 
 export default Route.extend({
   globalStore: service(),
+  access:      service(),
   shortcuts:   { 'g': 'toggleGrouping', },
 
   model(){
@@ -17,9 +18,11 @@ export default Route.extend({
   setupController(controller, model) {
     this._super(controller, model);
 
+    let { me: { hasAdmin: globalAdmin = false } } = this.access;
+
     let { clusterTemplates = [] } = model;
 
-    if (clusterTemplates.length <= 0) {
+    if (clusterTemplates.length <= 0 && !globalAdmin) {
       controller.set('disabledAddCluster', true);
     }
   },

--- a/lib/global-admin/addon/clusters/index/route.js
+++ b/lib/global-admin/addon/clusters/index/route.js
@@ -6,18 +6,6 @@ import { hash } from 'rsvp';
 export default Route.extend({
   globalStore: service(),
   shortcuts:   { 'g': 'toggleGrouping', },
-  actions:   {
-    toggleGrouping() {
-      let choices = ['list', 'grouped'];
-      let cur = this.get('controller.mode');
-      let neu = choices[((choices.indexOf(cur) + 1) % choices.length)];
-
-      next(() => {
-        this.set('controller.mode', neu);
-      });
-    },
-  },
-
   model(){
     return hash({ clusterTemplates: this.globalStore.findAll('clustertemplate') });
   },
@@ -28,6 +16,18 @@ export default Route.extend({
     if (clusterTemplates.length <= 0) {
       controller.set('disabledAddCluster', true);
     }
+  },
+
+  actions:   {
+    toggleGrouping() {
+      let choices = ['list', 'grouped'];
+      let cur = this.get('controller.mode');
+      let neu = choices[((choices.indexOf(cur) + 1) % choices.length)];
+
+      next(() => {
+        this.set('controller.mode', neu);
+      });
+    },
   },
 
 });

--- a/lib/global-admin/addon/clusters/index/route.js
+++ b/lib/global-admin/addon/clusters/index/route.js
@@ -1,8 +1,11 @@
 import { next } from '@ember/runloop';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { hash } from 'rsvp';
 
 export default Route.extend({
-  shortcuts: { 'g': 'toggleGrouping', },
+  globalStore: service(),
+  shortcuts:   { 'g': 'toggleGrouping', },
   actions:   {
     toggleGrouping() {
       let choices = ['list', 'grouped'];
@@ -13,6 +16,18 @@ export default Route.extend({
         this.set('controller.mode', neu);
       });
     },
+  },
+
+  model(){
+    return hash({ clusterTemplates: this.globalStore.findAll('clustertemplate') });
+  },
+
+  setupController(controller, model) {
+    let { clusterTemplates = [] } = model;
+
+    if (clusterTemplates.length <= 0) {
+      controller.set('disabledAddCluster', true);
+    }
   },
 
 });

--- a/lib/global-admin/addon/clusters/index/route.js
+++ b/lib/global-admin/addon/clusters/index/route.js
@@ -6,11 +6,17 @@ import { hash } from 'rsvp';
 export default Route.extend({
   globalStore: service(),
   shortcuts:   { 'g': 'toggleGrouping', },
+
   model(){
-    return hash({ clusterTemplates: this.globalStore.findAll('clustertemplate') });
+    return hash({
+      clusters:         this.globalStore.findAll('cluster'),
+      clusterTemplates: this.globalStore.findAll('clustertemplate'),
+    });
   },
 
   setupController(controller, model) {
+    this._super(controller, model);
+
     let { clusterTemplates = [] } = model;
 
     if (clusterTemplates.length <= 0) {

--- a/lib/global-admin/addon/clusters/index/template.hbs
+++ b/lib/global-admin/addon/clusters/index/template.hbs
@@ -40,6 +40,7 @@
   </div>
 </section>
 
+{{log model.clusters}}
 {{#if model.clusters.length}}
   {{#sortable-table
      classNames="grid sortable-table"

--- a/lib/global-admin/addon/clusters/index/template.hbs
+++ b/lib/global-admin/addon/clusters/index/template.hbs
@@ -14,13 +14,29 @@
       {{t "clustersPage.newTemplate"}}
     {{/link-to}}
 
-    {{#link-to
-       "clusters.new"
-       class="btn btn-sm bg-primary"
-       disabled=(rbac-prevents resource="cluster" scope="global" permission="create")
-    }}
-      {{t "clustersPage.newCluster"}}
-    {{/link-to}}
+    {{#if disabledAddCluster}}
+      {{#tooltip-element
+         type="tooltip-basic"
+         model=(t "clustersPage.clusterLaunchDisabled" htmlSafe=true)
+         tooltipTemplate="tooltip-static"
+         aria-describedby="tooltip-base"
+         tooltipFor="tooltipDisableClusterLaunch"
+      }}
+        <button
+          class="btn bg-disabled btn-sm btn-disabled"
+        >
+          {{t "clustersPage.newCluster"}}
+        </button>
+      {{/tooltip-element}}
+    {{else}}
+      {{#link-to
+         "clusters.new"
+         class="btn btn-sm bg-primary"
+         disabled=(rbac-prevents resource="cluster" scope="global" permission="create")
+      }}
+        {{t "clustersPage.newCluster"}}
+      {{/link-to}}
+    {{/if}}
   </div>
 </section>
 
@@ -59,11 +75,41 @@
     {{/if}}
   {{/sortable-table}}
 {{else}}
-  {{empty-table
-    resource="container"
-    newRoute="global-admin.clusters.new"
-    newTranslationKey="clustersPage.newCluster"
-    disabled=(rbac-prevents resource="cluster" scope="global" permission="create")
-    ctx=""
+  {{#empty-table
+     resource="container"
+     newRoute="global-admin.clusters.new"
+     newTranslationKey="clustersPage.newCluster"
+     disabled=(rbac-prevents resource="cluster" scope="global" permission="create")
+     ctx=""
   }}
+    <div class="col span-6 offset-3 text-center pt-40 pb-40">
+      <img style="width: 75%;" src="{{app.baseAssets}}assets/images/resources/container.svg"/>
+      <div class="text-center mt-50">
+        {{#if disabledAddCluster}}
+          {{#tooltip-element
+             type="tooltip-basic"
+             model=(t "clustersPage.clusterLaunchDisabled" htmlSafe=true)
+             tooltipTemplate="tooltip-static"
+             aria-describedby="tooltip-base"
+             tooltipFor="tooltipDisableClusterLaunch"
+             placement="top"
+          }}
+            <button
+              class="btn bg-disabled btn-sm btn-disabled"
+            >
+              {{t "clustersPage.newCluster"}}
+            </button>
+          {{/tooltip-element}}
+        {{else}}
+          {{#link-to
+             "clusters.new"
+             class="btn btn-sm bg-primary"
+             disabled=(rbac-prevents resource="cluster" scope="global" permission="create")
+          }}
+            {{t "clustersPage.newCluster"}}
+          {{/link-to}}
+        {{/if}}
+      </div>
+    </div>
+  {{/empty-table}}
 {{/if}}

--- a/lib/global-admin/addon/clusters/new/launch/route.js
+++ b/lib/global-admin/addon/clusters/new/launch/route.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
 import { inject as service } from '@ember/service';
 import { get, setProperties } from '@ember/object';
+import { isEmpty } from '@ember/utils';
 
 export default Route.extend({
   globalStore:            service(),
@@ -9,19 +10,29 @@ export default Route.extend({
   roleTemplateService:    service('roleTemplate'),
   clusterTemplateService: service('clusterTemplates'),
 
+  beforeModel(transition) {
+    const { clusterTemplates } = this.modelFor('clusters.new');
+
+    if (clusterTemplates.length === 1 && isEmpty(transition.queryParams.clusterTemplateRevision)) {
+      return this.replaceWith(this.routeName, transition.to.params.provider, { queryParams: { clusterTemplateRevision: clusterTemplates.firstObject.defaultRevisionId } });
+    }
+
+    return;
+  },
+
   model(params) {
-    const gs                                         = this.globalStore;
+    const gs                                    = this.globalStore;
     const {
       cluster,
       kontainerDrivers,
       nodeDrivers,
       clusterTemplates,
       clusterTemplateRevisions
-    } = this.modelFor('clusters.new');
-    const { provider, clusterTemplateRevision }      = params;
-    let ctr  = null;
-    let ct   = null;
-    let ctId = null;
+    }                                           = this.modelFor('clusters.new');
+    const { provider, clusterTemplateRevision } = params;
+    let ctr                                     = null;
+    let ct                                      = null;
+    let ctId                                    = null;
 
     if (clusterTemplateRevision) {
       ctr  = clusterTemplateRevisions.findBy('id', clusterTemplateRevision);

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -21,6 +21,7 @@ import moment from 'moment';
 import ManageLabels from 'shared/mixins/manage-labels';
 import { typeOf } from '@ember/utils';
 import Semver, { major, minor }  from 'semver';
+import { on } from '@ember/object/evented';
 
 const EXCLUDED_KEYS = ['extra_args'];
 
@@ -73,6 +74,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
   growl:                     service(),
   intl:                      service(),
   clusterTemplates:          service(),
+  access:                    service(),
 
   layout,
   authChoices:               AUTHCHOICES,
@@ -116,6 +118,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
   applyClusterTemplate:      null,
   useClusterTemplate:        false,
   clusterTemplateRevisionId: null,
+  clusterTemplatesEnforced:  false,
   isNew:                     equal('mode', 'new'),
   isEdit:                    equal('mode', 'edit'),
   notView:                   or('isNew', 'isEdit'),
@@ -274,6 +277,23 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       get(this, 'config.privateRegistries').removeObject(pr);
     },
   },
+
+  enforcementChanged: on('init', observer('settings.clusterTemplateEnforcement', function() {
+    let { me: { hasAdmin: globalAdmin = null } } = this.access;
+    let { clusterTemplateEnforcement = false } = this.settings;
+
+    if (!globalAdmin) {
+      // setting is string value
+      if (clusterTemplateEnforcement === 'true') {
+        clusterTemplateEnforcement = true;
+      } else {
+        clusterTemplateEnforcement = false;
+      }
+
+      set(this, 'useClusterTemplate', clusterTemplateEnforcement);
+      set(this, 'clusterTemplatesEnforced', clusterTemplateEnforcement);
+    }
+  })),
 
   usingClusterTemplate: observer('useClusterTemplate', function() {
     if (!this.useClusterTemplate && this.clusterTemplateRevisionId) {

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -278,23 +278,6 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     },
   },
 
-  enforcementChanged: on('init', observer('settings.clusterTemplateEnforcement', function() {
-    let { me: { hasAdmin: globalAdmin = null } } = this.access;
-    let { clusterTemplateEnforcement = false } = this.settings;
-
-    if (!globalAdmin) {
-      // setting is string value
-      if (clusterTemplateEnforcement === 'true') {
-        clusterTemplateEnforcement = true;
-      } else {
-        clusterTemplateEnforcement = false;
-      }
-
-      set(this, 'useClusterTemplate', clusterTemplateEnforcement);
-      set(this, 'clusterTemplatesEnforced', clusterTemplateEnforcement);
-    }
-  })),
-
   usingClusterTemplate: observer('useClusterTemplate', function() {
     if (!this.useClusterTemplate && this.clusterTemplateRevisionId) {
       set(this, 'clusterTemplateRevisionId', null);
@@ -354,6 +337,23 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
     set(this, 'config.services', services);
   }),
+
+  enforcementChanged: on('init', observer('settings.clusterTemplateEnforcement', function() {
+    let { me: { hasAdmin: globalAdmin = null } } = this.access;
+    let { clusterTemplateEnforcement = false } = this.settings;
+
+    if (!globalAdmin) {
+      // setting is string value
+      if (clusterTemplateEnforcement === 'true') {
+        clusterTemplateEnforcement = true;
+      } else {
+        clusterTemplateEnforcement = false;
+      }
+
+      set(this, 'useClusterTemplate', clusterTemplateEnforcement);
+      set(this, 'clusterTemplatesEnforced', clusterTemplateEnforcement);
+    }
+  })),
 
   allTemplates: computed('model.clusterTemplates.[]', 'model.clusterTemplateRevisions.[]', function() {
     const remapped = [];

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -14,9 +14,9 @@
 </section>
 
 {{#unless clusterTemplateCreate}}
-  {{#if (or model.clusterTemplateRevisions model.clusterTemplateRevision)}}
-    <section class="cluster-template-select mb-5">
-      <div class="row">
+  <section class="cluster-template-select mb-5">
+    <div class="row">
+      {{#if (or (or model.clusterTemplateRevisions model.clusterTemplateRevision) clusterTemplatesEnforced)}}
         <div class="col span-6">
           <label class="acc-label" for="use-existing-cluster-template">
             {{input
@@ -24,6 +24,7 @@
               type="checkbox"
               checked=useClusterTemplate
               id="use-existing-cluster-template"
+              disabled=clusterTemplatesEnforced
             }}
             {{t "clusterNew.rke.clustersSelectTemplate.label"}}
           </label>
@@ -41,1055 +42,1059 @@
             }}
           {{/if}}
         </div>
-      </div>
-    </section>
-  {{/if}}
+      {{/if}}
+    </div>
+  </section>
 {{/unless}}
 
-{{#if (and (not applyClusterTemplate) (not clusterTemplateCreate))}}
-  <section class="has-tabs p-0 pull-left">
-    <ul class="tab-nav">
-      {{#if pasteOrUpload}}
-        <li>
-          <button class="btn btn-sm bg-transparent" {{action "cancel"}}>
-            {{t "clusterNew.advanced.cancel"}}
-          </button>
-        </li>
-      {{else}}
-        <li>
-          <button class="btn btn-sm bg-transparent" {{action "showPaste"}}>
-            {{t "clusterNew.advanced.yaml"}} <span class="icon icon-copy"></span>
-          </button>
-        </li>
-      {{/if}}
-    </ul>
-  </section>
-{{/if}}
+{{#if (or (not clusterTemplatesEnforced) (and clusterTemplatesEnforced clusterTemplateRevisionId))}}
 
-{{#if (or isEdit (eq step 1))}}
-  {{#accordion-list
-     expandAll=(mut forceExpandAll)
-     showExpandAll=true
-     as |al expandFn|
-  }}
-    {{#if pasteOrUpload}}
-      <div class="accordion">
-        <div class="accordion-header">
-          <div class="expand"></div>
-          <div class="title">
-            <span class="m-0">{{t "clusterNew.kubernetesOptions.title" }}</span>
-            <p class="help-block">{{t "clusterNew.kubernetesOptions.detail" }}</p>
-          </div>
-        </div>
-        <div class="accordion-content">
-          <div class="banner bg-info">
-            <div class="banner-icon p-10"><i class="icon icon-info"></i></div>
-            <div class="banner-message">
-              {{t "clusterNew.advanced.helpText"}}
+  {{#if (and (not applyClusterTemplate) (not clusterTemplateCreate))}}
+    <section class="has-tabs p-0 pull-left">
+      <ul class="tab-nav">
+        {{#if pasteOrUpload}}
+          <li>
+            <button class="btn btn-sm bg-transparent" {{action "cancel"}}>
+              {{t "clusterNew.advanced.cancel"}}
+            </button>
+          </li>
+        {{else}}
+          <li>
+            <button class="btn btn-sm bg-transparent" {{action "showPaste"}}>
+              {{t "clusterNew.advanced.yaml"}} <span class="icon icon-copy"></span>
+            </button>
+          </li>
+        {{/if}}
+      </ul>
+    </section>
+  {{/if}}
+
+  {{#if (or isEdit (eq step 1))}}
+    {{#accordion-list
+       expandAll=(mut forceExpandAll)
+       showExpandAll=true
+       as |al expandFn|
+    }}
+      {{#if pasteOrUpload}}
+        <div class="accordion">
+          <div class="accordion-header">
+            <div class="expand"></div>
+            <div class="title">
+              <span class="m-0">{{t "clusterNew.kubernetesOptions.title" }}</span>
+              <p class="help-block">{{t "clusterNew.kubernetesOptions.detail" }}</p>
             </div>
           </div>
-          <div class="mt-25">
-            {{input-yaml
-              showDownload=false
-              canChangeName=false
-              autoResize=true
-              value=yamlValue
+          <div class="accordion-content">
+            <div class="banner bg-info">
+              <div class="banner-icon p-10"><i class="icon icon-info"></i></div>
+              <div class="banner-message">
+                {{t "clusterNew.advanced.helpText"}}
+              </div>
+            </div>
+            <div class="mt-25">
+              {{input-yaml
+                showDownload=false
+                canChangeName=false
+                autoResize=true
+                value=yamlValue
+              }}
+            </div>
+            {{copy-to-clipboard
+              tooltipText=""
+              buttonText="copyToClipboard.tooltip"
+              clipboardText=yamlValue
+              class="with-clip"
             }}
           </div>
-          {{copy-to-clipboard
-            tooltipText=""
-            buttonText="copyToClipboard.tooltip"
-            clipboardText=yamlValue
-            class="with-clip"
-          }}
         </div>
-      </div>
-    {{else}}
-      {{#accordion-list-item
-         title=(t "clusterNew.kubernetesOptions.title")
-         detail=(t "clusterNew.kubernetesOptions.detail")
-         expandOnInit=true
-         expandAll=al.expandAll
-         expand=(action expandFn)
-      }}
-        <div class="row">
-          <div class="col span-6">
-            <label class="acc-label">
-              {{t "clusterNew.rke.version.label"}}
-              {{#if clusterTemplateCreate}}
-                <ClusterTemplateOverrideToggle
-                  @path="rancherKubernetesEngineConfig.kubernetesVersion"
-                  @configVariable={{config.kubernetesVersion}}
-                  @addOverride={{action "addOverride"}}
-                  @questions={{model.clusterTemplateRevision.questions}}
-                />
-              {{/if}}
-            </label>
+      {{else}}
+        {{#accordion-list-item
+           title=(t "clusterNew.kubernetesOptions.title")
+           detail=(t "clusterNew.kubernetesOptions.detail")
+           expandOnInit=true
+           expandAll=al.expandAll
+           expand=(action expandFn)
+        }}
+          <div class="row">
+            <div class="col span-6">
+              <label class="acc-label">
+                {{t "clusterNew.rke.version.label"}}
+                {{#if clusterTemplateCreate}}
+                  <ClusterTemplateOverrideToggle
+                    @path="rancherKubernetesEngineConfig.kubernetesVersion"
+                    @configVariable={{config.kubernetesVersion}}
+                    @addOverride={{action "addOverride"}}
+                    @questions={{model.clusterTemplateRevision.questions}}
+                  />
+                {{/if}}
+              </label>
 
-            <CheckOverrideAllowed
-              @applyClusterTemplate={{applyClusterTemplate}}
-              @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-              @paramName="rancherKubernetesEngineConfig.kubernetesVersion"
-              @questions={{model.clusterTemplateRevision.questions}}
-            >
-              <FormVersions
+              <CheckOverrideAllowed
                 @applyClusterTemplate={{applyClusterTemplate}}
+                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                @paramName="rancherKubernetesEngineConfig.kubernetesVersion"
+                @questions={{model.clusterTemplateRevision.questions}}
+              >
+                <FormVersions
+                  @applyClusterTemplate={{applyClusterTemplate}}
+                  @cluster={{cluster}}
+                  @clusterTemplateCreate={{clusterTemplateCreate}}
+                  @editing={{and (eq mode "edit") (not clusterTemplateCreate)}}
+                  @initialVersion={{initialVersion}}
+                  @value={{config.kubernetesVersion}}
+                  @versions={{versionChoices}}
+                  @clusterTemplateQuestions={{clusterTemplateQuestions}}
+                />
+              </CheckOverrideAllowed>
+            </div>
+          </div>
+
+          <FormNetworkConfig
+            @config={{config}}
+            @mode={{mode}}
+            @isCustom={{isCustom}}
+            @windowsSupport={{windowsSupport}}
+            @enableNetworkPolicy={{primaryResource.enableNetworkPolicy}}
+            @clusterTemplateCreate={{clusterTemplateCreate}}
+            @clusterTemplateRevision={{model.clusterTemplateRevision}}
+            @applyClusterTemplate={{applyClusterTemplate}}
+            @addOverride={{action "addOverride"}}
+          />
+
+          <div class="row">
+            <div class="col span-12">
+              <CruCloudProvider
                 @cluster={{cluster}}
+                @driver={{nodeWhich}}
+                @setCpFields={{action "setCpFields"}}
+                @mode={{mode}}
                 @clusterTemplateCreate={{clusterTemplateCreate}}
-                @editing={{and (eq mode "edit") (not clusterTemplateCreate)}}
-                @initialVersion={{initialVersion}}
-                @value={{config.kubernetesVersion}}
-                @versions={{versionChoices}}
-                @clusterTemplateQuestions={{clusterTemplateQuestions}}
+                @applyClusterTemplate={{applyClusterTemplate}}
+                @clusterTemplateRevision={{model.clusterTemplateRevision}}
+                @questions={{model.clusterTemplateRevision.questions}}
+                @addOverride={{action "addOverride"}}
               />
-            </CheckOverrideAllowed>
+            </div>
           </div>
-        </div>
+        {{/accordion-list-item}}
 
-        <FormNetworkConfig
-          @config={{config}}
-          @mode={{mode}}
-          @isCustom={{isCustom}}
-          @windowsSupport={{windowsSupport}}
-          @enableNetworkPolicy={{primaryResource.enableNetworkPolicy}}
-          @clusterTemplateCreate={{clusterTemplateCreate}}
-          @clusterTemplateRevision={{model.clusterTemplateRevision}}
-          @applyClusterTemplate={{applyClusterTemplate}}
-          @addOverride={{action "addOverride"}}
-        />
+        {{#accordion-list-item
+           title=(t "cruPrivateRegistry.title.label")
+           detail=(t "cruPrivateRegistry.title.detail")
+           expandOnInit=(or (or (eq mode "edit" true false) forceExpandOnInit) applyClusterTemplate)
+           expandAll=al.expandAll
+           expand=(action expandFn)
+        }}
+          <CruPrivateRegistry
+            @cluster={{cluster}}
+            @addRegistry={{action "addRegistry"}}
+            @removeRegistry={{action "removeRegistry"}}
+            @addOverride={{action "addOverride"}}
+            @clusterTemplateCreate={{clusterTemplateCreate}}
+            @clusterTemplateRevision={{model.clusterTemplateRevision}}
+            @applyClusterTemplate={{applyClusterTemplate}}
+          />
+        {{/accordion-list-item}}
 
-        <div class="row">
-          <div class="col span-12">
-            <CruCloudProvider
-              @cluster={{cluster}}
-              @driver={{nodeWhich}}
-              @setCpFields={{action "setCpFields"}}
-              @mode={{mode}}
-              @clusterTemplateCreate={{clusterTemplateCreate}}
-              @applyClusterTemplate={{applyClusterTemplate}}
-              @clusterTemplateRevision={{model.clusterTemplateRevision}}
-              @questions={{model.clusterTemplateRevision.questions}}
-              @addOverride={{action "addOverride"}}
-            />
-          </div>
-        </div>
-      {{/accordion-list-item}}
-
-      {{#accordion-list-item
-         title=(t "cruPrivateRegistry.title.label")
-         detail=(t "cruPrivateRegistry.title.detail")
-         expandOnInit=(or (or (eq mode "edit" true false) forceExpandOnInit) applyClusterTemplate)
-         expandAll=al.expandAll
-         expand=(action expandFn)
-      }}
-        <CruPrivateRegistry
-          @cluster={{cluster}}
-          @addRegistry={{action "addRegistry"}}
-          @removeRegistry={{action "removeRegistry"}}
-          @addOverride={{action "addOverride"}}
-          @clusterTemplateCreate={{clusterTemplateCreate}}
-          @clusterTemplateRevision={{model.clusterTemplateRevision}}
-          @applyClusterTemplate={{applyClusterTemplate}}
-        />
-      {{/accordion-list-item}}
-
-      {{#accordion-list-item
-         title=(t "clusterNew.rke.advanced.label")
-         detail=(t "clusterNew.rke.advanced.detail")
-         expandOnInit=(or (or (eq mode "edit" true false) forceExpandOnInit) applyClusterTemplate)
-         expandAll=al.expandAll
-         expand=(action expandFn)
-      }}
-        <div class="row">
-          <div class="col span-4">
-            <label class="acc-label">
-              {{t "clusterNew.rke.ingress.label"}}
-              {{#if clusterTemplateCreate}}
-                <ClusterTemplateOverrideToggle
-                  @path="rancherKubernetesEngineConfig.ingress.provider"
-                  @configVariable={{config.ingress.provider}}
-                  @addOverride={{action "addOverride"}}
-                  @questions={{model.clusterTemplateRevision.questions}}
-                />
-              {{/if}}
-            </label>
-            <CheckOverrideAllowed
-              @applyClusterTemplate={{applyClusterTemplate}}
-              @paramName="rancherKubernetesEngineConfig.ingress.provider"
-              @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-              @questions={{model.clusterTemplateRevision.questions}}
-            >
-              <div class="radio">
-                <label>
-                  {{radio-button
-                    selection=config.ingress.provider
-                    value="nginx"
-                  }}
-                  {{t "generic.enabled"}}
-                </label>
-              </div>
-              <div class="radio">
-                <label>
-                  {{radio-button
-                    selection=config.ingress.provider
-                    value="none"
-                  }}
-                  {{t "generic.disabled"}}
-                </label>
-              </div>
-            </CheckOverrideAllowed>
-          </div>
-          <div class="col span-4">
-            <label class="acc-label">
-              {{t "clusterNew.rke.serviceNodePortRange.label"}}
-              {{#if clusterTemplateCreate}}
-                <ClusterTemplateOverrideToggle
-                  @path="rancherKubernetesEngineConfig.services.kubeApi.serviceNodePortRange"
-                  @configVariable={{config.services.kubeApi.serviceNodePortRange}}
-                  @addOverride={{action "addOverride"}}
-                  @questions={{model.clusterTemplateRevision.questions}}
-                />
-              {{/if}}
-            </label>
-            <CheckOverrideAllowed
-              @paramName="rancherKubernetesEngineConfig.services.kubeApi.serviceNodePortRange"
-              @applyClusterTemplate={{applyClusterTemplate}}
-              @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-              @questions={{model.clusterTemplateRevision.questions}}
-            >
-              {{input
-                type="text"
-                value=config.services.kubeApi.serviceNodePortRange
-                className="form-control"
-                placeholder=(t "clusterNew.rke.serviceNodePortRange.placeholder")
-              }}
-            </CheckOverrideAllowed>
-          </div>
-          <div class="col span-4">
-            <label class="acc-label">
-              {{t "clusterNew.rke.monitoring.label"}}
-              {{#if clusterTemplateCreate}}
-                <ClusterTemplateOverrideToggle
-                  @path="rancherKubernetesEngineConfig.monitoring.provider"
-                  @configVariable={{config.monitoring.provider}}
-                  @addOverride={{action "addOverride"}}
-                  @questions={{model.clusterTemplateRevision.questions}}
-                />
-              {{/if}}
-            </label>
-            <CheckOverrideAllowed
-              @paramName="rancherKubernetesEngineConfig.monitoring.provider"
-              @applyClusterTemplate={{applyClusterTemplate}}
-              @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-              @questions={{model.clusterTemplateRevision.questions}}
-            >
-              <div class="radio">
-                <label>
-                  {{radio-button
-                    selection=config.monitoring.provider
-                    value="metrics-server"
-                  }}
-                  {{t "generic.enabled"}}
-                </label>
-              </div>
-              <div class="radio">
-                <label>
-                  {{radio-button
-                    selection=config.monitoring.provider
-                    value="none"
-                  }}
-                  {{t "generic.disabled"}}
-                </label>
-              </div>
-            </CheckOverrideAllowed>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col span-4">
-            <label class="acc-label">
-              {{t "clusterNew.rke.podSecurityPolicy.label"}}
-              {{#if clusterTemplateCreate}}
-                <ClusterTemplateOverrideToggle
-                  @path="rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy"
-                  @configVariable={{config.services.kubeApi.podSecurityPolicy}}
-                  @addOverride={{action "addOverride"}}
-                  @questions={{model.clusterTemplateRevision.questions}}
-                />
-              {{/if}}
-            </label>
-            <CheckOverrideAllowed
-              @paramName="rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy"
-              @applyClusterTemplate={{applyClusterTemplate}}
-              @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-              @questions={{model.clusterTemplateRevision.questions}}
-            >
-              <div class="radio">
-                <label class={{unless model.psps.length "text-muted"}}>
-                  {{radio-button
-                    selection=config.services.kubeApi.podSecurityPolicy
-                    value=true
-                    disabled=(not model.psps.length)
-                  }}
-                  {{t "generic.enabled"}}
-                  {{#unless model.psps.length}}
-                    &mdash; {{t "clusterNew.psp.none"}}
-                  {{/unless}}
-                </label>
-              </div>
-              <div class="radio">
-                <label>
-                  {{radio-button
-                    selection=config.services.kubeApi.podSecurityPolicy
-                    value=false
-                    disabled=(not model.psps.length)
-                  }}
-                  {{t "generic.disabled"}}
-                </label>
-              </div>
-            </CheckOverrideAllowed>
-          </div>
-          <div class="col span-4">
-            {{#if config.services.kubeApi.podSecurityPolicy}}
+        {{#accordion-list-item
+           title=(t "clusterNew.rke.advanced.label")
+           detail=(t "clusterNew.rke.advanced.detail")
+           expandOnInit=(or (or (eq mode "edit" true false) forceExpandOnInit) applyClusterTemplate)
+           expandAll=al.expandAll
+           expand=(action expandFn)
+        }}
+          <div class="row">
+            <div class="col span-4">
               <label class="acc-label">
-                {{t "clusterNew.psp.label"}}{{field-required}}
+                {{t "clusterNew.rke.ingress.label"}}
                 {{#if clusterTemplateCreate}}
                   <ClusterTemplateOverrideToggle
-                    @path="defaultPodSecurityPolicyTemplateId"
-                    @configVariable={{cluster.defaultPodSecurityPolicyTemplateId}}
+                    @path="rancherKubernetesEngineConfig.ingress.provider"
+                    @configVariable={{config.ingress.provider}}
                     @addOverride={{action "addOverride"}}
                     @questions={{model.clusterTemplateRevision.questions}}
                   />
                 {{/if}}
               </label>
               <CheckOverrideAllowed
-                @paramName="defaultPodSecurityPolicyTemplateId"
+                @applyClusterTemplate={{applyClusterTemplate}}
+                @paramName="rancherKubernetesEngineConfig.ingress.provider"
+                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                @questions={{model.clusterTemplateRevision.questions}}
+              >
+                <div class="radio">
+                  <label>
+                    {{radio-button
+                      selection=config.ingress.provider
+                      value="nginx"
+                    }}
+                    {{t "generic.enabled"}}
+                  </label>
+                </div>
+                <div class="radio">
+                  <label>
+                    {{radio-button
+                      selection=config.ingress.provider
+                      value="none"
+                    }}
+                    {{t "generic.disabled"}}
+                  </label>
+                </div>
+              </CheckOverrideAllowed>
+            </div>
+            <div class="col span-4">
+              <label class="acc-label">
+                {{t "clusterNew.rke.serviceNodePortRange.label"}}
+                {{#if clusterTemplateCreate}}
+                  <ClusterTemplateOverrideToggle
+                    @path="rancherKubernetesEngineConfig.services.kubeApi.serviceNodePortRange"
+                    @configVariable={{config.services.kubeApi.serviceNodePortRange}}
+                    @addOverride={{action "addOverride"}}
+                    @questions={{model.clusterTemplateRevision.questions}}
+                  />
+                {{/if}}
+              </label>
+              <CheckOverrideAllowed
+                @paramName="rancherKubernetesEngineConfig.services.kubeApi.serviceNodePortRange"
                 @applyClusterTemplate={{applyClusterTemplate}}
                 @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
                 @questions={{model.clusterTemplateRevision.questions}}
               >
-                {{new-select
-                  content=model.psps
-                  optionLabelPath="displayName"
-                  optionValuePath="id"
-                  prompt="clusterNew.psp.prompt"
-                  localizedPrompt=true
-                  value=cluster.defaultPodSecurityPolicyTemplateId
-                  disabled=(not config.services.kubeApi.podSecurityPolicy)
+                {{input
+                  type="text"
+                  value=config.services.kubeApi.serviceNodePortRange
+                  className="form-control"
+                  placeholder=(t "clusterNew.rke.serviceNodePortRange.placeholder")
                 }}
               </CheckOverrideAllowed>
-            {{else}}
+            </div>
+            <div class="col span-4">
               <label class="acc-label">
-                {{t "clusterNew.psp.label"}}
+                {{t "clusterNew.rke.monitoring.label"}}
+                {{#if clusterTemplateCreate}}
+                  <ClusterTemplateOverrideToggle
+                    @path="rancherKubernetesEngineConfig.monitoring.provider"
+                    @configVariable={{config.monitoring.provider}}
+                    @addOverride={{action "addOverride"}}
+                    @questions={{model.clusterTemplateRevision.questions}}
+                  />
+                {{/if}}
               </label>
-              <div class="form-control-static">{{t "generic.none"}}</div>
-            {{/if}}
+              <CheckOverrideAllowed
+                @paramName="rancherKubernetesEngineConfig.monitoring.provider"
+                @applyClusterTemplate={{applyClusterTemplate}}
+                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                @questions={{model.clusterTemplateRevision.questions}}
+              >
+                <div class="radio">
+                  <label>
+                    {{radio-button
+                      selection=config.monitoring.provider
+                      value="metrics-server"
+                    }}
+                    {{t "generic.enabled"}}
+                  </label>
+                </div>
+                <div class="radio">
+                  <label>
+                    {{radio-button
+                      selection=config.monitoring.provider
+                      value="none"
+                    }}
+                    {{t "generic.disabled"}}
+                  </label>
+                </div>
+              </CheckOverrideAllowed>
+            </div>
           </div>
-        </div>
-        <div class="row">
-          <div class="col span-4">
-            <label class="acc-label">
-              {{t "clusterNew.rke.ignoreDockerVersion.label"}}
-              {{#if clusterTemplateCreate}}
-                <ClusterTemplateOverrideToggle
-                  @path="rancherKubernetesEngineConfig.ignoreDockerVersion"
-                  @configVariable={{cluster.ignoreDockerVersion}}
-                  @addOverride={{action "addOverride"}}
+          <div class="row">
+            <div class="col span-4">
+              <label class="acc-label">
+                {{t "clusterNew.rke.podSecurityPolicy.label"}}
+                {{#if clusterTemplateCreate}}
+                  <ClusterTemplateOverrideToggle
+                    @path="rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy"
+                    @configVariable={{config.services.kubeApi.podSecurityPolicy}}
+                    @addOverride={{action "addOverride"}}
+                    @questions={{model.clusterTemplateRevision.questions}}
+                  />
+                {{/if}}
+              </label>
+              <CheckOverrideAllowed
+                @paramName="rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy"
+                @applyClusterTemplate={{applyClusterTemplate}}
+                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                @questions={{model.clusterTemplateRevision.questions}}
+              >
+                <div class="radio">
+                  <label class={{unless model.psps.length "text-muted"}}>
+                    {{radio-button
+                      selection=config.services.kubeApi.podSecurityPolicy
+                      value=true
+                      disabled=(not model.psps.length)
+                    }}
+                    {{t "generic.enabled"}}
+                    {{#unless model.psps.length}}
+                      &mdash; {{t "clusterNew.psp.none"}}
+                    {{/unless}}
+                  </label>
+                </div>
+                <div class="radio">
+                  <label>
+                    {{radio-button
+                      selection=config.services.kubeApi.podSecurityPolicy
+                      value=false
+                      disabled=(not model.psps.length)
+                    }}
+                    {{t "generic.disabled"}}
+                  </label>
+                </div>
+              </CheckOverrideAllowed>
+            </div>
+            <div class="col span-4">
+              {{#if config.services.kubeApi.podSecurityPolicy}}
+                <label class="acc-label">
+                  {{t "clusterNew.psp.label"}}{{field-required}}
+                  {{#if clusterTemplateCreate}}
+                    <ClusterTemplateOverrideToggle
+                      @path="defaultPodSecurityPolicyTemplateId"
+                      @configVariable={{cluster.defaultPodSecurityPolicyTemplateId}}
+                      @addOverride={{action "addOverride"}}
+                      @questions={{model.clusterTemplateRevision.questions}}
+                    />
+                  {{/if}}
+                </label>
+                <CheckOverrideAllowed
+                  @paramName="defaultPodSecurityPolicyTemplateId"
+                  @applyClusterTemplate={{applyClusterTemplate}}
+                  @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
                   @questions={{model.clusterTemplateRevision.questions}}
-                />
-              {{/if}}
-            </label>
-            <CheckOverrideAllowed
-              @paramName="rancherKubernetesEngineConfig.ignoreDockerVersion"
-              @applyClusterTemplate={{applyClusterTemplate}}
-              @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-              @questions={{model.clusterTemplateRevision.questions}}
-            >
-              <div class="radio">
-                <label>
-                  {{radio-button
-                    selection=config.ignoreDockerVersion
-                    value=false
+                >
+                  {{new-select
+                    content=model.psps
+                    optionLabelPath="displayName"
+                    optionValuePath="id"
+                    prompt="clusterNew.psp.prompt"
+                    localizedPrompt=true
+                    value=cluster.defaultPodSecurityPolicyTemplateId
+                    disabled=(not config.services.kubeApi.podSecurityPolicy)
                   }}
-                  {{t "clusterNew.rke.ignoreDockerVersion.disabled"}}
+                </CheckOverrideAllowed>
+              {{else}}
+                <label class="acc-label">
+                  {{t "clusterNew.psp.label"}}
                 </label>
-              </div>
-              <div class="radio">
-                <label>
-                  {{radio-button
-                    selection=config.ignoreDockerVersion
-                    value=true
+                <div class="form-control-static">{{t "generic.none"}}</div>
+              {{/if}}
+            </div>
+          </div>
+          <div class="row">
+            <div class="col span-4">
+              <label class="acc-label">
+                {{t "clusterNew.rke.ignoreDockerVersion.label"}}
+                {{#if clusterTemplateCreate}}
+                  <ClusterTemplateOverrideToggle
+                    @path="rancherKubernetesEngineConfig.ignoreDockerVersion"
+                    @configVariable={{cluster.ignoreDockerVersion}}
+                    @addOverride={{action "addOverride"}}
+                    @questions={{model.clusterTemplateRevision.questions}}
+                  />
+                {{/if}}
+              </label>
+              <CheckOverrideAllowed
+                @paramName="rancherKubernetesEngineConfig.ignoreDockerVersion"
+                @applyClusterTemplate={{applyClusterTemplate}}
+                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                @questions={{model.clusterTemplateRevision.questions}}
+              >
+                <div class="radio">
+                  <label>
+                    {{radio-button
+                      selection=config.ignoreDockerVersion
+                      value=false
+                    }}
+                    {{t "clusterNew.rke.ignoreDockerVersion.disabled"}}
+                  </label>
+                </div>
+                <div class="radio">
+                  <label>
+                    {{radio-button
+                      selection=config.ignoreDockerVersion
+                      value=true
+                    }}
+                    {{t "clusterNew.rke.ignoreDockerVersion.enabled"}}
+                  </label>
+                </div>
+              </CheckOverrideAllowed>
+            </div>
+
+            <div class="col span-4">
+              <label class="acc-label">
+                {{t "loggingPage.dockerRootDir.label"}}
+                {{#if clusterTemplateCreate}}
+                  <ClusterTemplateOverrideToggle
+                    @path="dockerRootDir"
+                    @configVariable={{cluster.dockerRootDir}}
+                    @addOverride={{action "addOverride"}}
+                    @questions={{model.clusterTemplateRevision.questions}}
+                  />
+                {{/if}}
+              </label>
+              <CheckOverrideAllowed
+                @paramName="dockerRootDir"
+                @applyClusterTemplate={{applyClusterTemplate}}
+                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                @questions={{model.clusterTemplateRevision.questions}}
+              >
+                {{input
+                  type="text"
+                  value=cluster.dockerRootDir
+                  className="form-control"
+                  placeholder=(t "clusterNew.rke.dockerRootDir.placeholder" dir=defaultDockerRootDir)
+                }}
+              </CheckOverrideAllowed>
+            </div>
+
+          </div>
+          <div class="row">
+            <div class="col span-12">
+
+              <label class="acc-label">
+                {{t "clusterNew.rke.etcd.location.label"}}
+                {{#if clusterTemplateCreate}}
+                  <ClusterTemplateOverrideToggle
+                    @path="uiOverrideBackupStrategy"
+                    @configVariable={{backupStrategy}}
+                    @addOverride={{action "addOverride"}}
+                    @questions={{model.clusterTemplateRevision.questions}}
+                  />
+                {{/if}}
+              </label>
+              <CheckOverrideAllowed
+                @paramName="uiOverrideBackupStrategy"
+                @applyClusterTemplate={{applyClusterTemplate}}
+                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                @questions={{model.clusterTemplateRevision.questions}}
+              >
+                <div>
+                  <label class="radio mt-0">
+                    {{radio-button selection=backupStrategy value="local"}}
+                    {{t "clusterNew.rke.etcd.location.local.label"}}
+                    <p class="help-block">
+                      {{t "clusterNew.rke.etcd.location.local.help"}}
+                    </p>
+                  </label>
+                </div>
+                <div>
+                  <label class="radio">
+                    {{radio-button selection=backupStrategy value="s3"}}
+                    {{t "clusterNew.rke.etcd.location.s3.label"}}
+                    <p class="help-block">
+                      {{t "clusterNew.rke.etcd.location.s3.help"}}
+                    </p>
+                  </label>
+                </div>
+              </CheckOverrideAllowed>
+            </div>
+          </div>
+
+          {{#unless (eq backupStrategy "local")}}
+            <div class="row">
+              <div class="col span-3">
+                <label class="acc-label">
+                  {{t "clusterNew.rke.etcd.backupConfig.bucketName.label"}}
+                  {{#if clusterTemplateCreate}}
+                    <ClusterTemplateOverrideToggle
+                      @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.bucketName"
+                      @configVariable={{config.services.etcd.backupConfig.s3BackupConfig.bucketName}}
+                      @addOverride={{action "addOverride"}}
+                      @questions={{model.clusterTemplateRevision.questions}}
+                    />
+                  {{/if}}
+                </label>
+                <CheckOverrideAllowed
+                  @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.bucketName"
+                  @applyClusterTemplate={{applyClusterTemplate}}
+                  @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                  @questions={{model.clusterTemplateRevision.questions}}
+                >
+                  {{input
+                    type="text"
+                    value=config.services.etcd.backupConfig.s3BackupConfig.bucketName
+                    classNames="form-control"
+                    placeholder=(t "clusterNew.rke.etcd.backupConfig.bucketName.placeholder")
                   }}
-                  {{t "clusterNew.rke.ignoreDockerVersion.enabled"}}
-                </label>
+                </CheckOverrideAllowed>
               </div>
-            </CheckOverrideAllowed>
-          </div>
 
-          <div class="col span-4">
-            <label class="acc-label">
-              {{t "loggingPage.dockerRootDir.label"}}
-              {{#if clusterTemplateCreate}}
-                <ClusterTemplateOverrideToggle
-                  @path="dockerRootDir"
-                  @configVariable={{cluster.dockerRootDir}}
-                  @addOverride={{action "addOverride"}}
+              <div class="col span-3 offset-1">
+                <label class="acc-label">
+                  {{t "clusterNew.rke.etcd.backupConfig.region.label"}}
+                  {{#if clusterTemplateCreate}}
+                    <ClusterTemplateOverrideToggle
+                      @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.region"
+                      @configVariable={{config.services.etcd.backupConfig.s3BackupConfig.region}}
+                      @addOverride={{action "addOverride"}}
+                      @questions={{model.clusterTemplateRevision.questions}}
+                    />
+                  {{/if}}
+                </label>
+                <CheckOverrideAllowed
+                  @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.region"
+                  @applyClusterTemplate={{applyClusterTemplate}}
+                  @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
                   @questions={{model.clusterTemplateRevision.questions}}
-                />
-              {{/if}}
-            </label>
-            <CheckOverrideAllowed
-              @paramName="dockerRootDir"
-              @applyClusterTemplate={{applyClusterTemplate}}
-              @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-              @questions={{model.clusterTemplateRevision.questions}}
-            >
-              {{input
-                type="text"
-                value=cluster.dockerRootDir
-                className="form-control"
-                placeholder=(t "clusterNew.rke.dockerRootDir.placeholder" dir=defaultDockerRootDir)
-              }}
-            </CheckOverrideAllowed>
-          </div>
+                >
+                  {{input
+                    type="text"
+                    value=config.services.etcd.backupConfig.s3BackupConfig.region
+                    classNames="form-control"
+                    placeholder=(t "clusterNew.rke.etcd.backupConfig.region.placeholder")
+                  }}
+                </CheckOverrideAllowed>
+              </div>
 
-        </div>
-        <div class="row">
-          <div class="col span-12">
-
-            <label class="acc-label">
-              {{t "clusterNew.rke.etcd.location.label"}}
-              {{#if clusterTemplateCreate}}
-                <ClusterTemplateOverrideToggle
-                  @path="uiOverrideBackupStrategy"
-                  @configVariable={{backupStrategy}}
-                  @addOverride={{action "addOverride"}}
+              <div class="col span-3 offset-1">
+                <label class="acc-label">
+                  {{t "clusterNew.rke.etcd.backupConfig.endpoint.label"}}
+                  {{#if clusterTemplateCreate}}
+                    <ClusterTemplateOverrideToggle
+                      @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.endpoint"
+                      @configVariable={{config.services.etcd.backupConfig.s3BackupConfig.endpoint}}
+                      @addOverride={{action "addOverride"}}
+                      @questions={{model.clusterTemplateRevision.questions}}
+                    />
+                  {{/if}}
+                </label>
+                <CheckOverrideAllowed
+                  @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.endpoint"
+                  @applyClusterTemplate={{applyClusterTemplate}}
+                  @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
                   @questions={{model.clusterTemplateRevision.questions}}
-                />
-              {{/if}}
-            </label>
-            <CheckOverrideAllowed
-              @paramName="uiOverrideBackupStrategy"
-              @applyClusterTemplate={{applyClusterTemplate}}
-              @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-              @questions={{model.clusterTemplateRevision.questions}}
-            >
-              <div>
-                <label class="radio mt-0">
-                  {{radio-button selection=backupStrategy value="local"}}
-                  {{t "clusterNew.rke.etcd.location.local.label"}}
-                  <p class="help-block">
-                    {{t "clusterNew.rke.etcd.location.local.help"}}
-                  </p>
-                </label>
+                >
+                  {{input
+                    type="text"
+                    value=config.services.etcd.backupConfig.s3BackupConfig.endpoint
+                    classNames="form-control"
+                    placeholder=(t "clusterNew.rke.etcd.backupConfig.endpoint.placeholder")
+                  }}
+                </CheckOverrideAllowed>
               </div>
-              <div>
-                <label class="radio">
-                  {{radio-button selection=backupStrategy value="s3"}}
-                  {{t "clusterNew.rke.etcd.location.s3.label"}}
-                  <p class="help-block">
-                    {{t "clusterNew.rke.etcd.location.s3.help"}}
-                  </p>
-                </label>
-              </div>
-            </CheckOverrideAllowed>
-          </div>
-        </div>
+            </div>
 
-        {{#unless (eq backupStrategy "local")}}
+            <div class="row">
+              <div class="col span-3">
+                <label class="acc-label">
+                  {{t "clusterNew.rke.etcd.backupConfig.accessKey.label"}}
+                  {{#if clusterTemplateCreate}}
+                    <ClusterTemplateOverrideToggle
+                      @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.accessKey"
+                      @configVariable={{config.services.etcd.backupConfig.s3BackupConfig.accessKey}}
+                      @addOverride={{action "addOverride"}}
+                      @questions={{model.clusterTemplateRevision.questions}}
+                    />
+                  {{/if}}
+                </label>
+                <CheckOverrideAllowed
+                  @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.accessKey"
+                  @applyClusterTemplate={{applyClusterTemplate}}
+                  @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                  @questions={{model.clusterTemplateRevision.questions}}
+                >
+                  {{input
+                    type="text"
+                    name="accessKey"
+                    classNames="form-control"
+                    placeholder=(t "clusterNew.rke.etcd.backupConfig.accessKey.placeholder")
+                    value=config.services.etcd.backupConfig.s3BackupConfig.accessKey
+                  }}
+                </CheckOverrideAllowed>
+              </div>
+
+              <div class="col span-3 offset-1">
+                <label class="acc-label">
+                  {{t "clusterNew.rke.etcd.backupConfig.secretKey.label"}}
+                  {{#if clusterTemplateCreate}}
+                    <ClusterTemplateOverrideToggle
+                      @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.secretKey"
+                      @configVariable={{config.services.etcd.backupConfig.s3BackupConfig.secretKey}}
+                      @addOverride={{action "addOverride"}}
+                      @questions={{model.clusterTemplateRevision.questions}}
+                    />
+                  {{/if}}
+                </label>
+                <CheckOverrideAllowed
+                  @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.secretKey"
+                  @applyClusterTemplate={{applyClusterTemplate}}
+                  @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                  @questions={{model.clusterTemplateRevision.questions}}
+                >
+                  {{input
+                    type="password"
+                    name="password"
+                    classNames="form-control"
+                    placeholder=(t "clusterNew.rke.etcd.backupConfig.secretKey.placeholder")
+                    value=config.services.etcd.backupConfig.s3BackupConfig.secretKey
+                  }}
+                </CheckOverrideAllowed>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col span-7">
+                <label class="acc-label" for="s3-config-custom-ca">
+                  {{t "clusterNew.rke.etcd.backupConfig.customCa.label"}}
+                </label>
+                {{input-text-file
+                  accept="application/x-x509-ca-cert,text/plain,.pem,.crt"
+                  canChangeName=false
+                  classNames="box"
+                  id="s3-config-custom-ca"
+                  minHeight=60
+                  multiple=true
+                  placeholder="clusterNew.rke.etcd.backupConfig.customCa.placeholder"
+                  shouldChangeName=false
+                  value=cluster.rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.customCa
+                }}
+              </div>
+            </div>
+          {{/unless}}
+
           <div class="row">
             <div class="col span-3">
               <label class="acc-label">
-                {{t "clusterNew.rke.etcd.backupConfig.bucketName.label"}}
+                {{t "clusterNew.rke.etcd.enabled.label"}}
                 {{#if clusterTemplateCreate}}
                   <ClusterTemplateOverrideToggle
-                    @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.bucketName"
-                    @configVariable={{config.services.etcd.backupConfig.s3BackupConfig.bucketName}}
+                    @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.enabled"
+                    @configVariable={{config.services.etcd.backupConfig.enabled}}
                     @addOverride={{action "addOverride"}}
                     @questions={{model.clusterTemplateRevision.questions}}
                   />
                 {{/if}}
               </label>
               <CheckOverrideAllowed
-                @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.bucketName"
+                @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.enabled"
                 @applyClusterTemplate={{applyClusterTemplate}}
                 @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
                 @questions={{model.clusterTemplateRevision.questions}}
               >
-                {{input
-                  type="text"
-                  value=config.services.etcd.backupConfig.s3BackupConfig.bucketName
-                  classNames="form-control"
-                  placeholder=(t "clusterNew.rke.etcd.backupConfig.bucketName.placeholder")
-                }}
+                <div class="text-muted">
+                  <label>
+                    {{radio-button
+                      selection=config.services.etcd.backupConfig.enabled
+                      value=true
+                    }}
+                    {{t "generic.yes"}}
+                  </label>
+                  <label>
+                    {{radio-button
+                      selection=config.services.etcd.backupConfig.enabled
+                      value=false
+                    }}
+                    {{t "generic.no"}}
+                  </label>
+                </div>
               </CheckOverrideAllowed>
             </div>
 
             <div class="col span-3 offset-1">
               <label class="acc-label">
-                {{t "clusterNew.rke.etcd.backupConfig.region.label"}}
+                {{t "clusterNew.rke.etcd.backupConfig.interval.label"}}
                 {{#if clusterTemplateCreate}}
                   <ClusterTemplateOverrideToggle
-                    @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.region"
-                    @configVariable={{config.services.etcd.backupConfig.s3BackupConfig.region}}
+                    @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.intervalHours"
+                    @configVariable={{config.services.etcd.backupConfig.intervalHours}}
                     @addOverride={{action "addOverride"}}
                     @questions={{model.clusterTemplateRevision.questions}}
                   />
                 {{/if}}
               </label>
               <CheckOverrideAllowed
-                @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.region"
+                @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.intervalHours"
                 @applyClusterTemplate={{applyClusterTemplate}}
                 @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
                 @questions={{model.clusterTemplateRevision.questions}}
               >
-                {{input
-                  type="text"
-                  value=config.services.etcd.backupConfig.s3BackupConfig.region
-                  classNames="form-control"
-                  placeholder=(t "clusterNew.rke.etcd.backupConfig.region.placeholder")
-                }}
-              </CheckOverrideAllowed>
-            </div>
-
-            <div class="col span-3 offset-1">
-              <label class="acc-label">
-                {{t "clusterNew.rke.etcd.backupConfig.endpoint.label"}}
-                {{#if clusterTemplateCreate}}
-                  <ClusterTemplateOverrideToggle
-                    @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.endpoint"
-                    @configVariable={{config.services.etcd.backupConfig.s3BackupConfig.endpoint}}
-                    @addOverride={{action "addOverride"}}
-                    @questions={{model.clusterTemplateRevision.questions}}
-                  />
-                {{/if}}
-              </label>
-              <CheckOverrideAllowed
-                @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.endpoint"
-                @applyClusterTemplate={{applyClusterTemplate}}
-                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-                @questions={{model.clusterTemplateRevision.questions}}
-              >
-                {{input
-                  type="text"
-                  value=config.services.etcd.backupConfig.s3BackupConfig.endpoint
-                  classNames="form-control"
-                  placeholder=(t "clusterNew.rke.etcd.backupConfig.endpoint.placeholder")
-                }}
-              </CheckOverrideAllowed>
-            </div>
-          </div>
-
-          <div class="row">
-            <div class="col span-3">
-              <label class="acc-label">
-                {{t "clusterNew.rke.etcd.backupConfig.accessKey.label"}}
-                {{#if clusterTemplateCreate}}
-                  <ClusterTemplateOverrideToggle
-                    @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.accessKey"
-                    @configVariable={{config.services.etcd.backupConfig.s3BackupConfig.accessKey}}
-                    @addOverride={{action "addOverride"}}
-                    @questions={{model.clusterTemplateRevision.questions}}
-                  />
-                {{/if}}
-              </label>
-              <CheckOverrideAllowed
-                @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.accessKey"
-                @applyClusterTemplate={{applyClusterTemplate}}
-                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-                @questions={{model.clusterTemplateRevision.questions}}
-              >
-                {{input
-                  type="text"
-                  name="accessKey"
-                  classNames="form-control"
-                  placeholder=(t "clusterNew.rke.etcd.backupConfig.accessKey.placeholder")
-                  value=config.services.etcd.backupConfig.s3BackupConfig.accessKey
-                }}
-              </CheckOverrideAllowed>
-            </div>
-
-            <div class="col span-3 offset-1">
-              <label class="acc-label">
-                {{t "clusterNew.rke.etcd.backupConfig.secretKey.label"}}
-                {{#if clusterTemplateCreate}}
-                  <ClusterTemplateOverrideToggle
-                    @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.secretKey"
-                    @configVariable={{config.services.etcd.backupConfig.s3BackupConfig.secretKey}}
-                    @addOverride={{action "addOverride"}}
-                    @questions={{model.clusterTemplateRevision.questions}}
-                  />
-                {{/if}}
-              </label>
-              <CheckOverrideAllowed
-                @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.secretKey"
-                @applyClusterTemplate={{applyClusterTemplate}}
-                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-                @questions={{model.clusterTemplateRevision.questions}}
-              >
-                {{input
-                  type="password"
-                  name="password"
-                  classNames="form-control"
-                  placeholder=(t "clusterNew.rke.etcd.backupConfig.secretKey.placeholder")
-                  value=config.services.etcd.backupConfig.s3BackupConfig.secretKey
-                }}
-              </CheckOverrideAllowed>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col span-7">
-              <label class="acc-label" for="s3-config-custom-ca">
-                {{t "clusterNew.rke.etcd.backupConfig.customCa.label"}}
-              </label>
-              {{input-text-file
-                accept="application/x-x509-ca-cert,text/plain,.pem,.crt"
-                canChangeName=false
-                classNames="box"
-                id="s3-config-custom-ca"
-                minHeight=60
-                multiple=true
-                placeholder="clusterNew.rke.etcd.backupConfig.customCa.placeholder"
-                shouldChangeName=false
-                value=cluster.rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.customCa
-              }}
-            </div>
-          </div>
-        {{/unless}}
-
-        <div class="row">
-          <div class="col span-3">
-            <label class="acc-label">
-              {{t "clusterNew.rke.etcd.enabled.label"}}
-              {{#if clusterTemplateCreate}}
-                <ClusterTemplateOverrideToggle
-                  @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.enabled"
-                  @configVariable={{config.services.etcd.backupConfig.enabled}}
-                  @addOverride={{action "addOverride"}}
-                  @questions={{model.clusterTemplateRevision.questions}}
-                />
-              {{/if}}
-            </label>
-            <CheckOverrideAllowed
-              @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.enabled"
-              @applyClusterTemplate={{applyClusterTemplate}}
-              @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-              @questions={{model.clusterTemplateRevision.questions}}
-            >
-              <div class="text-muted">
-                <label>
-                  {{radio-button
-                    selection=config.services.etcd.backupConfig.enabled
-                    value=true
+                <div class="input-group">
+                  {{input-integer
+                    value=config.services.etcd.backupConfig.intervalHours
+                    min=1
+                    classNames="form-control"
+                    placeholder=(t "clusterNew.rke.etcd.backupConfig.interval.placeholder")
+                    disabled=(if (not config.services.etcd.backupConfig.enabled) true)
                   }}
-                  {{t "generic.yes"}}
-                </label>
-                <label>
-                  {{radio-button
-                    selection=config.services.etcd.backupConfig.enabled
-                    value=false
-                  }}
-                  {{t "generic.no"}}
-                </label>
-              </div>
-            </CheckOverrideAllowed>
-          </div>
+                  <span class="input-group-addon bg-default">{{t "generic.hours"}}</span>
+                </div>
+              </CheckOverrideAllowed>
+            </div>
 
-          <div class="col span-3 offset-1">
-            <label class="acc-label">
-              {{t "clusterNew.rke.etcd.backupConfig.interval.label"}}
-              {{#if clusterTemplateCreate}}
-                <ClusterTemplateOverrideToggle
-                  @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.intervalHours"
-                  @configVariable={{config.services.etcd.backupConfig.intervalHours}}
-                  @addOverride={{action "addOverride"}}
-                  @questions={{model.clusterTemplateRevision.questions}}
-                />
-              {{/if}}
-            </label>
-            <CheckOverrideAllowed
-              @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.intervalHours"
-              @applyClusterTemplate={{applyClusterTemplate}}
-              @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-              @questions={{model.clusterTemplateRevision.questions}}
-            >
-              <div class="input-group">
+            <div class="col span-3 offset-1">
+              <label class="acc-label">
+                {{t "clusterNew.rke.etcd.backupConfig.retention.label"}}
+                {{#if clusterTemplateCreate}}
+                  <ClusterTemplateOverrideToggle
+                    @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.retention"
+                    @configVariable={{config.services.etcd.backupConfig.retention}}
+                    @addOverride={{action "addOverride"}}
+                    @questions={{model.clusterTemplateRevision.questions}}
+                  />
+                {{/if}}
+              </label>
+              <CheckOverrideAllowed
+                @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.retention"
+                @applyClusterTemplate={{applyClusterTemplate}}
+                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                @questions={{model.clusterTemplateRevision.questions}}
+              >
                 {{input-integer
-                  value=config.services.etcd.backupConfig.intervalHours
+                  value=config.services.etcd.backupConfig.retention
                   min=1
                   classNames="form-control"
-                  placeholder=(t "clusterNew.rke.etcd.backupConfig.interval.placeholder")
+                  placeholder=(t "clusterNew.rke.etcd.backupConfig.retention.placeholder")
                   disabled=(if (not config.services.etcd.backupConfig.enabled) true)
                 }}
-                <span class="input-group-addon bg-default">{{t "generic.hours"}}</span>
+              </CheckOverrideAllowed>
+            </div>
+          </div>
+        {{/accordion-list-item}}
+
+        {{#accordion-list-item
+           title=(t "clusterNew.rke.authorizedEndpoint.title")
+           detail=(t "clusterNew.rke.authorizedEndpoint.detail")
+           expandOnInit=(or (or (eq mode "edit" true false) forceExpandOnInit) applyClusterTemplate)
+           expandAll=al.expandAll
+           expand=(action expandFn)
+        }}
+          <AuthorizedEndpoint
+            @addOverride={{action "addOverride"}}
+            @cluster={{cluster}}
+            @clusterTemplateCreate={{clusterTemplateCreate}}
+            @clusterTemplateRevision={{model.clusterTemplateRevision}}
+            @applyClusterTemplate={{applyClusterTemplate}}
+          />
+        {{/accordion-list-item}}
+
+      {{/if}}
+    {{/accordion-list}}
+  {{/if}} {{!-- endif (or isEdit (eq step 1)) --}}
+
+
+  {{#if (and isCustom (eq step 2)) }}
+    {{#accordion-list
+       expandAll=(mut forceExpandAll)
+       showExpandAll=false
+       as |al expandFn|
+    }}
+      {{#if windowsSupport}}
+        {{#accordion-list-item
+           title=(t "clusterNew.rke.system.title")
+           detail=(t "clusterNew.rke.system.detail")
+           expandOnInit=true
+           expandAll=al.expandAll
+           expand=(action expandFn)
+        }}
+          <div class="row">
+            <div class="col span-6 text-center mt-0 mb-0">
+              <div class="radio">
+                <label>
+                  {{radio-button selection=isLinux value=true}}
+                  {{t "clusterNew.rke.system.linux"}}
+                </label>
               </div>
-            </CheckOverrideAllowed>
+            </div>
+            <div class="col span-6 text-center mt-0 mb-0">
+              <div class="radio">
+                <label>
+                  {{radio-button selection=isLinux value=false}}
+                  {{t "clusterNew.rke.system.windows"}}
+                </label>
+              </div>
+            </div>
           </div>
-
-          <div class="col span-3 offset-1">
-            <label class="acc-label">
-              {{t "clusterNew.rke.etcd.backupConfig.retention.label"}}
-              {{#if clusterTemplateCreate}}
-                <ClusterTemplateOverrideToggle
-                  @path="rancherKubernetesEngineConfig.services.etcd.backupConfig.retention"
-                  @configVariable={{config.services.etcd.backupConfig.retention}}
-                  @addOverride={{action "addOverride"}}
-                  @questions={{model.clusterTemplateRevision.questions}}
-                />
-              {{/if}}
-            </label>
-            <CheckOverrideAllowed
-              @paramName="rancherKubernetesEngineConfig.services.etcd.backupConfig.retention"
-              @applyClusterTemplate={{applyClusterTemplate}}
-              @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-              @questions={{model.clusterTemplateRevision.questions}}
-            >
-              {{input-integer
-                value=config.services.etcd.backupConfig.retention
-                min=1
-                classNames="form-control"
-                placeholder=(t "clusterNew.rke.etcd.backupConfig.retention.placeholder")
-                disabled=(if (not config.services.etcd.backupConfig.enabled) true)
-              }}
-            </CheckOverrideAllowed>
-          </div>
-        </div>
-      {{/accordion-list-item}}
-
+        {{/accordion-list-item}}
+      {{/if}}
       {{#accordion-list-item
-         title=(t "clusterNew.rke.authorizedEndpoint.title")
-         detail=(t "clusterNew.rke.authorizedEndpoint.detail")
-         expandOnInit=(or (or (eq mode "edit" true false) forceExpandOnInit) applyClusterTemplate)
-         expandAll=al.expandAll
-         expand=(action expandFn)
-      }}
-        <AuthorizedEndpoint
-          @addOverride={{action "addOverride"}}
-          @cluster={{cluster}}
-          @clusterTemplateCreate={{clusterTemplateCreate}}
-          @clusterTemplateRevision={{model.clusterTemplateRevision}}
-          @applyClusterTemplate={{applyClusterTemplate}}
-        />
-      {{/accordion-list-item}}
-
-    {{/if}}
-  {{/accordion-list}}
-{{/if}} {{!-- endif (or isEdit (eq step 1)) --}}
-
-{{#if (and isCustom (eq step 2)) }}
-  {{#accordion-list
-     expandAll=(mut forceExpandAll)
-     showExpandAll=false
-     as |al expandFn|
-  }}
-    {{#if windowsSupport}}
-      {{#accordion-list-item
-         title=(t "clusterNew.rke.system.title")
-         detail=(t "clusterNew.rke.system.detail")
+         title=(t "clusterNew.rke.role.pageheader")
+         detail=(t "clusterNew.rke.info.text")
          expandOnInit=true
          expandAll=al.expandAll
          expand=(action expandFn)
       }}
-        <div class="row">
-          <div class="col span-6 text-center mt-0 mb-0">
-            <div class="radio">
-              <label>
-                {{radio-button selection=isLinux value=true}}
-                {{t "clusterNew.rke.system.linux"}}
-              </label>
-            </div>
-          </div>
-          <div class="col span-6 text-center mt-0 mb-0">
-            <div class="radio">
-              <label>
-                {{radio-button selection=isLinux value=false}}
-                {{t "clusterNew.rke.system.windows"}}
-              </label>
-            </div>
-          </div>
-        </div>
-      {{/accordion-list-item}}
-    {{/if}}
-    {{#accordion-list-item
-       title=(t "clusterNew.rke.role.pageheader")
-       detail=(t "clusterNew.rke.info.text")
-       expandOnInit=true
-       expandAll=al.expandAll
-       expand=(action expandFn)
-    }}
-      <section>
-        <p>
-          <ol class="alphalist ml-40 list-unstyled">
-            <li>
-              <ul class="list-unstyled">
-                <div class="pb-10">
-                  <h3 class="mb-0">{{t "clusterNew.rke.role.sectionheader"}}</h3>
-                  <p class="help-block">{{t "clusterNew.rke.role.detail"}}</p>
-                </div>
-                <li>
-                  {{t "clusterNew.rke.role.title"}}
-                </li>
-                <li>
-                  <div class="row">
-                    <div class="col span-4 text-center mt-0 mb-0">
-                      <label class="p-10 pl-30 pr-30 {{unless isLinux "text-muted"}}">
-                        {{input
-                          type="checkbox"
-                          checked=etcd
-                          disabled=(not isLinux)
-                        }} {{t "clusterNew.rke.role.header.etcd"}}
-                      </label>
-                    </div>
-                    <div class="col span-4 text-center mt-0 mb-0">
-                      <label class="p-10 pl-30 pr-30 {{unless isLinux "text-muted"}}">
-                        {{input
-                          type="checkbox"
-                          checked=controlplane
-                          disabled=(not isLinux)
-                        }} {{t "clusterNew.rke.role.header.controlplane"}}
-                      </label>
-                    </div>
-                    <div class="col span-4 text-center mt-0 mb-0">
-                      <label class="p-10 pl-30 pr-30">
-                        {{input
-                          type="checkbox"
-                          checked=worker
-                          disabled=(not isLinux)
-                        }} {{t "clusterNew.rke.role.header.worker"}}
-                      </label>
-                    </div>
+        <section>
+          <p>
+            <ol class="alphalist ml-40 list-unstyled">
+              <li>
+                <ul class="list-unstyled">
+                  <div class="pb-10">
+                    <h3 class="mb-0">{{t "clusterNew.rke.role.sectionheader"}}</h3>
+                    <p class="help-block">{{t "clusterNew.rke.role.detail"}}</p>
                   </div>
-                  {{#advanced-section advanced=commandAdvanced}}
-                    <div class="row mt-20">
-                      {{t "clusterNew.rke.address.title"}}
-                      <p class="help-block">{{t "clusterNew.rke.address.detail"}}</p>
-                      <ul class="list-unstyled">
-                        <li>
-                          <div class="row">
-                            <div class="col span-6">
-                              <label class="acc-label">
-                                {{t "clusterNew.rke.address.public.label"}}
-                              </label>
-                              {{input
-                                type="text"
-                                value=address
-                                placeholder=(t "clusterNew.rke.address.public.placeholder")
-                              }}
-                              {{#unless isAddressValid}}
-                                <div class="banner bg-warning">
-                                  <div class="banner-icon"><span class="icon icon-alert"></span></div>
-                                  <div class="banner-message">
-                                    <p>{{t "clusterNew.rke.address.warning"}}</p>
-                                  </div>
-                                </div>
-                              {{/unless}}
-                            </div>
-                            <div class="col span-6">
-                              <label class="acc-label">
-                                {{t "clusterNew.rke.address.private.label"}}
-                              </label>
-                              {{input
-                                type="text"
-                                value=internalAddress
-                                placeholder=(t "clusterNew.rke.address.private.placeholder")
-                              }}
-                              {{#unless isInternalAddressValid}}
-                                <div class="banner bg-warning">
-                                  <div class="banner-icon"><span class="icon icon-alert"></span></div>
-                                  <div class="banner-message">
-                                    <p>{{t "clusterNew.rke.address.warning"}}</p>
-                                  </div>
-                                </div>
-                              {{/unless}}
-                            </div>
-                          </div>
-                        </li>
-                      </ul>
+                  <li>
+                    {{t "clusterNew.rke.role.title"}}
+                  </li>
+                  <li>
+                    <div class="row">
+                      <div class="col span-4 text-center mt-0 mb-0">
+                        <label class="p-10 pl-30 pr-30 {{unless isLinux "text-muted"}}">
+                          {{input
+                            type="checkbox"
+                            checked=etcd
+                            disabled=(not isLinux)
+                          }} {{t "clusterNew.rke.role.header.etcd"}}
+                        </label>
+                      </div>
+                      <div class="col span-4 text-center mt-0 mb-0">
+                        <label class="p-10 pl-30 pr-30 {{unless isLinux "text-muted"}}">
+                          {{input
+                            type="checkbox"
+                            checked=controlplane
+                            disabled=(not isLinux)
+                          }} {{t "clusterNew.rke.role.header.controlplane"}}
+                        </label>
+                      </div>
+                      <div class="col span-4 text-center mt-0 mb-0">
+                        <label class="p-10 pl-30 pr-30">
+                          {{input
+                            type="checkbox"
+                            checked=worker
+                            disabled=(not isLinux)
+                          }} {{t "clusterNew.rke.role.header.worker"}}
+                        </label>
+                      </div>
                     </div>
-                    <div class="row mt-20">
-                      {{t "clusterNew.rke.nodeName.title"}}
-                      <p class="help-block">
-                        {{t "clusterNew.rke.nodeName.detail"}}
-                      </p>
-                      <ul class="list-unstyled">
-                        <li>
-                          <div class="row">
-                            <div class="col span-6">
-                              {{input
-                                type="text"
-                                value=nodeName
-                                placeholder=(t "clusterNew.rke.nodeName.placeholder")
-                              }}
-                              {{#unless isNodeNameValid}}
-                                {{top-errors errors=nodeNameErrors}}
-                              {{/unless}}
-                            </div>
-                          </div>
-                        </li>
-                      </ul>
-                    </div>
-                    <div class="row mt-20">
-                      {{t "clusterNew.rke.labels.title"}}
-                      <p class="help-block">
-                        {{t "clusterNew.rke.labels.detail"}}
-                      </p>
-                      <ul class="list-unstyled">
-                        <li>
-                          {{#form-user-labels
-                             setLabels=(action "setLabels")
-                             expandAll=al.expandAll
-                             expand=(action expandFn)
-                             detailKey="formUserLabels.nodeDetail"
-                             as | userLabelArray removeLabel addUserLabel |
-                          }}
-                            {{#if userLabelArray.length}}
-                              <table class="table fixed no-lines mt-20">
-                                <tr class="hidden-xs hidden-sm">
-                                  <th>{{t "formUserLabels.key.label"}}{{field-required}}</th>
-                                  <th width="30">&nbsp;</th>
-                                  <th>{{t "formUserLabels.value.label"}}</th>
-                                  <th width="40">&nbsp;</th>
-                                </tr>
-                                {{#each userLabelArray as |label|}}
-                                  <tr>
-                                    <td data-title="key">
-                                      {{input-paste
-                                        pasted=(action "pastedLabels")
-                                        class="form-control input-sm key"
-                                        type="text"
-                                        value=label.key
-                                        placeholder="formUserLabels.key.placeholder"
-                                        disabled=(eq label.readonly true)
-                                      }}
-                                    </td>
-
-                                    <td class="text-center">
-                                      <p class="input-sm">
-                                        {{t "formUserLabels.separator"}}
-                                      </p>
-                                    </td>
-
-                                    <td data-title="label">
-                                      {{input
-                                        class="form-control input-sm"
-                                        type="text"
-                                        value=label.value
-                                        placeholder=(t "formUserLabels.value.placeholder")
-                                        disabled=(eq label.readonly true)
-                                      }}
-                                    </td>
-
-                                    <td class="text-right">
-                                      <button class="btn bg-primary btn-sm" {{action removeLabel label}} disabled={{eq label.readonly true}}>
-                                        <i class="icon icon-minus"/>
-                                        <span class="sr-only">
-                                          {{t "generic.remove"}}
-                                        </span>
-                                      </button>
-                                    </td>
-                                  </tr>
-                                {{/each}}
-                              </table>
-                              <div class="protip pt-10">
-                                {{t "formUserLabels.protip"}}
+                    {{#advanced-section advanced=commandAdvanced}}
+                      <div class="row mt-20">
+                        {{t "clusterNew.rke.address.title"}}
+                        <p class="help-block">{{t "clusterNew.rke.address.detail"}}</p>
+                        <ul class="list-unstyled">
+                          <li>
+                            <div class="row">
+                              <div class="col span-6">
+                                <label class="acc-label">
+                                  {{t "clusterNew.rke.address.public.label"}}
+                                </label>
+                                {{input
+                                  type="text"
+                                  value=address
+                                  placeholder=(t "clusterNew.rke.address.public.placeholder")
+                                }}
+                                {{#unless isAddressValid}}
+                                  <div class="banner bg-warning">
+                                    <div class="banner-icon"><span class="icon icon-alert"></span></div>
+                                    <div class="banner-message">
+                                      <p>{{t "clusterNew.rke.address.warning"}}</p>
+                                    </div>
+                                  </div>
+                                {{/unless}}
                               </div>
-                            {{/if}}
+                              <div class="col span-6">
+                                <label class="acc-label">
+                                  {{t "clusterNew.rke.address.private.label"}}
+                                </label>
+                                {{input
+                                  type="text"
+                                  value=internalAddress
+                                  placeholder=(t "clusterNew.rke.address.private.placeholder")
+                                }}
+                                {{#unless isInternalAddressValid}}
+                                  <div class="banner bg-warning">
+                                    <div class="banner-icon"><span class="icon icon-alert"></span></div>
+                                    <div class="banner-message">
+                                      <p>{{t "clusterNew.rke.address.warning"}}</p>
+                                    </div>
+                                  </div>
+                                {{/unless}}
+                              </div>
+                            </div>
+                          </li>
+                        </ul>
+                      </div>
+                      <div class="row mt-20">
+                        {{t "clusterNew.rke.nodeName.title"}}
+                        <p class="help-block">
+                          {{t "clusterNew.rke.nodeName.detail"}}
+                        </p>
+                        <ul class="list-unstyled">
+                          <li>
+                            <div class="row">
+                              <div class="col span-6">
+                                {{input
+                                  type="text"
+                                  value=nodeName
+                                  placeholder=(t "clusterNew.rke.nodeName.placeholder")
+                                }}
+                                {{#unless isNodeNameValid}}
+                                  {{top-errors errors=nodeNameErrors}}
+                                {{/unless}}
+                              </div>
+                            </div>
+                          </li>
+                        </ul>
+                      </div>
+                      <div class="row mt-20">
+                        {{t "clusterNew.rke.labels.title"}}
+                        <p class="help-block">
+                          {{t "clusterNew.rke.labels.detail"}}
+                        </p>
+                        <ul class="list-unstyled">
+                          <li>
+                            {{#form-user-labels
+                               setLabels=(action "setLabels")
+                               expandAll=al.expandAll
+                               expand=(action expandFn)
+                               detailKey="formUserLabels.nodeDetail"
+                               as | userLabelArray removeLabel addUserLabel |
+                            }}
+                              {{#if userLabelArray.length}}
+                                <table class="table fixed no-lines mt-20">
+                                  <tr class="hidden-xs hidden-sm">
+                                    <th>{{t "formUserLabels.key.label"}}{{field-required}}</th>
+                                    <th width="30">&nbsp;</th>
+                                    <th>{{t "formUserLabels.value.label"}}</th>
+                                    <th width="40">&nbsp;</th>
+                                  </tr>
+                                  {{#each userLabelArray as |label|}}
+                                    <tr>
+                                      <td data-title="key">
+                                        {{input-paste
+                                          pasted=(action "pastedLabels")
+                                          class="form-control input-sm key"
+                                          type="text"
+                                          value=label.key
+                                          placeholder="formUserLabels.key.placeholder"
+                                          disabled=(eq label.readonly true)
+                                        }}
+                                      </td>
 
-                            <button class="btn bg-link icon-btn" {{action addUserLabel}}>
-                              <span class="darken">
-                                <i class="icon icon-plus text-small"/>
-                              </span>
-                              <span>
-                                {{t "formUserLabels.addAction"}}
-                              </span>
-                            </button>
-                          {{/form-user-labels}}
-                        </li>
-                      </ul>
+                                      <td class="text-center">
+                                        <p class="input-sm">
+                                          {{t "formUserLabels.separator"}}
+                                        </p>
+                                      </td>
+
+                                      <td data-title="label">
+                                        {{input
+                                          class="form-control input-sm"
+                                          type="text"
+                                          value=label.value
+                                          placeholder=(t "formUserLabels.value.placeholder")
+                                          disabled=(eq label.readonly true)
+                                        }}
+                                      </td>
+
+                                      <td class="text-right">
+                                        <button class="btn bg-primary btn-sm" {{action removeLabel label}} disabled={{eq label.readonly true}}>
+                                          <i class="icon icon-minus"/>
+                                          <span class="sr-only">
+                                            {{t "generic.remove"}}
+                                          </span>
+                                        </button>
+                                      </td>
+                                    </tr>
+                                  {{/each}}
+                                </table>
+                                <div class="protip pt-10">
+                                  {{t "formUserLabels.protip"}}
+                                </div>
+                              {{/if}}
+
+                              <button class="btn bg-link icon-btn" {{action addUserLabel}}>
+                                <span class="darken">
+                                  <i class="icon icon-plus text-small"/>
+                                </span>
+                                <span>
+                                  {{t "formUserLabels.addAction"}}
+                                </span>
+                              </button>
+                            {{/form-user-labels}}
+                          </li>
+                        </ul>
+                      </div>
+                    {{/advanced-section}}
+                  </li>
+                </ul>
+              </li>
+              <li>
+                {{t (if isLinux "clusterNew.rke.command.instructions" "clusterNew.rke.command.winInstructions") htmlSafe=true version="1809"}}
+                {{!-- <p class="help-block">{{t "clusterNew.rke.labels.detail"}}</p> --}}
+                <ul class="list-unstyled">
+                  <li>
+                    <div class="copy-pre mt-20 mb-20">
+                      {{#if loading}}
+                        <div class="text-center"><i class="icon icon-spinner icon-spin"></i> {{t "generic.loading"}}</div>
+                      {{else if command}}
+                        {{copy-to-clipboard
+                          clipboardText=command
+                          tagName="div"
+                          classNames="copy-to-pre"
+                        }}
+                        <pre id="registration-command" style="font-size: 14px;">{{command}}</pre>
+                      {{/if}}
                     </div>
-                  {{/advanced-section}}
-                </li>
-              </ul>
-            </li>
-            <li>
-              {{t (if isLinux "clusterNew.rke.command.instructions" "clusterNew.rke.command.winInstructions") htmlSafe=true version="1809"}}
-              {{!-- <p class="help-block">{{t "clusterNew.rke.labels.detail"}}</p> --}}
-              <ul class="list-unstyled">
-                <li>
-                  <div class="copy-pre mt-20 mb-20">
-                    {{#if loading}}
-                      <div class="text-center"><i class="icon icon-spinner icon-spin"></i> {{t "generic.loading"}}</div>
-                    {{else if command}}
-                      {{copy-to-clipboard
-                        clipboardText=command
-                        tagName="div"
-                        classNames="copy-to-pre"
-                      }}
-                      <pre id="registration-command" style="font-size: 14px;">{{command}}</pre>
-                    {{/if}}
-                  </div>
-                </li>
-              </ul>
-            </li>
-          </ol>
-        </p>
+                  </li>
+                </ul>
+              </li>
+            </ol>
+          </p>
 
-      </section>
-    {{/accordion-list-item}}
-  {{/accordion-list}}
+        </section>
+      {{/accordion-list-item}}
+    {{/accordion-list}}
 
-  {{#if newNodeCount}}
-    <div class="banner bg-success">
-      <div class="banner-icon"><span class="icon icon-success"></span></div>
-      <div class="banner-message">
-        <p>{{t "clusterNew.rke.detected" count=newNodeCount}}</p>
+    {{#if newNodeCount}}
+      <div class="banner bg-success">
+        <div class="banner-icon"><span class="icon icon-success"></span></div>
+        <div class="banner-message">
+          <p>{{t "clusterNew.rke.detected" count=newNodeCount}}</p>
+        </div>
       </div>
+    {{/if}}
+  {{/if}} {{!-- endif (and isCustom (eq step 2)) --}}
+
+
+  {{#if (or clusterTemplateCreate applyClusterTemplate)}}
+    {{#accordion-list
+       expandAll=(mut forceExpandAll)
+       showExpandAll=false
+       as |al expandFn|
+    }}
+      {{#accordion-list-item
+         title=(t "clusterTemplateQuestions.label")
+         detail=(t "clusterTemplateQuestions.detail")
+         expandAll=al.expandAll
+         expand=(action expandFn)
+         expandOnInit=true
+      }}
+        <CruClusterTemplateQuestions
+          @addQuestion={{addQuestion}}
+          @removeQuestion={{removeQuestion}}
+          @allQuestions={{clusterTemplateQuestions}}
+          @applyClusterTemplate={{applyClusterTemplate}}
+          @clusterTemplateCreate={{clusterTemplateCreate}}
+        />
+      {{/accordion-list-item}}
+    {{/accordion-list}}
+  {{/if}}
+
+  {{top-errors errors=errors}}
+  {{top-errors errors=clusterErrors}}
+  {{top-errors errors=otherErrors}}
+  {{top-errors errors=clusterOptErrors}}
+
+  {{#if (or isEdit (eq step 1))}}
+    {{save-cancel
+      createLabel=(or overrideCreateLabel (if isCustom "saveCancel.next" "saveCancel.create"))
+      editing=isEdit
+      save=(action "driverSave")
+      cancel=(action "close")
+    }}
+  {{else}}
+    <div class="footer-actions">
+      <button {{action "close"}} class="btn bg-primary">
+        {{t "clusterNew.rke.done"}}
+      </button>
     </div>
   {{/if}}
-{{/if}} {{!-- endif (and isCustom (eq step 2)) --}}
-
-
-{{#if (or clusterTemplateCreate applyClusterTemplate)}}
-  {{#accordion-list
-     expandAll=(mut forceExpandAll)
-     showExpandAll=false
-     as |al expandFn|
-  }}
-    {{#accordion-list-item
-       title=(t "clusterTemplateQuestions.label")
-       detail=(t "clusterTemplateQuestions.detail")
-       expandAll=al.expandAll
-       expand=(action expandFn)
-       expandOnInit=true
-    }}
-      <CruClusterTemplateQuestions
-        @addQuestion={{addQuestion}}
-        @removeQuestion={{removeQuestion}}
-        @allQuestions={{clusterTemplateQuestions}}
-        @applyClusterTemplate={{applyClusterTemplate}}
-        @clusterTemplateCreate={{clusterTemplateCreate}}
-      />
-    {{/accordion-list-item}}
-  {{/accordion-list}}
-{{/if}}
-
-{{top-errors errors=errors}}
-{{top-errors errors=clusterErrors}}
-{{top-errors errors=otherErrors}}
-{{top-errors errors=clusterOptErrors}}
-
-{{#if (or isEdit (eq step 1))}}
-  {{save-cancel
-    createLabel=(or overrideCreateLabel (if isCustom "saveCancel.next" "saveCancel.create"))
-    editing=isEdit
-    save=(action "driverSave")
-    cancel=(action "close")
-  }}
-{{else}}
-  <div class="footer-actions">
-    <button {{action "close"}} class="btn bg-primary">
-      {{t "clusterNew.rke.done"}}
-    </button>
-  </div>
 {{/if}}
 
 <input

--- a/lib/shared/addon/components/cru-node-pools/template.hbs
+++ b/lib/shared/addon/components/cru-node-pools/template.hbs
@@ -23,7 +23,7 @@
   {{else if (eq kind "suffix")}}
     <tbody>
       <tr class="banner bg-info suffix">
-        <td colspan="3" class="pl-20 text-bold">{{t "clusterNew.rke.role.requirements.label"}}</td>
+        <td colspan="4" class="pl-20 text-bold">{{t "clusterNew.rke.role.requirements.label"}}</td>
         <td class="text-center {{if etcdOk "text-success" "text-error text-bold"}}">
           <i class="icon {{if etcdOk "icon-success" "icon-x-circle"}}"></i>
           {{t "clusterNew.rke.role.requirements.etcd"}}
@@ -36,7 +36,6 @@
           <i class="icon {{if workerOk "icon-success" "icon-x-circle"}}"></i>
           {{t "clusterNew.rke.role.requirements.worker"}}
         </td>
-        <td></td>
         <td></td>
       </tr>
     </tbody>

--- a/lib/shared/addon/components/cru-private-registry/component.js
+++ b/lib/shared/addon/components/cru-private-registry/component.js
@@ -8,6 +8,7 @@ import {
 } from '@ember/object';
 import { alias, gt } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import { scheduleOnce } from '@ember/runloop';
 
 export default Component.extend({
   globalStore:       service(),
@@ -33,16 +34,18 @@ export default Component.extend({
   init() {
     this._super(...arguments);
 
-    set(this, 'config', get(this, `cluster.${ get(this, 'configName') }`));
+    scheduleOnce('afterRender', () => {
+      set(this, 'config', get(this, `cluster.${ get(this, 'configName') }`));
 
-    if (this.config.privateRegistries) {
-      if ( this.config.privateRegistries.length >= 1 ) {
-        setProperties(this, {
-          privateRegistry:       get(this, 'config.privateRegistries.firstObject'),
-          enablePrivateRegistry: true,
-        });
+      if (this.config.privateRegistries) {
+        if ( this.config.privateRegistries.length >= 1 ) {
+          setProperties(this, {
+            privateRegistry:       get(this, 'config.privateRegistries.firstObject'),
+            enablePrivateRegistry: true,
+          });
+        }
       }
-    }
+    });
   },
 
   actions: {

--- a/lib/shared/addon/components/empty-table/template.hbs
+++ b/lib/shared/addon/components/empty-table/template.hbs
@@ -1,43 +1,47 @@
-<div class="col span-6 offset-3 text-center pt-40 pb-40">
-  <img style="width: 75%;" src="{{app.baseAssets}}assets/images/resources/{{resource}}.svg"/>
-  {{#if showNew}}
-    <br/>
-    {{#if istio}}
-      <a
-        class="btn bg-link icon-btn mt-50 link"
-        href="{{href-to newRoute scope.currentProject.id (query-params istio=true)}}"
-        disabled={{disabled}}
-      >
-        <span class="darken"><i class="icon icon-plus text-small"></i></span>
-        <span>{{t newTranslationKey}}</span>
-      </a>
-    {{else if (and (eq ctx "projectId") scope.currentProject.id)}}
-      <a
-        class="btn bg-link icon-btn mt-50 link"
-        href="{{href-to newRoute scope.currentProject.id}}"
-        disabled={{disabled}}
-      >
-        <span class="darken"><i class="icon icon-plus text-small"></i></span>
-        <span>{{t newTranslationKey}}</span>
-      </a>
-    {{else if (eq ctx "clusterId")}}
-      <a
-        class="btn bg-link icon-btn mt-50 link"
-        href="{{href-to newRoute scope.currentCluster.id}}"
-        disabled={{disabled}}
-      >
-        <span class="darken"><i class="icon icon-plus text-small"></i></span>
-        <span>{{t newTranslationKey}}</span>
-      </a>
-    {{else}}
-      <a
-        class="btn bg-link icon-btn mt-50 link"
-        href="{{href-to newRoute}}"
-        disabled={{disabled}}
-      >
-        <span class="darken"><i class="icon icon-plus text-small"></i></span>
-        <span>{{t newTranslationKey}}</span>
-      </a>
+{{#if hasBlock}}
+  {{yield}}
+{{else}}
+  <div class="col span-6 offset-3 text-center pt-40 pb-40">
+    <img style="width: 75%;" src="{{app.baseAssets}}assets/images/resources/{{resource}}.svg"/>
+    {{#if showNew}}
+      <br/>
+      {{#if istio}}
+        <a
+          class="btn bg-link icon-btn mt-50 link"
+          href="{{href-to newRoute scope.currentProject.id (query-params istio=true)}}"
+          disabled={{disabled}}
+        >
+          <span class="darken"><i class="icon icon-plus text-small"></i></span>
+          <span>{{t newTranslationKey}}</span>
+        </a>
+      {{else if (and (eq ctx "projectId") scope.currentProject.id)}}
+        <a
+          class="btn bg-link icon-btn mt-50 link"
+          href="{{href-to newRoute scope.currentProject.id}}"
+          disabled={{disabled}}
+        >
+          <span class="darken"><i class="icon icon-plus text-small"></i></span>
+          <span>{{t newTranslationKey}}</span>
+        </a>
+      {{else if (eq ctx "clusterId")}}
+        <a
+          class="btn bg-link icon-btn mt-50 link"
+          href="{{href-to newRoute scope.currentCluster.id}}"
+          disabled={{disabled}}
+        >
+          <span class="darken"><i class="icon icon-plus text-small"></i></span>
+          <span>{{t newTranslationKey}}</span>
+        </a>
+      {{else}}
+        <a
+          class="btn bg-link icon-btn mt-50 link"
+          href="{{href-to newRoute}}"
+          disabled={{disabled}}
+        >
+          <span class="darken"><i class="icon icon-plus text-small"></i></span>
+          <span>{{t newTranslationKey}}</span>
+        </a>
+      {{/if}}
     {{/if}}
-  {{/if}}
-</div>
+  </div>
+{{/if}}

--- a/lib/shared/addon/settings/service.js
+++ b/lib/shared/addon/settings/service.js
@@ -128,13 +128,14 @@ export default Service.extend(Evented, {
     return promise;
   },
 
-  cliVersion:           alias(`asMap.${ C.SETTING.VERSION_CLI }.value`),
-  dockerMachineVersion: alias(`asMap.${ C.SETTING.VERSION_MACHINE }.value`),
-  helmVersion:          alias(`asMap.${ C.SETTING.VERSION_HELM }.value`),
-  minDockerVersion:     alias(`asMap.${ C.SETTING.MIN_DOCKER }.value`),
-  rancherImage:         alias(`asMap.${ C.SETTING.IMAGE_RANCHER }.value`),
-  rancherVersion:       alias(`asMap.${ C.SETTING.VERSION_RANCHER }.value`),
-  serverUrl:            alias(`asMap.${ C.SETTING.SERVER_URL }.value`),
+  cliVersion:                 alias(`asMap.${ C.SETTING.VERSION_CLI }.value`),
+  dockerMachineVersion:       alias(`asMap.${ C.SETTING.VERSION_MACHINE }.value`),
+  helmVersion:                alias(`asMap.${ C.SETTING.VERSION_HELM }.value`),
+  minDockerVersion:           alias(`asMap.${ C.SETTING.MIN_DOCKER }.value`),
+  rancherImage:               alias(`asMap.${ C.SETTING.IMAGE_RANCHER }.value`),
+  rancherVersion:             alias(`asMap.${ C.SETTING.VERSION_RANCHER }.value`),
+  serverUrl:                  alias(`asMap.${ C.SETTING.SERVER_URL }.value`),
+  clusterTemplateEnforcement: alias(`asMap.${ C.SETTING.CLUSTER_TEMPLATE_ENFORCEMENT }.value`),
 
   asMap: computed('all.@each.{name,value,customized}', function() {
     var out = {};

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -880,6 +880,7 @@ clustersPage:
   newTemplate: "New Template"
   newClusterName: "Add Cluster: {name}"
   editClusterName: "Edit Cluster: {name}"
+  clusterLaunchDisabled: "Cluster Template Enforcement is enabled and you do not have access to any templates.<br /> Please contact your admin for access."
   launch:
     new: Add Cluster
   cluster:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -880,7 +880,7 @@ clustersPage:
   newTemplate: "New Template"
   newClusterName: "Add Cluster: {name}"
   editClusterName: "Edit Cluster: {name}"
-  clusterLaunchDisabled: "Cluster Template Enforcement is enabled and you do not have access to any templates.<br /> Please contact your admin for access."
+  clusterLaunchDisabled: "You have not been granted access to any cluster templates."
   launch:
     new: Add Cluster
   cluster:


### PR DESCRIPTION
Proposed changes
======

Adds cluster template enforcement logic when the global setting is enabled. 

Global Admin is not effected by cluster template enforcement.
Users who have no cluster templates when enforcement is enabled will not be able to select the launch cluster button and will be presented with a tooltip.
Users who have one template will be taken to the cluster add page with the default revision of the single template they have selected as the cluster template to launch with.
Users who have < one cluster template will be presented with the cluster add page with no default selected. These users will not see the cluster options until they select a template. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Enhancement
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#21378
rancher/rancher#21576
rancher/rancher#21679
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

Cru node pool alignment issue fixed in this pr as well. 
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
