### PR TITLE
[2.3.0] Fix typo and rancher-images issue

### DIFF
--- a/lib/nodes/addon/custom-drivers/cluster-drivers/controller.js
+++ b/lib/nodes/addon/custom-drivers/cluster-drivers/controller.js
@@ -58,7 +58,7 @@ export default Controller.extend({
         url:    '/v3/kontainerdrivers/rancher-images',
         method: 'GET',
       }).then((res) => {
-        downloadFile(`.rancher-images.yml`, get(res, 'body'));
+        downloadFile(`.rancher-images.txt`, get(res, 'body'));
       }).catch((error) => {
         get(this, 'growl').fromError('Error downloading image list', error.message);
       });

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -8180,4 +8180,4 @@ windowsCluster:
       brokerTypeHelpText: Use the Broker list as the Kafka connection entry point.
     helpText: We will use fluentd to collect stdout/stderr logs from each container and the log files which exist under path <code >/var/log/containers/</code> on each <b>Linux</b> host and <code >c:/var/log/containers/</code> on each <b>Windows</b> host. The logs can be shipped to a target you configure below.
   istio: Istio is not supported in Windows clusters.
-  pipelines: Pipelines is not supported in Windows clusters.
+  pipelines: Pipelines are not supported in Windows clusters.


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->
1. Fix typo on Pipelines warning in windows cluster.
2. Fix wrong file type for rancher-images download.

Types of changes
======

- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

https://github.com/rancher/rancher/issues/20951
https://github.com/rancher/rancher/issues/22422

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
