### PR TITLE
Use template value for localClusterAuthEndpoint

### DIFF
--- a/lib/shared/addon/components/authorized-endpoint/component.js
+++ b/lib/shared/addon/components/authorized-endpoint/component.js
@@ -53,7 +53,7 @@ export default Component.extend({
   initClusterAuthEndpoint() {
     const { cluster } = this;
 
-    if (cluster.localClusterAuthEndpoint && cluster.localClusterAuthEndpoint.enabled) {
+    if (cluster.localClusterAuthEndpoint && cluster.localClusterAuthEndpoint.enabled === 'true') {
       set(this, 'enableLocalClusterAuthEndpoint', true);
     } else {
       set(this, 'enableLocalClusterAuthEndpoint', false);


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When creating a cluster using a template localClusterAuthEndpoint was not
using the value provided by the template.  The component assumed that
localClusterAuthEndpoint was a boolean when it was in fact a string that
represented a boolean. To resolve this a string comparison needed to
be made.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#22972
