### PR TITLE
Make groups visible when editing cluster template

### DIFF
--- a/lib/shared/addon/components/share-member-row/component.js
+++ b/lib/shared/addon/components/share-member-row/component.js
@@ -25,9 +25,12 @@ export default Component.extend({
 
     const { isPublic, member } = this;
 
-    if (!isPublic && member.userPrincipalId) {
+
+    if (!isPublic && (member.userPrincipalId || member.groupPrincipalId)) {
+      const principalId = member.userPrincipalId || member.groupPrincipalId;
+
       this.globalStore.rawRequest({
-        url:    `principals/${ encodeURIComponent(member.userPrincipalId) }`,
+        url:    `principals/${ encodeURIComponent(principalId) }`,
         method: 'GET',
       }).then((xhr) => {
         if ( xhr.status === 204 ) {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
While editing a cluster template when the template was shared with a
group the group was not visible under the Share Template section. We
needed to ensure that the group was visible.

The reason that this was occurring was because we weren't fetching the
principal for the group because we were only fetching when the
userPrincipalId was present and not when the groupPrincipalId was
present.

Old:
![Screen Shot 2019-09-20 at 11 18 14 AM](https://user-images.githubusercontent.com/18536626/65282870-d313bf80-daea-11e9-890c-f3543087d2f9.png)

New:
![Screen Shot 2019-09-20 at 11 18 14 AM](https://user-images.githubusercontent.com/55104481/65350328-53452e00-db9a-11e9-868a-d7835fcc9cf3.png)


Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#22971
