### PR TITLE
You are in a maze of twisty catalog logic, all slightly different

### DIFF
--- a/app/catalog-tab/controller.js
+++ b/app/catalog-tab/controller.js
@@ -1,9 +1,6 @@
 import Controller from '@ember/controller';
 
 export default Controller.extend({
-  queryParams:      ['category', 'catalogId', 'clusterCatalogId', 'projectCatalogId'],
+  queryParams:      ['category'],
   category:         '',
-  catalogId:        '',
-  clusterCatalogId: '',
-  projectCatalogId: '',
 });

--- a/app/catalog-tab/index/controller.js
+++ b/app/catalog-tab/index/controller.js
@@ -2,7 +2,7 @@ import { alias } from '@ember/object/computed';
 import Controller, { inject as controller } from '@ember/controller';
 import { isAlternate } from 'ui/utils/platform';
 import { getOwner } from '@ember/application';
-import { get, computed } from '@ember/object';
+import { get } from '@ember/object';
 
 
 export default Controller.extend({
@@ -15,27 +15,8 @@ export default Controller.extend({
 
   category:          alias('catalogController.category'),
   actions:           {
-    filterAction(catalog){
-      let out      = {
-        catalogId:        '',
-        clusterCatalogId: '',
-        projectCatalogId: '',
-      };
-      let scope    = get(catalog, 'scope');
-      let scopedId = `${ scope }Id`;
-
-      out[scopedId] = get(catalog, 'catalogId');
-
-      this.transitionToRoute(this.get('parentRoute'), { queryParams: out });
-    },
-
-    categoryAction(category, catalogId){
-      this.transitionToRoute(this.get('launchRoute'), {
-        queryParams: {
-          category,
-          catalogId
-        }
-      });
+    categoryAction(category){
+      this.transitionToRoute(this.get('launchRoute'), { queryParams: { category } });
     },
 
     launch(id, onlyAlternate) {
@@ -56,24 +37,4 @@ export default Controller.extend({
       catalogTab.send('refresh');
     },
   },
-
-  catalogId: computed('catalogController.catalogId', 'catalogController.clusterCatalogId', 'catalogController.projectCatalogId', function() {
-    const clusterCatalogId = get(this, 'catalogController.clusterCatalogId')
-    const projectCatalogId = get(this, 'catalogController.projectCatalogId')
-    const catalogId = get(this, 'catalogController.catalogId')
-    let out = ''
-
-    if (catalogId) {
-      out = catalogId
-    }
-    if (clusterCatalogId) {
-      out = clusterCatalogId.split(':')[1]
-    }
-    if (projectCatalogId) {
-      out = projectCatalogId.split(':')[1]
-    }
-
-    return out
-  }),
-
 });

--- a/app/catalog-tab/index/template.hbs
+++ b/app/catalog-tab/index/template.hbs
@@ -1,9 +1,7 @@
 {{catalog-index
   application=application
-  catalogId=catalogId
   category=category
   categoryAction=(action "categoryAction")
-  filterAction=(action "filterAction")
   launch=(action "launch")
   launchRoute=launchRoute
   model=model

--- a/app/catalog-tab/route.js
+++ b/app/catalog-tab/route.js
@@ -1,6 +1,6 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import { get, set } from '@ember/object';
+import { get } from '@ember/object';
 
 export default Route.extend({
   access:  service(),
@@ -10,38 +10,19 @@ export default Route.extend({
   beforeModel() {
     this._super(...arguments);
 
-    return get(this, 'catalog').fetchUnScopedCatalogs().then((hash) => {
-      this.set('catalogs', hash);
-    });
+    return get(this, 'catalog').fetchUnScopedCatalogs();
   },
 
-  model(params) {
-    const project = this.modelFor('authenticated.project').get('project');
+  model() {
+    // Do not use the model result
+    const out = {};
 
-    set(params, 'project', project);
-
-    return get(this, 'catalog').fetchTemplates(params)
-      .then((res) => {
-        res.catalog.forEach((tpl) => {
-          let exists = project.get('apps').findBy('externalIdInfo.templateId', tpl.get('id'));
-
-          tpl.set('exists', !!exists);
-        });
-
-        res.catalogs = get(this, 'catalogs');
-
-        return res;
-      });
+    return get(this, 'catalog').fetchTemplates().then(() => out);
   },
 
   resetController(controller, isExiting/* , transition*/) {
     if (isExiting) {
-      controller.setProperties({
-        category:         '',
-        catalogId:        '',
-        projectCatalogId: '',
-        clusterCatalogId: '',
-      })
+      controller.setProperties({ category: '' })
     }
   },
 
@@ -57,12 +38,4 @@ export default Route.extend({
       this.refresh();
     },
   },
-
-  queryParams: {
-    category:         { refreshModel: true },
-    catalogId:        { refreshModel: true },
-    clusterCatalogId: { refreshModel: true },
-    projectCatalogId: { refreshModel: true },
-  },
-
 });

--- a/app/styles/pages/_catalog.scss
+++ b/app/styles/pages/_catalog.scss
@@ -1,3 +1,9 @@
+.catalog-group:not(:last-child) {
+  padding-bottom: 15px;
+  border-bottom: 1px solid $border;
+  margin-bottom: 15px;
+}
+
 .launch-catalog {
   H4 {
     // font-weight: bold;

--- a/lib/global-admin/addon/multi-cluster-apps/catalog/controller.js
+++ b/lib/global-admin/addon/multi-cluster-apps/catalog/controller.js
@@ -1,9 +1,6 @@
 import Controller from '@ember/controller';
 
 export default Controller.extend({
-  queryParams:      ['category', 'catalogId', 'clusterCatalogId', 'projectCatalogId'],
+  queryParams:      ['category'],
   category:         '',
-  catalogId:        '',
-  clusterCatalogId: '',
-  projectCatalogId: '',
 });

--- a/lib/global-admin/addon/multi-cluster-apps/catalog/index/controller.js
+++ b/lib/global-admin/addon/multi-cluster-apps/catalog/index/controller.js
@@ -2,8 +2,6 @@ import { alias } from '@ember/object/computed';
 import Controller, { inject as controller } from '@ember/controller';
 import { isAlternate } from 'ui/utils/platform';
 import { getOwner } from '@ember/application';
-import { get } from '@ember/object';
-
 
 export default Controller.extend({
   application:       controller(),
@@ -11,30 +9,10 @@ export default Controller.extend({
   parentRoute:       'multi-cluster-apps.catalog',
   launchRoute:       'multi-cluster-apps.catalog.launch',
   category:          alias('catalogController.category'),
-  catalogId:         alias('catalogController.catalogId'),
 
   actions:           {
-    filterAction(catalog){
-      let out      = {
-        catalogId:        '',
-        clusterCatalogId: '',
-        projectCatalogId: '',
-      };
-      let scope    = get(catalog, 'scope');
-      let scopedId = `${ scope }Id`;
-
-      out[scopedId] = get(catalog, 'catalogId');
-
-      this.transitionToRoute(this.get('parentRoute'), { queryParams: out });
-    },
-
-    categoryAction(category, catalogId){
-      this.transitionToRoute(this.get('parentRoute'), {
-        queryParams: {
-          category,
-          catalogId
-        }
-      });
+    categoryAction(category){
+      this.transitionToRoute(this.get('parentRoute'), { queryParams: { category } });
     },
 
     launch(id, onlyAlternate) {

--- a/lib/global-admin/addon/multi-cluster-apps/catalog/index/template.hbs
+++ b/lib/global-admin/addon/multi-cluster-apps/catalog/index/template.hbs
@@ -3,7 +3,6 @@
   catalogId=catalogId
   category=category
   categoryAction=(action "categoryAction")
-  filterAction=(action "filterAction")
   launch=(action "launch")
   launchRoute=launchRoute
   model=model

--- a/lib/global-admin/addon/multi-cluster-apps/catalog/route.js
+++ b/lib/global-admin/addon/multi-cluster-apps/catalog/route.js
@@ -1,6 +1,6 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import { get } from '@ember/object';
+import { get, set } from '@ember/object';
 
 export default Route.extend({
   access:  service(),
@@ -10,49 +10,25 @@ export default Route.extend({
   beforeModel() {
     this._super(...arguments);
 
-    return get(this, 'catalog').fetchUnScopedCatalogs().then((hash) => {
-      this.set('catalogs', hash);
-    });
+    return get(this, 'catalog').fetchUnScopedCatalogs();
   },
 
-  model(params) {
-    return get(this, 'catalog').fetchTemplates(params)
-      .then((res) => {
-        res.catalogs = get(this, 'catalogs');
+  model() {
+    // Do not use the model result
+    const out = {};
 
-        return res;
-      });
+    return get(this, 'catalog').fetchTemplates().then(() => out);
   },
 
   resetController(controller, isExiting/* , transition*/) {
     if (isExiting) {
-      controller.setProperties({
-        category:         '',
-        catalogId:        '',
-        projectCatalogId: '',
-        clusterCatalogId: '',
-      })
+      set(controller, 'category', '');
     }
-  },
-
-  deactivate() {
-    // Clear the cache when leaving the route so that it will be reloaded when you come back.
-    this.set('cache', null);
   },
 
   actions: {
     refresh() {
-      // Clear the cache so it has to ask the server again
-      this.set('cache', null);
       this.refresh();
     },
   },
-
-  queryParams: {
-    category:         { refreshModel: true },
-    catalogId:        { refreshModel: true },
-    clusterCatalogId: { refreshModel: true },
-    projectCatalogId: { refreshModel: true },
-  },
-
 });

--- a/lib/pipeline/addon/components/steps/step-apply-catalog/component.js
+++ b/lib/pipeline/addon/components/steps/step-apply-catalog/component.js
@@ -17,7 +17,6 @@ export default Component.extend(Step, {
   field:           'applyAppConfig',
   defaultConfig:   DEFAULT_CONFIG,
   loading:         false,
-  selectedCatalog: null,
 
   init() {
     this._super(...arguments);
@@ -82,15 +81,16 @@ export default Component.extend(Step, {
   },
 
   initCatalog() {
+    const catalog = get(this, 'catalog');
+
     set(this, 'loading', true);
-    get(this, 'catalog').fetchUnScopedCatalogs().then((hash) => {
-      get(this, 'catalog').fetchTemplates()
-        .then((res) => {
-          set(this, 'allApps', res.catalog);
-          this.setCatalogs(hash);
-        }).finally(() => {
-          set(this, 'loading', false);
-        });
+    catalog.fetchUnScopedCatalogs().then((hash) => {
+      return catalog.fetchTemplates().then(() => {
+        set(this, 'allApps', catalog._allTemplates);
+        this.setCatalogs(hash);
+      })
+    }).finally(() => {
+      set(this, 'loading', false);
     })
   },
 
@@ -109,17 +109,14 @@ export default Component.extend(Step, {
       }
     }));
 
-    const catalog = get(this, 'config.applyAppConfig.catalogTemplate');
+    const templateId = get(this, 'config.applyAppConfig.catalogTemplate');
 
-    if ( catalog ) {
-      const c = get(this, 'allApps').findBy('id', catalog);
+    if ( templateId ) {
+      const c = get(this, 'allApps').findBy('id', templateId);
 
       if ( c ) {
-        set(this, 'selectedCatalog', get(c, 'catalogId') ||  get(c, 'clusterCatalogId') ||  get(c, 'projectCatalogId'));
         this.appDidChange();
       }
-    } else {
-      set(this, 'selectedCatalog', get(get(catalogs, 'firstObject'), 'id'))
     }
   },
 

--- a/lib/shared/addon/catalog/service.js
+++ b/lib/shared/addon/catalog/service.js
@@ -1,14 +1,13 @@
-import { resolve, reject } from 'rsvp';
+import { resolve } from 'rsvp';
 import Service, { inject as service } from '@ember/service';
 import { addQueryParams, uniqKeys } from 'shared/utils/util';
-import EmberObject from '@ember/object'
-import { set, get, observer, setProperties } from '@ember/object';
+import { get, setProperties } from '@ember/object';
 import { /* parseExternalId, */ parseHelmExternalId } from 'ui/utils/parse-externalid';
 import { allSettled, hash } from 'rsvp';
 import { union } from '@ember/object/computed';
+import C from 'shared/utils/constants';
 
 const RANCHER_VERSION = 'rancherVersion';
-const SYSTEM_CATALOG = 'system-library';
 
 export default Service.extend({
   globalStore:     service(),
@@ -17,12 +16,10 @@ export default Service.extend({
   scope:           service(),
   app:             service(),
 
-  templateCache:   null,
   catalogs:        null,
 
   _allCatalogs:    union('globalCatalogs', 'clusterCatalogs', 'projectCatalogs'),
-  _allTemplates:   null,
-  _refreshMap:     null,
+  _allTemplates:    null,
 
   globalCatalogs:  null,
   clusterCatalogs: null,
@@ -36,43 +33,18 @@ export default Service.extend({
       globalCatalogs:  store.all('catalog'),
       clusterCatalogs: store.all('clustercatalog'),
       projectCatalogs: store.all('projectcatalog'),
-      '_allTemplates': store.all('template'),
-      '_refreshMap':   {},
+      '_allTemplates':  store.all('template'),
     });
   },
 
-  catalogsDidChange: observer('_allCatalogs.@each.state', '_refreshMap', function() {
-    if ( get(this, 'templateCache') !== null ) {
-      const oldRefreshMap = get(this, '_refreshMap');
-      const newRefreshMap = {};
-
-      (get(this, '_allCatalogs') || []).forEach((c) => {
-        newRefreshMap[get(c, 'id')] = get(c, 'lastRefreshTimestamp');
-      });
-      let needRefresh = false;
-
-      for (let k of new Set([...Object.keys(newRefreshMap), ...Object.keys(oldRefreshMap)])) {
-        if ( !oldRefreshMap.hasOwnProperty(k) || !newRefreshMap.hasOwnProperty(k) || oldRefreshMap[k] !== newRefreshMap[k] ) {
-          needRefresh = true;
-        }
-      }
-      set(this, 'needRefresh', needRefresh);
-    }
-  }),
-
   reset() {
-    this.setProperties({
-      templateCache: null,
-      catalogs:      null,
-    });
+    this.setProperties({ catalogs: null });
   },
 
   refresh() {
     const store = get(this, 'globalStore');
 
     return this.fetchUnScopedCatalogs().then(() => {
-      set(this, 'templateCache', null);
-
       return hash({
         projectCatalogs: store.request({
           method: 'POST',
@@ -158,81 +130,16 @@ export default Service.extend({
     return get(this, 'globalStore').request({ url });
   },
 
-  fetchTemplates(params) {
-    params = params || {};
-
-    let cache     = get(this, 'templateCache');
-    let catalogId = null;
-    let qp        = { 'category_ne': 'system', };
-    let project = params.project ? params.project : null;
-    let currentProjectId = project ? project.id.split(':')[1] : null;
-    let currentClusterId = project ? project.clusterId : null;
-
-    if (params.catalogId) {
-      catalogId = params.catalogId;
-
-      if (catalogId && catalogId !== 'all') {
-        qp['catalogId'] = catalogId;
-      }
-    } else if (params.clusterCatalogId) {
-      catalogId = params.clusterCatalogId;
-
-      if (catalogId && catalogId !== 'all') {
-        qp['clusterCatalogId'] = catalogId;
-      }
-    } else if (params.projectCatalogId) {
-      catalogId = params.projectCatalogId;
-
-      if (catalogId && catalogId !== 'all') {
-        qp['projectCatalogId'] = catalogId;
-      }
+  fetchTemplates() {
+    if ( arguments.length ) {
+      console.error('Deprecated', new Error("Use a catalogService.filter(globalStore.all('templates'))"));
     }
 
-    // If the catalogIds dont match we need to go get the other catalog from the store since we do not cache all catalogs
-    if ( cache && cache.catalogId === catalogId && !get(this, 'needRefresh') ) {
-      return resolve(this.filter(cache, params.category));
-    }
+    const globalStore = get(this, 'globalStore');
+    const qp  = { 'category_ne': 'system' };
+    const url = this._addLimits(`${ get(this, 'app.apiEndpoint') }/templates`, qp);
 
-    const catalogs = get(this, '_allCatalogs');
-    const refreshMap = {};
-
-    catalogs.forEach((c) => {
-      refreshMap[get(c, 'id')] = get(c, 'lastRefreshTimestamp');
-    });
-    set(this, '_refreshMap', refreshMap);
-
-    let url = this._addLimits(`${ get(this, 'app.apiEndpoint') }/templates`, qp);
-
-    return get(this, 'globalStore').request({ url, }).then((res) => {
-      res.catalogId = catalogId;
-
-      if (catalogId === 'all' || !catalogId) {
-        set(this, 'templateCache', res.filter((t) => {
-          this;
-          if (t.clusterId && currentClusterId) {
-            if (t.clusterId === currentClusterId) {
-              return t;
-            }
-          } else if (t.projectId && currentProjectId) {
-            if (t.projectId === currentProjectId) {
-              return t;
-            }
-          } else {
-            return t;
-          }
-        }));
-      } else {
-        set(this, 'templateCache', res);
-      }
-
-      return this.filter(res, params.category);
-    }).catch((err) => {
-      if ( params.allowFailure ) {
-        return this.filter([], params.category);
-      } else {
-        return reject(err);
-      }
-    });
+    return globalStore.request({ url }).then(() => ({ catalog: this._allTemplates }));
   },
 
   cleanVersionsArray(template) {
@@ -252,33 +159,48 @@ export default Service.extend({
     return get(this, 'store').request({ url });
   },
 
-  filter(data, category) {
-    category = (category || '').toLowerCase();
-
-    let categories = [];
-
-    data.forEach((obj) => {
-      if ( get(obj, 'catalogId') !== SYSTEM_CATALOG ) {
-        categories.pushObjects(obj.get('categoryArray'));
-      }
-    });
-    categories = uniqKeys(categories);
-    categories.unshift('');
+  filter(data, project, istio) {
+    let currentProjectId = project ? project.id : null;
+    let currentClusterId = project ? project.clusterId : null;
 
     data = data.filter((tpl) => {
-      if ( category !== '' && !tpl.get('categoryLowerArray').includes(category) ) {
+      if ( tpl.clusterId && tpl.clusterId !== currentClusterId ) {
         return false;
       }
 
-      return get(tpl, 'catalogId') !== SYSTEM_CATALOG;
+      if ( tpl.projectId && tpl.projectId !== currentProjectId ) {
+        return false;
+      }
+
+      if ( typeof istio !== undefined ) {
+        if ( istio !== get(tpl, 'isIstio') ) {
+          return false;
+        }
+
+        if ( !istio && get(tpl, 'catalogId') === C.CATALOG.SYSTEM_LIBRARY_KEY ) {
+          return false;
+        }
+      }
+
+      return true;
     });
 
     data = data.sortBy('name');
 
-    return EmberObject.create({
-      categories,
-      catalog:    data,
+    return data;
+  },
+
+  uniqueCategories(data) {
+    let out = [];
+
+    data.forEach((obj) => {
+      out.pushObjects(obj.get('categoryArray'));
     });
+
+    out = uniqKeys(out);
+    out.unshift('');
+
+    return out;
   },
 
   _addLimits(url, qp) {

--- a/lib/shared/addon/components/catalog-box/component.js
+++ b/lib/shared/addon/components/catalog-box/component.js
@@ -14,7 +14,6 @@ export default Component.extend(LazyIcon, {
 
   model:             null,
   showIcon:          true,
-  showSource:        false,
   showDescription:   true,
   active:            true,
   launchAction:      null,

--- a/lib/shared/addon/components/catalog-index/component.js
+++ b/lib/shared/addon/components/catalog-index/component.js
@@ -4,10 +4,10 @@ import Component from '@ember/component';
 import layout from './template';
 import { inject as service } from '@ember/service';
 import { observer, computed, get, set } from '@ember/object';
-const SYSTEM_CATALOG = 'system-library';
 
 export default Component.extend({
   catalog:      service(),
+  prefs:        service(),
   settings:     service(),
   scope:        service(),
   modalService: service('modal'),
@@ -19,7 +19,6 @@ export default Component.extend({
 
   istio:        false,
   projectId:    alias(`cookies.${ C.COOKIE.PROJECT }`),
-  categories:   alias('model.categories'),
   catalogs:     union('model.catalogs.globalCatalogs', 'clusterCatalogs', 'projectCatalogs'),
 
 
@@ -32,6 +31,7 @@ export default Component.extend({
     clearSearch() {
       set(this, 'search', '');
     },
+
     update() {
       set(this, 'updating', 'yes');
       get(this, 'catalog').refresh()
@@ -47,21 +47,26 @@ export default Component.extend({
         });
     },
 
-    filterType(opt, dropdown) {
+    filterCatalog(category, dropdown) {
       if (dropdown && dropdown.isOpen) {
         dropdown.actions.close();
       }
 
-      this.filterAction(opt);
+      this.categoryAction(category);
     },
 
-    filterCatalog(category, catalogId, dropdown) {
-      if (dropdown && dropdown.isOpen) {
-        dropdown.actions.close();
+    toggleCollapse(group) {
+      const collapsedNames = get(this, `prefs.${ C.PREFS.COLLAPSED_CATALOGS }`) || [];
+
+      if ( group.collapsed ) {
+        collapsedNames.removeObject(group.name);
+      } else {
+        collapsedNames.addObject(group.name);
       }
 
-      this.categoryAction(category, catalogId);
-    },
+      set(group, 'collapsed', !group.collapsed);
+      set(this, `prefs.${ C.PREFS.COLLAPSED_CATALOGS }`, collapsedNames);
+    }
   },
 
   childRequestiongRefresh: observer('catalog.componentRequestingRefresh', function() {
@@ -78,53 +83,33 @@ export default Component.extend({
     return get(this, 'model.catalogs.clusterCatalogs').filter( (c) => c.clusterId === get(this, 'scope.currentCluster.id'));
   }),
 
-  totalCategories: computed('categoryWithCounts', function() {
-    var categories = get(this, 'categoryWithCounts');
-    var count      = 0;
+  categories: computed('matchingSearch.@each.{category,categories}', function() {
+    let map = {};
 
-    Object.keys(categories).forEach((cat) => {
-      count = count + categories[cat].count;
-    });
+    get(this, 'matchingSearch').forEach((tpl) => {
+      const categories = tpl.categories;
 
-    return count;
-  }),
+      if ( !categories ){
+        return;
+      }
 
-  categoryWithCounts: computed('category', 'categories', function() {
-    let categories = [];
-    let out        = {};
-    let templates  = get(this, 'catalog.templateCache');
+      for ( let i = 0 ; i < categories.length ; i++ ) {
+        let ctgy = categories[i];
+        let normalized = ctgy.underscore();
 
-    templates = templates.filterBy('isIstio', get(this, 'istio'));
-
-    templates.forEach((tpl) => {
-      if (tpl.categories) {
-        tpl.categories.forEach((ctgy) => {
-          categories.push(ctgy);
-        });
+        if (map[normalized] ) {
+          map[normalized].count += 1;
+        } else {
+          map[normalized] = {
+            name:     ctgy,
+            category: normalized,
+            count:    1,
+          };
+        }
       }
     });
 
-    categories.sort().forEach((ctgy) => {
-      let normalized = ctgy.underscore();
-
-      if (out[normalized] && ctgy) {
-        out[normalized].count++;
-      } else {
-        out[normalized] = {
-          name:     ctgy,
-          category: normalized,
-          count:    1,
-        };
-      }
-    });
-
-    const list = [];
-
-    Object.keys(out).forEach((key) => {
-      list.push(out[key]);
-    });
-
-    return list;
+    return Object.values(map);
   }),
 
   catalogURL: computed('catalogs', function() {
@@ -140,55 +125,72 @@ export default Component.extend({
     return JSON.stringify(neu);
   }),
 
-  filters: computed('catalogs', function() {
-    return get(this, 'catalogs').filter((obj) => get(this, 'istio') || get(obj, 'id') !== SYSTEM_CATALOG).map((obj) => ({
-      catalogId: get(obj, 'id'),
-      label:     get(obj, 'name'),
-      scope:     get(obj, 'type'),
-    }));
+  inScopeTemplates: computed('catalog._allTemplates.@each.{name,id,catalogId}', 'scope.currentProject', 'istio', function() {
+    const svc = get(this, 'catalog');
+
+    return svc.filter(
+      get(svc, '_allTemplates'),
+      get(this, 'scope.currentProject'),
+      get(this, 'istio')
+    );
   }),
 
-  arrangedContent: computed('catalog._allTemplates.@each.{name,id,catalogId}', 'search', function() {
-    let search           = get(this, 'search').toUpperCase();
-    let result           = [];
-    let catalog          = get(this, 'catalog._allTemplates');
-    let currentProjectId = get(this, 'scope.currentProject.id');
-    let currentClusrerId = get(this, 'scope.currentCluster.id');
+  matchingSearch: computed('inScopeTemplates.@each.{name,description}', 'search', function() {
+    const search = (get(this, 'search') || '').toLowerCase();
+    const all = get(this, 'inScopeTemplates');
 
-    catalog = catalog.filter( (item) => {
-      let {
-        projectCatalogId, clusterCatalogId, catalogId
-      } = item;
-
-      if ( !get(this, 'istio') && catalogId === SYSTEM_CATALOG ) {
-        return false;
-      }
-
-      if (projectCatalogId && currentProjectId) {
-        if (projectCatalogId.split(':').firstObject === currentProjectId.split(':')[1]) {
-          return item;
-        }
-      } else if (clusterCatalogId && currentClusrerId) {
-        if (clusterCatalogId.split(':')[0] === currentClusrerId) {
-          return item;
-        }
-      } else if (item.isGlobalCatalog) {
-        return item;
-      }
-    });
-
-    catalog = catalog.filterBy('isIstio', get(this, 'istio'));
-
-    if (!search) {
-      return catalog.sortBy('name');
+    if ( !search ) {
+      return all;
     }
 
-    catalog.forEach((item) => {
-      if (item.name.toUpperCase().indexOf(search) >= 0 || item.description.toUpperCase().indexOf(search) >= 0) {
-        result.push(item);
-      }
+    return all.filter((tpl) => tpl.name.toLowerCase().includes(search) || tpl.description.toLowerCase().includes(search));
+  }),
+
+  arrangedContent: computed('matchingSearch.@each.categoryLowerArray', 'category', function() {
+    const category = (get(this, 'category') || '').toLowerCase();
+    const all = get(this, 'matchingSearch');
+
+    if ( !category || category === 'all') {
+      return all;
+    }
+
+    return all.filter((tpl) => get(tpl, 'categoryLowerArray').includes(category));
+  }),
+
+  groupedContent: computed('arrangedContent.[]', 'catalogs.@each.name', function() {
+    const out = [];
+    const collapsedNames = get(this, `prefs.${ C.PREFS.COLLAPSED_CATALOGS }`) || [];
+    const all = get(this, 'arrangedContent');
+
+    all.forEach((template) => {
+      const entry = getOrCreateGroup(template.displayCatalogId);
+
+      entry.items.push(template);
     });
 
-    return result.sortBy('name');
+    return out.sortBy('priority', 'name');
+
+    function getOrCreateGroup(name){
+      let entry = out.findBy('name', name);
+      let priority = 0;
+
+      if ( name === C.CATALOG.LIBRARY_KEY ) {
+        priority = 1;
+      } else if ( [C.CATALOG.HELM_STABLE_KEY, C.CATALOG.HELM_INCUBATOR_KEY].includes(name) ) {
+        priority = 2;
+      }
+
+      if ( !entry ) {
+        entry = {
+          name,
+          priority,
+          collapsed: collapsedNames.includes(name),
+          items:     [],
+        }
+        out.push(entry);
+      }
+
+      return entry;
+    }
   }),
 });

--- a/lib/shared/addon/components/catalog-index/template.hbs
+++ b/lib/shared/addon/components/catalog-index/template.hbs
@@ -23,51 +23,6 @@
         {{/if}}
       </div>
 
-      <div class="filter-group pull-right ml-20">
-        {{#basic-dropdown
-           verticalPosition="below"
-           horizontalPosition="right"
-           as |dd|
-        }}
-          {{#dd.trigger
-             class="btn bg-default btn-md pt-5 pb-5"
-          }}
-            <i class="icon icon-chevron-down pull-right ml-10"></i>
-            <span class="text-capitalize">
-              {{#if (eq catalogId "")}}
-                {{t "catalogPage.index.allCatalogs"}}
-              {{else}}
-                {{catalogId}}
-              {{/if}}
-            </span>
-          {{/dd.trigger}}
-
-          {{#dd.content
-             class="text-right"
-          }}
-            <li class="text-capitalize {{if (eq catalogId "") "active"}}">
-              <a href="#" {{action "filterType" "" dd}}>
-                {{t "catalogPage.index.allCatalogs"}}
-              </a>
-            </li>
-            {{#each filters as |opt|}}
-              <li class="{{if (eq catalogId opt.catalogId) "active"}}">
-                <a href="#" {{action "filterType" opt dd}}>
-                  {{#if opt.icon}}
-                    <i class="{{opt.icon}}"></i>
-                  {{/if}}
-                  {{#if opt.localizedLabel}}
-                    {{t opt.localizedLabel}}
-                  {{else}}
-                    <div class="text-capitalize">{{opt.label}}</div>
-                  {{/if}}
-                </a>
-              </li>
-            {{/each}}
-          {{/dd.content}}
-        {{/basic-dropdown}}
-      </div>
-
       <div class="dropdown filter-group pull-right ml-20">
         {{#basic-dropdown
            horizontalPosition="right"
@@ -91,14 +46,14 @@
              class="text-right"
           }}
             <li class="text-capitalize {{if (eq category "") "active"}}">
-              <a href="#" {{action "filterCatalog" "" catalogId dd}}>
-                {{t "catalogPage.index.allCategories"}}
+              <a href="#" {{action "filterCatalog" "" dd}}>
+                {{t "catalogPage.index.allCategories"}} ({{matchingSearch.length}})
               </a>
             </li>
-            {{#each categoryWithCounts as |opt|}}
+            {{#each categories as |opt|}}
               <li class="{{if (eq category opt.category) "active"}}">
-                <a href="#" {{action "filterCatalog" opt.category catalogId dd}}>
-                  <div class="text-capitalize">{{opt.name}}</div>
+                <a href="#" {{action "filterCatalog" opt.category dd}}>
+                  <div class="text-capitalize">{{opt.name}} ({{opt.count}})</div>
                 </a>
               </li>
             {{/each}}
@@ -131,18 +86,31 @@
   </section>
 {{/if}}
 
-{{#each arrangedContent as |catalogItem|}}
-  {{catalog-box
-    model=catalogItem
-    showSource=showCatalogDropdown
-    launchAction=(action launch)
-  }}
+{{#each groupedContent as |group|}}
+  <div class="catalog-group">
+    <div class="clearfix">
+      <button class="btn btn-sm bg-transparent mt-10 pull-right" {{action "toggleCollapse" group}}>
+        {{t (if group.collapsed 'generic.expand' 'generic.collapse')}}
+      </button>
+      <p>{{group.name}}</p>
+    </div>
+    {{#if (not group.collapsed) }}
+      <div class="clearfix">
+        {{#each group.items as |catalogItem|}}
+          {{catalog-box
+            model=catalogItem
+            launchAction=(action launch)
+          }}
+        {{else}}
+          <div class="text-muted mt-20">
+            {{t "catalogPage.index.noData.singular"}}
+          </div>
+        {{/each}}
+      </div>
+    {{/if}}
+  </div>
 {{else}}
   <div class="text-muted mt-20">
-    {{#if showCatalogDropdown}}
-      {{t "catalogPage.index.noData.plural"}}
-    {{else}}
-      {{t "catalogPage.index.noData.singular"}}
-    {{/if}}
+    {{t "catalogPage.index.noData.plural"}}
   </div>
 {{/each}}

--- a/lib/shared/addon/components/searchable-select/component.js
+++ b/lib/shared/addon/components/searchable-select/component.js
@@ -74,7 +74,12 @@ export default Component.extend({
   },
 
   didInsertElement() {
-    this.$('.input-search').on('click', () => {
+    const search = this.$('.input-search');
+
+    // Stop chrome from showing autocomplete over our options
+    search.attr('autocomplete', Math.random());
+
+    search.on('click', () => {
       this.send('show');
     });
   },

--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -176,7 +176,7 @@ var C = {
     BODY_BACKGROUND:        'body-background',
     CLUSTER_DEFAULT:        'default-cluster-id',
     CONTAINER_VIEW:         'container-view',
-    EXPANDED_STACKS:        'expanded-stacks',
+    COLLAPSED_CATALOGS:     'collapsed-catalogs',
     FEEDBACK:               'feedback',
     HOST_VIEW:              'host-view',
     I_HATE_SPINNERS:        'ihatespinners',

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -18,6 +18,7 @@ generic:
   cancel: Cancel
   closeModal: Close
   cluster: Cluster
+  collapse: Collapse
   collapseAll: Collapse All
   comingSoon: Coming Soon
   command: Command
@@ -43,6 +44,7 @@ generic:
   enabled: Enabled
   entrypoint: Entrypoint
   environment: Environment
+  expand: Expand
   expandAll: Expand All
   experimental: "(experimental)"
   from: from


### PR DESCRIPTION
Proposed changes
======

- Group catalog templates in the launch screen by catalog
- Drops the catalog picker (because you see groups now) and the query params for it
- Fixes category filtering so that it works again
- Removes all the query param -> router refreshModel -> fetchTemplates -> filters everywhere -> needsRefresh -> ... maze
- Buy now and also get browser autocomplete disabled on {{searchable-select}}s

Types of changes
======

Multitudious

Linked Issues
======

rancher/rancher#21895
rancher/rancher#20602

Further comments
======

A while ago the catalog-index component was changed to use the live templates array.
This broke a few things, but all the caching and refreshModel and filtering around it doesn't really make sense anymore.

- `fetchTemplates()` now just loads all the templates into the global store.
- catalog-index watches `_allTemplates`
- Separate computed properties filter down to the right project, category, and search results
- Query params are still updated, but not refreshModel