### PR TITLE
Add more context to the namespace deletion modal

### DIFF
--- a/lib/shared/addon/components/confirm-delete/component.js
+++ b/lib/shared/addon/components/confirm-delete/component.js
@@ -101,4 +101,25 @@ export default Component.extend(ModalBase, {
     return get(namespaces, 'length') > 0;
   }),
 
+  resourceType: computed('hasSystemProjectNamespace', function() {
+    if (get(this, 'hasSystemProjectNamespace')) {
+      return 'namespace';
+    }
+
+    return '';
+  }),
+
+  resourceTypeStringId: computed('resourceType', function() {
+    const resourceType = get(this, 'resourceType');
+
+    return resourceType
+      ? `confirmDelete.resourceType.${ resourceType }`
+      : null;
+  }),
+
+  titleStringId: computed('resourceType', function() {
+    return get(this, 'resourceType') !== null
+      ? 'confirmDelete.titleWithResourceType'
+      : 'confirmDelete.titleWithoutResourceType';
+  })
 });

--- a/lib/shared/addon/components/confirm-delete/template.hbs
+++ b/lib/shared/addon/components/confirm-delete/template.hbs
@@ -1,6 +1,10 @@
 <div class="container-header-text">
   <h3>
-    {{t "confirmDelete.title"}}:
+    {{t 
+      titleStringId 
+      resourceType=(t resourceTypeStringId)
+      htmlSafe=true
+    }}
   </h3>
   <hr/>
   {{#if isSystemProject}}

--- a/translations/de-de.yaml
+++ b/translations/de-de.yaml
@@ -2124,7 +2124,7 @@ resourceEventList:
   noData: Keine Ereignisse
   noMatch: Keine Ereignisse gefunden, die den Suchkriterien entsprechen
 confirmDelete:
-  title: 'Sind SIe sicher, dass Sie Löschen wollen?'
+  titleWithoutResourceType: 'Sind SIe sicher, dass Sie Löschen wollen?'
   environmentNote: 'Hinweis: Alle Ressourcen in diesem Projekt werden dauerhaft entfernt, einschließlich der durch {appName} erstellten Namespaces.'
   clusterNote: 'Hinweis: Zugehörige Ressourcen wie Volumes, Balancer und Netzwerke, die im Cloud-Anbieter erstellt wurden, werden nicht automatisch entfernt.'
   clusterRoleTemplateBindingNote: "Hinweis: Die Projektberechtigungen des Benutzers werden nicht entfernt."

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3555,7 +3555,10 @@ resourceEventList:
   noMatch: No events match the current search
 
 confirmDelete:
-  title: 'Are you sure you want to delete'
+  titleWithoutResourceType: 'Are you sure you want to delete:'
+  titleWithResourceType: 'Are you sure you want to delete the <b>{resourceType}</b>:'
+  resourceType:
+    namespace: 'namespace'
   environmentNote: 'Note: All resources inside this Project will be permanently removed, including any namespaces that were created through {appName}.'
   clusterNote: 'Note: Associated resources such as volumes, balancers, and networks that were created in the cloud provider will not be automatically removed.'
   clusterRoleTemplateBindingNote: "Note: User's project permissions will not be removed."

--- a/translations/es-es.yaml
+++ b/translations/es-es.yaml
@@ -2087,7 +2087,7 @@ resourceEventList:
   noData: No hay eventos
   noMatch: No hay eventos de coincidencia con la búsqueda actual
 confirmDelete:
-  title: '¿Está seguro que desea eliminar'
+  titleWithoutResourceType: '¿Está seguro que desea eliminar'
   environmentNote: 'Nota: Todos los recursos dentro de este Proyecto se eliminará de forma permanente, incluyendo cualquier espacio de nombres que fueron creados a través de {appName}.'
   clusterNote: 'Nota: Los recursos asociados como volúmenes, equilibradores y redes que se crearon en el proveedor de la nube no se eliminarán automáticamente.'
   clusterRoleTemplateBindingNote: "Nota: los permisos de proyecto no será eliminado."

--- a/translations/fr-fr.yaml
+++ b/translations/fr-fr.yaml
@@ -1480,7 +1480,7 @@ clusterNew:
       label: Projet
       placeholder: p.ex. mon-projet
 confirmDelete:
-  title: 'Êtes-vous sûr de vouloir le supprimer'
+  titleWithoutResourceType: 'Êtes-vous sûr de vouloir le supprimer'
   protip: 'Astuce Pro : Maintenez la touche {key} tout en cliquant sur Supprimer afin de contourner cette confirmation.'
   confirmAction: Supprimer
   cancelAction: Annuler

--- a/translations/hu-hu.yaml
+++ b/translations/hu-hu.yaml
@@ -657,7 +657,7 @@ catalogSettings:
       label: Branch
       placeholder: 'pl. master'
 confirmDelete:
-  title: 'Biztosan törölni szeretné?'
+  titleWithoutResourceType: 'Biztosan törölni szeretné?'
   protip: 'Profi tipp: Tartsd nyomva a {key} billenytűt, miközben a Törlés-re kattintasz, hogy kikerüld a megerősítést.'
   confirmAction: Törlés
   cancelAction: Mégsem

--- a/translations/ja-jp.yaml
+++ b/translations/ja-jp.yaml
@@ -2012,7 +2012,7 @@ resourceEventList:
   noData: イベントはありません
   noMatch: 検索条件に一致するイベントはありません
 confirmDelete:
-  title: '本当に削除してもよろしいですか?'
+  titleWithoutResourceType: '本当に削除してもよろしいですか?'
   environmentNote: 'ノート: このプロジェクト内にある {appName} により作られた名前空間を含むの全てのリソースは完全に削除されます'
   clusterNote: '注意: クラウドプロバイダーにより作成されたボリューム、ロードバランサー、ネットワークなどの関連リソースは自動的には削除されません。'
   protip: 'ProTip: この確認画面を飛ばす場合は削除ボタンのクリック時に {key} キーを長押ししてください。'

--- a/translations/ko-kr.yaml
+++ b/translations/ko-kr.yaml
@@ -884,7 +884,7 @@ clusterNew:
     ignoreDockerVersion:
       label: 노드의 도커 버전
 confirmDelete:
-  title: '삭제하시겠습니까?'
+  titleWithoutResourceType: '삭제하시겠습니까?'
   confirmAction: 제거
   cancelAction: 취소
 containerLogs:

--- a/translations/nb-no.yaml
+++ b/translations/nb-no.yaml
@@ -519,7 +519,7 @@ clusterNew:
       user:
         label: Brukernavn
 confirmDelete:
-  title: 'Er du sikker på at du ønsker å slette'
+  titleWithoutResourceType: 'Er du sikker på at du ønsker å slette'
   confirmAction: Slett
   cancelAction: Avbryt
 containerLogs:

--- a/translations/pt-br.yaml
+++ b/translations/pt-br.yaml
@@ -1975,7 +1975,7 @@ clusterNew:
       password:
         label: Senha
 confirmDelete:
-  title: 'Tem certeza de que deseja excluir'
+  titleWithoutResourceType: 'Tem certeza de que deseja excluir'
   protip: 'Dica: Mantenha a chave {key} enquanto clicar Delete para ignorar essa confirmação.'
   confirmAction: Excluir
   cancelAction: Cancelar

--- a/translations/ru-ru.yaml
+++ b/translations/ru-ru.yaml
@@ -1625,7 +1625,7 @@ conditionSections:
   noData: Нет условий
   noMatch: Никакие условия не соответствуют текущему поиску
 confirmDelete:
-  title: 'Вы действительно хотите удалить'
+  titleWithoutResourceType: 'Вы действительно хотите удалить'
   protip: 'Совет: удерживайте клавишу {key} во время нажатия "Удалить", чтобы обойти это подтверждение.'
   confirmAction: Удалить
   cancelAction: Отмена

--- a/translations/tr-tr.yaml
+++ b/translations/tr-tr.yaml
@@ -1863,7 +1863,7 @@ resourceEventList:
   noData: Olay yok
   noMatch: Mevcut aramayla eşleşen olay yok
 confirmDelete:
-  title: 'Silmek istediğinizden emin misiniz'
+  titleWithoutResourceType: 'Silmek istediğinizden emin misiniz'
   environmentNote: 'Not: Bu Proje içindeki tüm kaynaklar, {appName} ile oluşturulan ad alanları da dahil olmak üzere kalıcı olarak silinecektir.'
   clusterNote: 'Not: Bulut sağlayıcısında oluşturulan birimler, balancer''lar ve ağlar gibi ilişkili kaynaklar otomatik olarak kaldırılmaz.'
   clusterRoleTemplateBindingNote: "Not: Kullanıcının proje izinleri kaldırılmayacak."

--- a/translations/uk-ua.yaml
+++ b/translations/uk-ua.yaml
@@ -1874,7 +1874,7 @@ resourceEventList:
     message: Повідомлення
   noData: Немає подій
 confirmDelete:
-  title: 'Ви впевнені, що бажаєте видалити'
+  titleWithoutResourceType: 'Ви впевнені, що бажаєте видалити'
   protip: 'Порада: Утримуйте клавішу {key} при натисканні Delete, щоб обійти це підтвердження.'
   confirmAction: Видалити
   cancelAction: Скасувати

--- a/translations/zh-hans.yaml
+++ b/translations/zh-hans.yaml
@@ -3552,7 +3552,7 @@ resourceEventList:
   noMatch: 没有事件与当前搜索匹配
 
 confirmDelete:
-  title: '是否确认要删除'
+  titleWithoutResourceType: '是否确认要删除'
   environmentNote: '注意: 此环境内的所有资源都将被永久性的删除，包括通过{appName}创建的主机。'
   clusterNote: '注意: 在云平台中创建的关联资源(如卷，负载均衡器和网络)不会自动删除。'
   clusterRoleTemplateBindingNote: "注意: 此用户的权限直接添加到项目中将不会被删除."

--- a/translations/zh-hant.yaml
+++ b/translations/zh-hant.yaml
@@ -2284,7 +2284,7 @@ resourceEventList:
   noMatch: 沒有事件與當前搜索匹配
 
 confirmDelete:
-  title: '是否確認要刪除'
+  titleWithoutResourceType: '是否確認要刪除'
   environmentNote: '注意: 此環境內的所有資源都將被永久性的刪除，包括通過{appName}創建的主機。'
   clusterNote: '注意: 在雲平台中創建的關聯資源(如卷，負載均衡器和網絡)不會自動刪除。'
   clusterRoleTemplateBindingNote: "注意: 此用戶的權限直接添加到項目中將不會被刪除."


### PR DESCRIPTION
Adds the resource type "namespace" as additional context to the
title of the namespace deletion modal in order to reduce the
likelyhood of a user accidentally deleting an unintented resource.

We changed the title from "Are you sure you want to delete" to
"Are you sure you want to delete the namespace:" with namespace
being bold.

Resolves #17619

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
