### PR TITLE
Delete keys option on change password

### DIFF
--- a/app/components/input-edit-password/component.js
+++ b/app/components/input-edit-password/component.js
@@ -76,6 +76,7 @@ export default Component.extend({
         if ( get(this, 'deleteTokens') ) {
           return get(this, 'globalStore').findAll('token').then((tokens) => {
             const promises = [];
+
             tokens.forEach((token) => {
               if ( !token.current ) {
                 promises.push(token.delete());

--- a/app/components/input-edit-password/template.hbs
+++ b/app/components/input-edit-password/template.hbs
@@ -7,6 +7,10 @@
     style="display: none;"
   />
   <div class="content">
+    {{#if showDeleteTokens}}
+      <label>{{input type="checkbox" checked=deleteTokens}} {{t 'modalEditPassword.deleteTokens'}}</label>
+    {{/if}}
+
     {{#if showCurrent}}
       <div class="row mb-20">
         <div class="col span-12">

--- a/app/components/modal-edit-password/template.hbs
+++ b/app/components/modal-edit-password/template.hbs
@@ -7,6 +7,7 @@
 {{input-edit-password
     complete=(action "complete")
     showCurrent=true
+    showDeleteTokens=true
     cancel=(action "cancel")
     editButton='modalEditPassword.actionButton'
     user=user

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -165,6 +165,7 @@
                   @value={{config.kubernetesVersion}}
                   @versions={{versionChoices}}
                   @clusterTemplateQuestions={{clusterTemplateQuestions}}
+                  @showNotAllowed=true
                 />
               </CheckOverrideAllowed>
             </div>

--- a/lib/shared/addon/components/form-versions/component.js
+++ b/lib/shared/addon/components/form-versions/component.js
@@ -23,6 +23,7 @@ export default Component.extend({
   disabled:               false,
   value:                  null,
   mode:                   'new',
+  showNotAllowed:         false,
   editing:                equal('mode', 'edit'),
   isView:                 equal('mode', 'view'),
 
@@ -135,11 +136,13 @@ export default Component.extend({
           };
         }
       } else {
+        const suffix = ( this.showNotAllowed ? 'formVersions.notallowed' : 'formVersions.unsupported' );
+
         if (gt(version, coerceVersion(maxVersion))) {
           if (overrideMatch && !isEmpty(overrideMatch.satisfies)) {
             out = {
               disabled: true,
-              label:    `${ label } ${ this.intl.t('formVersions.unsupported') }`,
+              label:    `${ label } ${ this.intl.t(suffix) }`,
               value:    v
             };
           } else {
@@ -152,7 +155,7 @@ export default Component.extend({
         } else if (lt(version, coerceVersion(maxVersion))) {
           out = {
             disabled: true,
-            label:    `${ label } ${ this.intl.t('formVersions.unsupported') }`,
+            label:    `${ label } ${ this.intl.t(suffix) }`,
             value:    v
           };
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "private": true,
   "repository": "https://github.com/rancher/ui",
   "license": "Apache-2.0",

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -6154,6 +6154,7 @@ modalEditPassword:
   mode:
     generate: 'Use a new randomly generated password:'
     manual: 'Set a specific password to use:'
+  deleteTokens: Delete all existing API keys
 
 modalFeedback:
   header: Welcome to {appName}!

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -5579,7 +5579,8 @@ formVersions:
   experimental: "(experimental)"
   dotx: "Latest {minor} (allows patch version upgrades)"
   downgrade: "(can't downgrade)"
-  unsupported: "(not allowed by template)"
+  notallowed: "(not allowed by template)"
+  unsupported: "(unsupported)"
 
 formIstioHost:
   prompt: Select a host...


### PR DESCRIPTION
Proposed changes
======

Adds a checkbox option to delete all existing API keys (that the user can see) when changing your password.

Types of changes
======
- New feature (non-breaking change which adds functionality)