### PR TITLE
Edit clusters using node templates you can't see (rancher/rancher#22080)

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -91,9 +91,9 @@ export default Resource.extend(Grafana, ResourceUsage, {
     return get(this, 'configName') === 'rancherKubernetesEngineConfig';
   }),
 
-  provider: computed('configName', 'nodePools.@each.nodeTemplateId', 'driver', function() {
+  provider: computed('configName', 'nodePools.@each.{driver,nodeTemplateId}', 'driver', function() {
     const pools = get(this, 'nodePools') || [];
-    const firstTemplate = get(pools, 'firstObject.nodeTemplate');
+    const firstPool = pools.objectAt(0);
 
     switch ( get(this, 'configName') ) {
     case 'amazonElasticContainerServiceConfig':
@@ -109,15 +109,12 @@ export default Resource.extend(Grafana, ResourceUsage, {
     case 'huaweiEngineConfig':
       return 'huaweicce';
     case 'rancherKubernetesEngineConfig':
-      if ( pools.length > 0 ) {
-        if ( firstTemplate ) {
-          return get(firstTemplate, 'driver');
-        } else {
-          return null;
-        }
-      } else {
+      if ( !pools.length ) {
         return 'custom';
       }
+
+
+      return firstPool.driver || get(firstPool, 'nodeTemplate.driver') || null;
     default:
       if (get(this, 'driver') && get(this, 'configName')) {
         return get(this, 'driver');

--- a/app/models/nodepool.js
+++ b/app/models/nodepool.js
@@ -1,15 +1,26 @@
 import Resource from '@rancher/ember-api-store/models/resource';
 import { reference } from '@rancher/ember-api-store/utils/denormalize';
 import { cancel, later } from '@ember/runloop'
-import { get, set } from '@ember/object';
-import { alias } from '@ember/object/computed';
+import { get, set, computed } from '@ember/object';
+import { ucFirst } from 'shared/utils/util';
 
 const NodePool = Resource.extend({
   type:          'nodePool',
   quantityTimer: null,
+
   nodeTemplate:  reference('nodeTemplateId'),
 
-  displayProvider: alias('nodeTemplate.displayProvider'),
+  displayProvider: computed('driver', 'nodeTemplate.driver', 'intl.locale', function() {
+    const intl = get(this, 'intl');
+    const driver = get(this, 'driver');
+    const key = `nodeDriver.displayName.${ driver }`;
+
+    if ( intl.exists(key) ) {
+      return intl.t(key);
+    } else {
+      return ucFirst(driver);
+    }
+  }),
 
   incrementQuantity(by) {
     let quantity = get(this, 'quantity');

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,1 +1,1 @@
-{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","tmp","vendor",".git","dist"]}
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}

--- a/lib/global-admin/addon/accounts/index/template.hbs
+++ b/lib/global-admin/addon/accounts/index/template.hbs
@@ -6,14 +6,6 @@
   </div>
 
   <div class="right-buttons">
-    {{#link-to
-       "accounts.new"
-       classNames="btn btn-sm bg-primary right-divider-btn"
-       disabled=(rbac-prevents resource="user" scope="global" permission="create")
-    }}
-      {{t "accountsPage.index.localLink"}}
-    {{/link-to}}
-
     {{#if hasRefreshProviderAccess}}
       {{#if refreshing}}
         <button
@@ -33,6 +25,14 @@
         </button>
       {{/if}}
     {{/if}}
+
+    {{#link-to
+       "accounts.new"
+       classNames="btn btn-sm bg-primary right-divider-btn"
+       disabled=(rbac-prevents resource="user" scope="global" permission="create")
+    }}
+      {{t "accountsPage.index.localLink"}}
+    {{/link-to}}
   </div>
 </section>
 

--- a/lib/shared/addon/components/cru-node-pools/component.js
+++ b/lib/shared/addon/components/cru-node-pools/component.js
@@ -230,9 +230,21 @@ export default Component.extend({
     return false;
   }),
 
-  filteredNodeTemplates: computed('driver', 'nodeTemplates.@each.{state,driver}', function() {
+  filteredNodeTemplates: computed('driver', 'nodeTemplates.@each.{state,driver}', 'nodePools.@each.nodeTemplateId', function() {
     const driver = get(this, 'driver');
     let templates = get(this, 'nodeTemplates').filterBy('state', 'active').filterBy('driver', driver);
+
+    (get(this, 'nodePools') || []).forEach((pool) => {
+      const templateId = get(pool, 'nodeTemplateId');
+
+      if ( !templates.findBy('id', templateId) ) {
+        templates.push(get(this, 'globalStore').createRecord({
+          type: 'nodetemplate',
+          id:   templateId,
+          name: `(${  templateId  })`,
+        }));
+      }
+    });
 
     return templates;
   }),


### PR DESCRIPTION
Proposed changes
======

Adds the ability to edit clusters that have nodepools which use nodetemplates that the current user can't see (because they are not sharable yet).

Previously in 2.2 the pools were preserved by the UI but not displayed so you couldn't manage them.  And in 2.3/master the rest of the cluster options wree missing due to now knowing what driver to use.

The template will show up in the dropdown as its ID (user-xxxxx:nt-yyyyy) since that's the only info we have.

Requires pending backend change to add `driver` field to `nodePool` resources (backed by nodePool.nodeTemplateId -> nodeTemplate -> nodeTemplate.driver)

Types of changes
======
- New feature (non-breaking change which adds functionality)

Linked Issues
======

rancher/rancher#22080