### PR TITLE
Cluster Template Revision Select Bug

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -84,7 +84,7 @@
                   localizedPrompt=true
                 }}
               {{else}}
-                {{model.cluster.clusterTemplateRevisionId}}
+                {{clusterTemplateRevisionId}}
               {{/if}}
             </div>
           {{/if}}
@@ -94,7 +94,7 @@
   {{/if}}
 {{/if}}
 
-{{#if (or clusterTemplateCreate (or (not clusterTemplatesEnforced) (and clusterTemplatesEnforced model.cluster.clusterTemplateRevisionId)))}}
+{{#if (or clusterTemplateCreate (or (not clusterTemplatesEnforced) (and clusterTemplatesEnforced clusterTemplateRevisionId)))}}
   {{#if (or isEdit (eq step 1))}}
     {{#accordion-list
        expandAll=(mut forceExpandAll)

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -78,7 +78,7 @@
                   optionValuePath="id"
                   optionLabelPath="name"
                   content=filteredTemplateRevisions
-                  value=model.cluster.clusterTemplateRevisionId
+                  value=clusterTemplateRevisionId
                   disabled=(not selectedClusterTemplateId)
                   prompt=(t "clusterNew.rke.clustersSelectTemplateRevision.select.prompt")
                   localizedPrompt=true


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When selecting a cluster template revision to use when launching a cluster via a template the revision would change the URL and subsequently would not reload the new model and values. This was because the select for this component was attached to the clusterTemplateRevisionId on the model being passed down from the launch route, we specifically pass down `clusterTemplateRevisionId` that is watched as a query param and is marked as mutable. I switched the select to use this param and all works as expected. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#22977

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
N/A

<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
