### PR TITLE
Prevent main content from overlapping user menu

### DIFF
--- a/app/styles/components/_identity-block.scss
+++ b/app/styles/components/_identity-block.scss
@@ -2,6 +2,9 @@
 
   &.block-wide {
     width: 30vw;
+    body.touch & {
+      width: 50vw;
+    }
   }
 
   .gh-block-name > div {

--- a/app/styles/components/_page-header.scss
+++ b/app/styles/components/_page-header.scss
@@ -108,6 +108,8 @@ $project-nav-active: $dropdown-link-hover-bg !default;
   .nav-user {
     border-radius: 0 3px 3px 0;
     margin: 0;
+    position: relative;
+    z-index: 4;
 
     .nav-item {
       a.nav-link {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
In mobile the user menu was being overlapped by the main content.
To fix this we just needed to update the z-index of the user menu.

Broken:
![Screen Shot 2019-09-19 at 9 47 49 AM](https://user-images.githubusercontent.com/55104481/65268362-d8addd00-dacb-11e9-83b0-83c988675ff4.png)

Fixed:
![Screen Shot 2019-09-19 at 10 35 40 AM](https://user-images.githubusercontent.com/55104481/65268378-e1061800-dacb-11e9-9c01-2b6661fb7c84.png)


Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#21914


