### PR TITLE
Fix auto-reconnect ws issue

### DIFF
--- a/lib/shared/addon/mixins/subscribe.js
+++ b/lib/shared/addon/mixins/subscribe.js
@@ -1,6 +1,6 @@
 import { schedule, cancel, later } from '@ember/runloop';
 import Mixin from '@ember/object/mixin';
-import { get, set, observer, setProperties } from '@ember/object';
+import { get, set, setProperties } from '@ember/object';
 import Ember from 'ember';
 import Socket from 'ui/utils/socket';
 import C from 'ui/utils/constants';
@@ -229,16 +229,6 @@ export default Mixin.create({
       });
     });
   },
-
-  watchedStateChanged: observer('watchStateOf.relevantState', function() {
-    const state = get(this, 'watchState.relevantState');
-
-    if ( state === 'active' ) {
-      this.connect();
-    } else {
-      this.disconnect();
-    }
-  }),
 
   forStr() {
     let out       = '';


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Due to a typo in `const state = get(this, 'watchState.relevantState');`, the state will be always `undefined`.

So it means every time the state of the cluster changed, the cluster websocket will be closed. And it will never get re-connected.

The lines removed in this PR is only used for cluster websocket. It doesn't work since day one. There is another logic to deal with the case which cluster state changed from inactive to active state. As the function is never used before, so we can just remove them directly.

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/20988
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
