### PR TITLE
Preserve state of 'Use Private IP To Connect'

### DIFF
--- a/lib/nodes/addon/components/driver-azure/component.js
+++ b/lib/nodes/addon/components/driver-azure/component.js
@@ -91,8 +91,6 @@ export default Component.extend(NodeDriver, {
 
     if (get(this, 'publicIpChoices').findBy('value', publicIpChoice).name === 'None') {
       set(this, 'config.usePrivateIp', true);
-    } else {
-      set(this, 'config.usePrivateIp', false);
     }
   }),
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When editing Azure node templates we failed to
preserve the state of 'Use Private IP To Connect 'when the value of
public ip was 'Static' or 'Dynamic'. We were erroneously overwriting the
value of config.usePrivateIp to false when those public ip values were
chosen.


Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#22752
