### PR TITLE
Improve the mobile sub-navigation UX

### DIFF
--- a/app/components/page-header/component.js
+++ b/app/components/page-header/component.js
@@ -25,6 +25,7 @@ export default Component.extend({
   settings:         service(),
   access:           service(),
   prefs:            service(),
+  router:           service(),
 
   layout,
   // Inputs
@@ -92,12 +93,12 @@ export default Component.extend({
     });
   },
 
-  willRender() {
-    if ($('BODY').hasClass('touch') && $('header > nav').hasClass('nav-open')) {// eslint-disable-line
-      run.later(() => {
+  didInsertElement() {
+    run.scheduleOnce('afterRender', this, function() {
+      this.get('router').on('willTransition', () => {
         $('header > nav').removeClass('nav-open');// eslint-disable-line
       });
-    }
+    });
   },
 
   shouldUpdateNavTree: observer(

--- a/app/styles/components/_page-header.scss
+++ b/app/styles/components/_page-header.scss
@@ -25,6 +25,10 @@ $project-nav-active: $dropdown-link-hover-bg !default;
     align-items: center;
 
     .ember-basic-dropdown-content {
+      body.touch & {
+        position: static;
+      }
+
       font-size:  15px;
     }
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->
In the navigation menu when a user attempted to open a sub-menu the
entire navigation menu instantly closed. To resolve this we now listen
to the router willTransition event to close the navigation rather than
a willRender invocation.

The sub-menu was also overlapping other menu items because it had an
absolute position. To resolve this we now give the sub-menu a static
position.

Old menu:
![old-menu](https://user-images.githubusercontent.com/55104481/64973812-8ddc5d00-d860-11e9-9cd8-8802943d3457.gif)

New menu:
![new-menu](https://user-images.githubusercontent.com/55104481/64973824-92087a80-d860-11e9-9fdc-6987c03f1141.gif)

Unaffected desktop menu:
![desktop-nav-unaffected](https://user-images.githubusercontent.com/55104481/64973831-959c0180-d860-11e9-9c75-3ecdf1058e7e.gif)

Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?

-->
Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 
rancher/rancher#21914

