### PR TITLE
Match provisioning banner to cluster state color

### DIFF
--- a/app/authenticated/cluster/template.hbs
+++ b/app/authenticated/cluster/template.hbs
@@ -1,5 +1,5 @@
 {{#unless model.isActive}}
-  {{#banner-message color='bg-error m-0'}}
+  {{#banner-message color=(concat model.stateBackground '  m-0')}}
     <p>{{t (if model.isReady 'clusterDashboard.notActive' 'clusterDashboard.notReady') state=model.displayState htmlSafe=true}}</p>
     {{#if model.showTransitioningMessage}}
       <p class="{{model.stateColor}}">{{uc-first model.transitioningMessage}}</p>


### PR DESCRIPTION
Proposed changes
======

Match the "This custer is currently <State>; areas that interact..." message banner color to the state of the cluster so that it's not always red.

Types of changes
======
- New feature (non-breaking change which adds functionality)