### PR TITLE
[WIP] Display security options when editing GKE cluster

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
@@ -78,6 +78,106 @@ const DEFAULT_AUTH_SCOPES = ['devstorage.read_only', 'logging.write', 'monitorin
 const ZONE_TYPE = 'zonal';
 const REGION_TYPE = 'regional';
 
+const OAUTH_SCOPE_OPTIONS = {
+  DEFAULT: 'default',
+  FULL:    'full',
+  CUSTOM:  'custom'
+};
+
+const GOOGLE_AUTH_URL_PREFIX = 'https://www.googleapis.com/auth/';
+const GOOGLE_AUTH_DEFAULT_URLS = DEFAULT_AUTH_SCOPES.map((a) => `${ GOOGLE_AUTH_URL_PREFIX }${ a }`);
+const GOOGLE_FULL_AUTH_URL = 'https://www.googleapis.com/auth/cloud-platform';
+
+function getValueFromOauthScopes(oauthScopes, key, defaultValue) {
+  const filteredValues = oauthScopes
+    .filter((scope) => scope.indexOf(key) !== -1)
+    .map((scope) => {
+      return scope
+        .replace(GOOGLE_AUTH_URL_PREFIX, '')
+        .replace(key, '').split('.')
+    })
+    .filter((splitScopes) => splitScopes.length <= 2);
+
+  if (filteredValues.length !== 1) {
+    return defaultValue || 'none';
+  }
+
+  return filteredValues[0].length === 1
+    ? key
+    : `${ key }.${ filteredValues[0][1] }`;
+}
+
+/**
+ * This oauthScopesMapper is responsible for both the mapping to oauthScopes
+ * and unmapping from oauthscopes to form values. If you modify either
+ * method ensure that the other reflects your changes.
+ */
+const oauthScopesMapper = {
+  mapOauthScopes(oauthScopesSelection, scopeConfig) {
+    if (oauthScopesSelection === OAUTH_SCOPE_OPTIONS.DEFAULT) {
+      return GOOGLE_AUTH_DEFAULT_URLS;
+    } else if (oauthScopesSelection === OAUTH_SCOPE_OPTIONS.FULL) {
+      return [GOOGLE_FULL_AUTH_URL];
+    } else if (oauthScopesSelection === OAUTH_SCOPE_OPTIONS.CUSTOM) {
+      scopeConfig = scopeConfig || {};
+      let arr = [];
+
+      Object.keys(scopeConfig).map((key) => {
+        if (scopeConfig[key] !== 'none') {
+          arr.pushObject(`https://www.googleapis.com/auth/${ scopeConfig[key] }`)
+        }
+      })
+
+      return arr;
+    }
+  },
+  unmapOauthScopes(oauthScopes) {
+    const containsUrls = !oauthScopes || oauthScopes.length > 0;
+
+    if (!containsUrls) {
+      return { oauthScopesSelection: OAUTH_SCOPE_OPTIONS.DEFAULT };
+    }
+
+    const isAllAndOnlyDefaultUrls = ( GOOGLE_AUTH_DEFAULT_URLS.length === oauthScopes.length
+      && GOOGLE_AUTH_DEFAULT_URLS.every((url) => oauthScopes.indexOf(url) !== -1) );
+
+    if (isAllAndOnlyDefaultUrls) {
+      return { oauthScopesSelection: OAUTH_SCOPE_OPTIONS.DEFAULT }
+    }
+
+    const isOnlyTheFullUrl = oauthScopes.length === 1
+      && oauthScopes[0] === GOOGLE_FULL_AUTH_URL;
+
+    if (isOnlyTheFullUrl) {
+      return { oauthScopesSelection: OAUTH_SCOPE_OPTIONS.FULL }
+    }
+
+    return {
+      oauthScopesSelection: OAUTH_SCOPE_OPTIONS.CUSTOM,
+      scopeConfig:          {
+        userInfo:                 getValueFromOauthScopes(oauthScopes, 'userinfo', 'none'),
+        computeEngine:            getValueFromOauthScopes(oauthScopes, 'compute', 'none'),
+        storage:                  getValueFromOauthScopes(oauthScopes, 'devstorage', 'devstorage.read_only'),
+        taskQueue:                getValueFromOauthScopes(oauthScopes, 'taskqueue', 'none'),
+        bigQuery:                 getValueFromOauthScopes(oauthScopes, 'bigquery', 'none'),
+        cloudSQL:                 getValueFromOauthScopes(oauthScopes, 'sqlservice', 'none'),
+        cloudDatastore:           getValueFromOauthScopes(oauthScopes, 'clouddatastore', 'none'),
+        stackdriverLoggingAPI:    getValueFromOauthScopes(oauthScopes, 'logging', 'logging.write'),
+        stackdriverMonitoringAPI: getValueFromOauthScopes(oauthScopes, 'monitoring', 'monitoring'),
+        cloudPlatform:            getValueFromOauthScopes(oauthScopes, 'cloud-platform', 'none'),
+        bigtableData:             getValueFromOauthScopes(oauthScopes, 'bigtable.data', 'none'),
+        bigtableAdmin:            getValueFromOauthScopes(oauthScopes, 'bigtable.admin', 'none'),
+        cloudPub:                 getValueFromOauthScopes(oauthScopes, 'pubsub', 'none'),
+        serviceControl:           getValueFromOauthScopes(oauthScopes, 'servicecontrol', 'none'),
+        serviceManagement:        getValueFromOauthScopes(oauthScopes, 'service.management', 'service.management.readonly'),
+        stackdriverTrace:         getValueFromOauthScopes(oauthScopes, 'trace', 'trace.append'),
+        cloudSourceRepositories:  getValueFromOauthScopes(oauthScopes, 'source', 'none'),
+        cloudDebugger:            getValueFromOauthScopes(oauthScopes, 'cloud_debugger', 'none'),
+      }
+    };
+  }
+};
+
 export default Component.extend(ClusterDriver, {
   intl: service(),
 
@@ -127,7 +227,7 @@ export default Component.extend(ClusterDriver, {
 
       setProperties(this, {
         'cluster.googleKubernetesEngineConfig': config,
-        oauthScopesSelection:                   'default',
+        oauthScopesSelection:                   OAUTH_SCOPE_OPTIONS.DEFAULT,
         scopeConfig:                            {
           userInfo:                 'none',
           computeEngine:            'none',
@@ -196,6 +296,16 @@ export default Component.extend(ClusterDriver, {
         set(this, 'taints', _taints)
       } else {
         set(this, 'taints', [])
+      }
+
+      if (!get(this, 'oauthScopesSelection')) {
+        const oauthScopes = get(config, 'oauthScopes')
+        const { oauthScopesSelection, scopeConfig } = oauthScopesMapper.unmapOauthScopes(oauthScopes);
+
+        set(this, 'oauthScopesSelection', oauthScopesSelection);
+        if (scopeConfig) {
+          set(this, 'scopeConfig', scopeConfig);
+        }
       }
     }
 
@@ -731,21 +841,10 @@ export default Component.extend(ClusterDriver, {
       delete config.locations
     }
 
-    if (get(this, 'oauthScopesSelection') === 'default') {
-      set(config, 'oauthScopes', DEFAULT_AUTH_SCOPES.map((a) => `https://www.googleapis.com/auth/${ a }`))
-    } else if (get(this, 'oauthScopesSelection') === 'full') {
-      set(config, 'oauthScopes', ['https://www.googleapis.com/auth/cloud-platform'])
-    } else if (get(this, 'oauthScopesSelection') === 'custom') {
-      const scopeConfig = get(this, 'scopeConfig') || {}
-      let arr = []
+    const oauthScopesSelection = get(this, 'oauthScopesSelection');
+    const scopeConfig = get(this, 'scopeConfig');
 
-      Object.keys(scopeConfig).map((key) => {
-        if (scopeConfig[key] !== 'none') {
-          arr.pushObject(`https://www.googleapis.com/auth/${ scopeConfig[key] }`)
-        }
-      })
-      set(config, 'oauthScopes', arr)
-    }
+    set(config, 'oauthScopes', oauthScopesMapper.mapOauthScopes(oauthScopesSelection, scopeConfig));
 
     const taints = get(this, 'taints') || []
 

--- a/lib/shared/addon/components/cluster-driver/driver-googlegke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-googlegke/template.hbs
@@ -892,72 +892,72 @@
       {{/unless}}
     {{/accordion-list-item}}
 
-    {{#if (eq mode "new")}}
-      {{#accordion-list-item
-         title=(t "clusterNew.security.title")
-         detail=(t "clusterNew.security.detail")
-         showExpand=true
-         expandOnInit=false
-         expandAll=al.expandAll
-         expand=(action expandFn)
-      }}
-        <div class="row">
-          <div class="col span-6">
-            <label class="acc-label">
-              {{t "clusterNew.googlegke.serviceAccount.label"}}
+    {{#accordion-list-item
+        title=(t "clusterNew.security.title")
+        detail=(t "clusterNew.security.detail")
+        showExpand=true
+        expandOnInit=false
+        expandAll=al.expandAll
+        expand=(action expandFn)
+    }}
+      <div class="row">
+        <div class="col span-6">
+          <label class="acc-label">
+            {{t "clusterNew.googlegke.serviceAccount.label"}}
+          </label>
+          {{searchable-select
+            content=serviceAccountContent
+            classNames="form-control"
+            value=config.serviceAccount
+            optionLabelPath="displayName"
+            optionValuePath="uniqueId"
+            readOnly=editing
+          }}
+        </div>
+        <div class="col span-6">
+          <label class="acc-label">
+            {{t "clusterNew.googlegke.oauthScopes.label"}}
+          </label>
+          <div class="radio">
+            <label>
+              {{radio-button
+                selection=oauthScopesSelection
+                value="default"
+                disabled=editing
+              }}
+              {{t "clusterNew.googlegke.oauthScopes.default"}}
             </label>
-            {{searchable-select
-              content=serviceAccountContent
-              classNames="form-control"
-              value=config.serviceAccount
-              optionLabelPath="displayName"
-              optionValuePath="uniqueId"
-            }}
           </div>
-          <div class="col span-6">
-            <label class="acc-label">
-              {{t "clusterNew.googlegke.oauthScopes.label"}}
+          <div class="radio">
+            <label>
+              {{radio-button
+                selection=oauthScopesSelection
+                value="full"
+                disabled=editing
+              }}
+              {{t "clusterNew.googlegke.oauthScopes.full"}}
             </label>
-            <div class="radio">
-              <label>
-                {{radio-button
-                  selection=oauthScopesSelection
-                  value="default"
-                  disabled=editing
-                }}
-                {{t "clusterNew.googlegke.oauthScopes.default"}}
-              </label>
-            </div>
-            <div class="radio">
-              <label>
-                {{radio-button
-                  selection=oauthScopesSelection
-                  value="full"
-                  disabled=editing
-                }}
-                {{t "clusterNew.googlegke.oauthScopes.full"}}
-              </label>
-            </div>
-            <div class="radio">
-              <label>
-                {{radio-button
-                  selection=oauthScopesSelection
-                  value="custom"
-                  disabled=editing
-                }}
-                {{t "clusterNew.googlegke.oauthScopes.custom"}}
-              </label>
-            </div>
+          </div>
+          <div class="radio">
+            <label>
+              {{radio-button
+                selection=oauthScopesSelection
+                value="custom"
+                disabled=editing
+              }}
+              {{t "clusterNew.googlegke.oauthScopes.custom"}}
+            </label>
           </div>
         </div>
+      </div>
 
-        {{#if (eq oauthScopesSelection "custom")}}
-          {{gke-access-scope
-            config=scopeConfig
-          }}
-        {{/if}}
-      {{/accordion-list-item}}
-    {{/if}}
+      {{#if (eq oauthScopesSelection "custom")}}
+        {{gke-access-scope
+          config=scopeConfig
+          readOnly=editing
+        }}
+      {{/if}}
+    {{/accordion-list-item}}
   {{/accordion-list}}
 
   {{top-errors errors=errors}}

--- a/lib/shared/addon/components/gke-access-scope/template.hbs
+++ b/lib/shared/addon/components/gke-access-scope/template.hbs
@@ -6,6 +6,7 @@
         classNames="form-control"
         value=config.userInfo
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
   <div class="col span-6">
@@ -15,6 +16,7 @@
         classNames="form-control"
         value=config.computeEngine
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
 </div>
@@ -27,6 +29,7 @@
         classNames="form-control"
         value=config.storage
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
   <div class="col span-6">
@@ -36,6 +39,7 @@
         classNames="form-control"
         value=config.taskQueue
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
 </div>
@@ -48,6 +52,7 @@
         classNames="form-control"
         value=config.bigQuery
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
   <div class="col span-6">
@@ -57,6 +62,7 @@
         classNames="form-control"
         value=config.cloudSQL
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
 </div>
@@ -69,6 +75,7 @@
         classNames="form-control"
         value=config.cloudDatastore
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
   <div class="col span-6">
@@ -78,6 +85,7 @@
         classNames="form-control"
         value=config.stackdriverLoggingAPI
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
 </div>
@@ -90,6 +98,7 @@
         classNames="form-control"
         value=config.stackdriverMonitoringAPI
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
   <div class="col span-6">
@@ -99,6 +108,7 @@
         classNames="form-control"
         value=config.cloudPlatform
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
 </div>
@@ -111,6 +121,7 @@
         classNames="form-control"
         value=config.bigtableData
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
   <div class="col span-6">
@@ -120,6 +131,7 @@
         classNames="form-control"
         value=config.bigtableAdmin
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
 </div>
@@ -132,6 +144,7 @@
         classNames="form-control"
         value=config.cloudPub
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
   <div class="col span-6">
@@ -141,6 +154,7 @@
         classNames="form-control"
         value=config.serviceControl
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
 </div>
@@ -153,6 +167,7 @@
         classNames="form-control"
         value=config.serviceManagement
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
   <div class="col span-6">
@@ -162,6 +177,7 @@
         classNames="form-control"
         value=config.stackdriverTrace
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
 </div>
@@ -174,6 +190,7 @@
         classNames="form-control"
         value=config.cloudSourceRepositories
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
   <div class="col span-6">
@@ -183,6 +200,7 @@
         classNames="form-control"
         value=config.cloudDebugger
         localizedLabel=true
+        readOnly=readOnly
     }}
   </div>
 </div>


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
We want the user to be able to see the security options that were
selected even if they can't be edited when editing the cluster.

Old edit missing security options:
![Screen Shot 2019-09-16 at 11 06 44 AM](https://user-images.githubusercontent.com/55104481/64999334-4c69a300-d89c-11e9-9507-f0c080559eb3.png)

New edit with security options for default access:
![Screen Shot 2019-09-16 at 2 21 59 PM](https://user-images.githubusercontent.com/55104481/64999367-66a38100-d89c-11e9-939b-bca6e7792bb1.png)

New edit with security options for full access:
![Screen Shot 2019-09-16 at 2 14 55 PM](https://user-images.githubusercontent.com/55104481/64999395-79b65100-d89c-11e9-831f-1dc6be0ddcc8.png)

New edit with security options for custom access:
![Screen Shot 2019-09-16 at 3 42 35 PM](https://user-images.githubusercontent.com/55104481/64999404-833fb900-d89c-11e9-9119-bf55ff1f6cad.png)


Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#19070
