### PR TITLE
Fix unable to edit workload scheduling rule in UI

### DIFF
--- a/app/components/container/new-edit/component.js
+++ b/app/components/container/new-edit/component.js
@@ -75,8 +75,7 @@ export default Component.extend(NewOrEdit, ChildHook, {
 
     const service = get(this, 'service');
 
-    if (!get(this, 'isSidekick') &&
-      service && !get(service, 'scheduling')) {
+    if (!get(this, 'isSidekick') && !get(service, 'scheduling.node')) {
       set(service, 'scheduling', { node: {} });
     }
 


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

It should check `scheduling.node` to init scheduling.

Types of changes
======

- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

https://github.com/rancher/rancher/issues/22351

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
