### PR TITLE
Default to m5.large for EKS

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
@@ -51,7 +51,7 @@ export default Component.extend(ClusterDriver, {
         accessKey:         null,
         secretKey:         null,
         region:            'us-west-2',
-        instanceType:      'm4.large',
+        instanceType:      'm5.large',
         desiredNodes:      1,
         minimumNodes:      1,
         maximumNodes:      1,


### PR DESCRIPTION
Bring EC2 type current