### PR TITLE
Don't overwrite cluster config with answers on edit (rancher/rancher#22085)

### DIFF
--- a/app/authenticated/cluster/edit/route.js
+++ b/app/authenticated/cluster/edit/route.js
@@ -57,7 +57,8 @@ export default Route.extend({
         if (ctr) {
           set(model, 'clusterTemplateRevision', ctr);
 
-          this.clusterTemplateService.cloneAndPopulateClusterConfig(cluster, ctr);
+          // This is breaking fields that already have values that don't match the template, like kubernetesVersion with 1.14.x
+          // this.clusterTemplateService.cloneAndPopulateClusterConfig(cluster, ctr);
         } else {
           // user does not have access to the template that was used to launch a cluster
           // create a fake cluster that we'll use to turn into a "temaplate Revision" to be passed down to components

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -1449,7 +1449,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       clusterTemplateQuestions.forEach((question) => {
         let path = question.variable;
 
-        if (!question.variable.includes('uiOverride') && question.default) {
+        if (!this.isEdit && !question.variable.includes('uiOverride') && question.default) {
           deepSet(primaryResource, path, question.default);
         }
 


### PR DESCRIPTION
Proposed changes
======

Disables 2 places that were copying the values from question answers on top of the cluster config, which was overwriting the current rkeConfig.kubernetesVersion=(actual version deployed) with the 1.14.x requested value (that the backend later turns into a concrete version).

Types of changes
======
- Bugfix

Linked Issues
======
rancher/rancher#22085