### PR TITLE
Hide unsupported storage providers

### DIFF
--- a/app/authenticated/route.js
+++ b/app/authenticated/route.js
@@ -116,6 +116,7 @@ export default Route.extend(Preload, {
             this.preload('authConfig', 'globalStore', { url: 'authConfigs' }),
             this.preload('globalRoleBinding', 'globalStore', { url: 'globalRoleBinding' }),
             this.preload('user', 'globalStore', { url: 'user' }),
+            this.preload('features', 'globalStore', { url: 'features' }),
 
             globalStore.findAll('principal').then((principals) => {
               const me = principals.filter((p) => p.me === true);

--- a/app/components/cru-persistent-volume/component.js
+++ b/app/components/cru-persistent-volume/component.js
@@ -9,6 +9,7 @@ import { parseSi } from 'shared/utils/parse-unit';
 export default Component.extend(ViewNewEdit, {
   intl:         service(),
   clusterStore: service(),
+  globalStore:  service(),
 
   layout,
   model:      null,
@@ -58,7 +59,8 @@ export default Component.extend(ViewNewEdit, {
 
   sourceChoices: computed('intl.locale', function() {
     const intl = get(this, 'intl');
-    const out = getSources('persistent').map((p) => {
+    const showUnsupported = get(this, 'globalStore').all('feature').filterBy('name', 'unsupported-storage-drivers').get('firstObject.value');
+    const out = getSources('persistent', showUnsupported).map((p) => {
       const entry = Object.assign({}, p);
       const key = `volumeSource.${ entry.name }.title`;
 
@@ -85,7 +87,8 @@ export default Component.extend(ViewNewEdit, {
 
   sourceComponent: computed('sourceName', function() {
     const name = get(this, 'sourceName');
-    const sources = getSources('persistent');
+    const showUnsupported = get(this, 'globalStore').all('feature').filterBy('name', 'unsupported-storage-drivers').get('firstObject.value');
+    const sources = getSources('persistent', showUnsupported);
     const entry = sources.findBy('name', name);
 
     if (entry) {
@@ -95,8 +98,7 @@ export default Component.extend(ViewNewEdit, {
 
   willSave() {
     const vol = get(this, 'primaryResource');
-
-    const entry = getSources('persistent').findBy('name', get(this, 'sourceName'));
+    const entry = getSources('persistent', true).findBy('name', get(this, 'sourceName'));
 
     if ( !entry ) {
       const errors = [];

--- a/app/components/cru-storage-class/component.js
+++ b/app/components/cru-storage-class/component.js
@@ -7,7 +7,8 @@ import { getProvisioners } from 'ui/models/storageclass';
 import ChildHook from 'shared/mixins/child-hook';
 
 export default Component.extend(ViewNewEdit, ChildHook, {
-  intl: service(),
+  intl:        service(),
+  globalStore:  service(),
 
   layout,
   model: null,
@@ -42,7 +43,8 @@ export default Component.extend(ViewNewEdit, ChildHook, {
 
   provisionerChoices: computed('intl.locale', function() {
     const intl = get(this, 'intl');
-    const out = getProvisioners().map((p) => {
+    const showUnsupported = get(this, 'globalStore').all('feature').filterBy('name', 'unsupported-storage-drivers').get('firstObject.value');
+    const out = getProvisioners(showUnsupported).map((p) => {
       const entry = Object.assign({}, p);
       const key = `storageClass.${ entry.name }.title`;
 

--- a/app/components/cru-volume/component.js
+++ b/app/components/cru-volume/component.js
@@ -6,7 +6,8 @@ import layout from './template';
 import { getSources } from 'ui/models/volume';
 
 export default Component.extend(ViewNewEdit, {
-  intl: service(),
+  intl:        service(),
+  globalStore:  service(),
 
   layout,
   model:      null,
@@ -24,7 +25,9 @@ export default Component.extend(ViewNewEdit, {
 
   actions: {
     updateParams(key, map) {
-      getSources('ephemeral').forEach((source) => {
+      const showUnsupported = get(this, 'globalStore').all('feature').filterBy('name', 'unsupported-storage-drivers').get('firstObject.value');
+
+      getSources('ephemeral', showUnsupported).forEach((source) => {
         if (source.value === key){
           set(this, `primaryResource.${ key }`, map);
         } else {
@@ -45,7 +48,8 @@ export default Component.extend(ViewNewEdit, {
   sourceChoices: computed('intl.locale', function() {
     const intl = get(this, 'intl');
     const skip = ['host-path', 'secret'];
-    const out = getSources('ephemeral').map((p) => {
+    const showUnsupported = get(this, 'globalStore').all('feature').filterBy('name', 'unsupported-storage-drivers').get('firstObject.value');
+    const out = getSources('ephemeral', showUnsupported).map((p) => {
       const entry = Object.assign({}, p);
       const key = `volumeSource.${ entry.name }.title`;
 
@@ -71,7 +75,8 @@ export default Component.extend(ViewNewEdit, {
 
   sourceComponent: computed('sourceName', function() {
     const name = get(this, 'sourceName');
-    const sources = getSources('ephemeral');
+    const showUnsupported = get(this, 'globalStore').all('feature').filterBy('name', 'unsupported-storage-drivers').get('firstObject.value');
+    const sources = getSources('ephemeral', showUnsupported);
     const entry = sources.findBy('name', name);
 
     if (entry) {

--- a/app/models/storageclass.js
+++ b/app/models/storageclass.js
@@ -8,21 +8,21 @@ const DEFAULT_ANNOTATION = 'storageclass.kubernetes.io/is-default-class';
 
 const PROVISIONERS = [];
 
-registerProvisioner('aws-ebs',        'kubernetes.io/aws-ebs',         true);
-registerProvisioner('gce-pd',         'kubernetes.io/gce-pd',          true);
-registerProvisioner('glusterfs',      'kubernetes.io/glusterfs',       true);
-registerProvisioner('cinder',         'kubernetes.io/cinder',          true);
-registerProvisioner('vsphere-volume', 'kubernetes.io/vsphere-volume',  true);
-registerProvisioner('rbd',            'kubernetes.io/rbd',             true);
-registerProvisioner('quobyte',        'kubernetes.io/quobyte',         true);
-registerProvisioner('azure-disk',     'kubernetes.io/azure-disk',      true);
-registerProvisioner('azure-file',     'kubernetes.io/azure-file',      true);
-registerProvisioner('portworx-volume', 'kubernetes.io/portworx-volume', true);
-registerProvisioner('scaleio',        'kubernetes.io/scaleio',         true);
-registerProvisioner('storageos',      'kubernetes.io/storageos',       true);
-registerProvisioner('longhorn',      'rancher.io/longhorn',       true);
+registerProvisioner('aws-ebs',        'kubernetes.io/aws-ebs',         true, true);
+registerProvisioner('gce-pd',         'kubernetes.io/gce-pd',          true, true);
+registerProvisioner('glusterfs',      'kubernetes.io/glusterfs',       true, false);
+registerProvisioner('cinder',         'kubernetes.io/cinder',          true, false);
+registerProvisioner('vsphere-volume', 'kubernetes.io/vsphere-volume',  true, true);
+registerProvisioner('rbd',            'kubernetes.io/rbd',             true, false);
+registerProvisioner('quobyte',        'kubernetes.io/quobyte',         true, false);
+registerProvisioner('azure-disk',     'kubernetes.io/azure-disk',      true, true);
+registerProvisioner('azure-file',     'kubernetes.io/azure-file',      true, true);
+registerProvisioner('portworx-volume', 'kubernetes.io/portworx-volume', true, false);
+registerProvisioner('scaleio',        'kubernetes.io/scaleio',         true, false);
+registerProvisioner('storageos',      'kubernetes.io/storageos',       true, false);
+registerProvisioner('longhorn',      'rancher.io/longhorn',       true, true);
 
-export function registerProvisioner(name, provisioner, component) {
+export function registerProvisioner(name, provisioner, component, supported) {
   if ( component === true ) {
     component = name;
   }
@@ -37,11 +37,16 @@ export function registerProvisioner(name, provisioner, component) {
     name,
     value:     provisioner,
     component,
+    supported,
   });
 }
 
-export function getProvisioners() {
-  return JSON.parse(JSON.stringify(PROVISIONERS));
+export function getProvisioners(showUnsupported = false) {
+  const supportedProvisioners = showUnsupported
+    ? PROVISIONERS
+    : PROVISIONERS.filter((p) => p.supported);
+
+  return JSON.parse(JSON.stringify(supportedProvisioners));
 }
 
 export default Resource.extend({

--- a/app/models/volume.js
+++ b/app/models/volume.js
@@ -5,37 +5,37 @@ import Resource from '@rancher/ember-api-store/models/resource';
 const SOURCES = [];
 
 //             name/component    field                     component ephemeral persistent driver
-registerSource('aws-ebs',              'awsElasticBlockStore',   true, true,  true);
-registerSource('azure-disk',           'azureDisk',              true, true,  true);
-registerSource('azure-file',           'azureFile',              true, true,  true);
-registerSource('cephfs',               'cephfs',                 true, true,  true);
-registerSource('cinder',               'cinder',                 true, true,  true);
-registerSource('config-map',           'configMap',              true, false, false);
-// registerSource('downward-api',      'downwardAPI',            true, true,  false);
-registerSource('empty-dir',            'emptyDir',               true, true,  false);
-registerSource('fc',                   'fc',                     true, true,  true);
-registerSource('flex-volume',          'flexVolume',             true, true,  true);
-registerSource('flex-volume-longhorn', 'flexVolume',             true, true,  true, 'rancher.io/longhorn');
-registerSource('flocker',              'flocker',                true, true,  true);
-registerSource('gce-pd',               'gcePersistentDisk',      true, true,  true);
-// registerSource('git-repo',          'gitRepo',                true, true,  false);
-registerSource('glusterfs',            'glusterfs',              true, true,  true);
-registerSource('host-path',            'hostPath',               true, true,  true);
-registerSource('iscsi',                'iscsi',                  true, true,  true);
-registerSource('local',                'local',                  true, false, true);
-registerSource('nfs',                  'nfs',                    true, true,  true);
-// registerSource('pvc',               'persisitentVolumeClaim', true, true,  false);
-registerSource('photon',               'photonPersistentDisk',   true, true,  true);
-registerSource('portworx',             'portworxVolume',         true, true,  true);
-// registerSource('projected',         'projected',              true, true,  false);
-registerSource('quobyte',              'quobyte',                true, true,  true);
-registerSource('rbd',                  'rbd',                    true, true,  true);
-registerSource('scaleio',              'scaleIO',                true, true,  true);
-registerSource('secret',               'secret',                 true, true,  false);
-registerSource('storageos',            'storageos',              true, true,  true);
-registerSource('vsphere-volume',       'vsphereVolume',          true, true,  true);
+registerSource('aws-ebs',              'awsElasticBlockStore',   true, true,  true, true);
+registerSource('azure-disk',           'azureDisk',              true, true,  true, true);
+registerSource('azure-file',           'azureFile',              true, true,  true, true);
+registerSource('cephfs',               'cephfs',                 true, true,  true, false);
+registerSource('cinder',               'cinder',                 true, true,  true, false);
+registerSource('config-map',           'configMap',              true, false, false, false);
+// registerSource('downward-api',      'downwardAPI',            true, true,  false, false);
+registerSource('empty-dir',            'emptyDir',               true, true,  false, false);
+registerSource('fc',                   'fc',                     true, true,  true, false);
+registerSource('flex-volume',          'flexVolume',             true, true,  true, false);
+registerSource('flex-volume-longhorn', 'flexVolume',             true, true,  true, true, 'rancher.io/longhorn');
+registerSource('flocker',              'flocker',                true, true,  true, false);
+registerSource('gce-pd',               'gcePersistentDisk',      true, true,  true, true);
+// registerSource('git-repo',          'gitRepo',                true, true,  false, false);
+registerSource('glusterfs',            'glusterfs',              true, true,  true, false);
+registerSource('host-path',            'hostPath',               true, true,  true, true);
+registerSource('iscsi',                'iscsi',                  true, true,  true, false);
+registerSource('local',                'local',                  true, false, true, true);
+registerSource('nfs',                  'nfs',                    true, true,  true, true);
+// registerSource('pvc',               'persisitentVolumeClaim', true, true,  false, false);
+registerSource('photon',               'photonPersistentDisk',   true, true,  true, false);
+registerSource('portworx',             'portworxVolume',         true, true,  true, false);
+// registerSource('projected',         'projected',              true, true,  false, false);
+registerSource('quobyte',              'quobyte',                true, true,  true, false);
+registerSource('rbd',                  'rbd',                    true, true,  true, false);
+registerSource('scaleio',              'scaleIO',                true, true,  true, false);
+registerSource('secret',               'secret',                 true, true,  false, false);
+registerSource('storageos',            'storageos',              true, true,  true, false);
+registerSource('vsphere-volume',       'vsphereVolume',          true, true,  true, true);
 
-export function registerSource(name, field, component, ephemeral = true, persistent = true, driver = '') {
+export function registerSource(name, field, component, ephemeral = true, persistent = true, supported = false, driver = '') {
   if ( component === true ) {
     component = name;
   }
@@ -53,16 +53,21 @@ export function registerSource(name, field, component, ephemeral = true, persist
     component,
     ephemeral:  !!ephemeral,
     persistent: !!persistent,
+    supported:  !!supported,
   });
 }
 
-export function getSources(which = 'all') {
+export function getSources(which = 'all', showUnsupported = false) {
+  const supportedSources = showUnsupported
+    ? SOURCES
+    : SOURCES.filter((s) => s.supported);
+
   if (which === 'ephemeral') {
-    return JSON.parse(JSON.stringify(SOURCES.filter((s) => s.ephemeral)));
+    return JSON.parse(JSON.stringify(supportedSources.filter((s) => s.ephemeral)));
   } else if ( which === 'persistent' ) {
-    return JSON.parse(JSON.stringify(SOURCES.filter((s) => s.persistent)));
+    return JSON.parse(JSON.stringify(supportedSources.filter((s) => s.persistent)));
   } else {
-    return JSON.parse(JSON.stringify(SOURCES));
+    return JSON.parse(JSON.stringify(supportedSources));
   }
 }
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
We want to make it more difficult to use unsupported storage providers
to reduce the likelihood of a user accidently using one of these
storage providers.

Persistent storage filtered:
![Screen Shot 2019-09-17 at 12 58 48 PM](https://user-images.githubusercontent.com/55104481/65075727-53e88500-d94c-11e9-878e-14c8d3838d7e.png)

Storage class filtered:
![Screen Shot 2019-09-17 at 12 58 29 PM](https://user-images.githubusercontent.com/55104481/65075770-6367ce00-d94c-11e9-9c26-ef1459c8ce22.png)

Ephemeral volume filtered:
![Screen Shot 2019-09-17 at 1 00 00 PM](https://user-images.githubusercontent.com/55104481/65075783-6d89cc80-d94c-11e9-9bfa-05458a9370e5.png)

Types of changes
======
- New feature (non-breaking change which adds functionality)

Linked Issues
======
rancher/rancher#22895

Further comments
======
This is blocked until this is merged rancher/rancher#22899. It may be the case that this will by default filter without the feature flag but I'd be reluctant to merge without it.
