### PR TITLE
Include Template/Revision Upgrade Notifications

### DIFF
--- a/app/models/clustertemplate.js
+++ b/app/models/clustertemplate.js
@@ -30,6 +30,12 @@ const ClusterTemplate =  Resource.extend({
     return isNaN(get(this, 'revisions.length')) ? 0 : get(this, 'revisions.length');
   }),
 
+  latestRevision: computed('revisions.[]', function() {
+    return isNaN(get(this, 'revisions.length'))
+      ? null
+      : get(this, 'revisions').sortBy('createdTS').get('lastObject');
+  }),
+
   displayDefaultRevisionId: computed('revisionsCount', 'revisions.[]', function() {
     return get(this, 'defaultRevisionId').split(':')[1];
   }),

--- a/app/styles/_rancher.scss
+++ b/app/styles/_rancher.scss
@@ -62,6 +62,7 @@
 @import "app/styles/components/logging";
 @import "app/styles/components/identity-block";
 @import "app/styles/components/istio-graph";
+@import "app/styles/components/cluster-template-revision-upgrade-notification";
 
 // Vendor
 // Pretty much what it says. Vendor specific changes/overrides or includes.

--- a/app/styles/base/_icons.scss
+++ b/app/styles/base/_icons.scss
@@ -64,7 +64,7 @@ $icon-inverse:          #fff !default;
 .icon-stack {
   position: relative;
   display: inline-block;
-  // width: 2em;
+  width: 2em;
   height: 2em;
   line-height: 2em;
   vertical-align: middle;

--- a/app/styles/components/_banners.scss
+++ b/app/styles/components/_banners.scss
@@ -190,5 +190,12 @@
     .block .text-small {
       font-size: 0.7em;
     }
+
+    span.cluster-template-revision-upgrade-notification {
+      height: 0px;
+      display: inline-block;
+      margin-top: -1.5%;
+      vertical-align: top;
+    }
   }
 }

--- a/app/styles/components/_cluster-template-revision-upgrade-notification.scss
+++ b/app/styles/components/_cluster-template-revision-upgrade-notification.scss
@@ -1,0 +1,17 @@
+.cluster-template-revision-upgrade-notification {
+    .icon-stack {
+        color: $banner-warning;
+
+        .icon-notification, .icon-circle-o {
+            color: lighten($warning, 5);
+        }
+
+        .icon-circle, .icon-circle-o {
+            font-size: 1.45em;
+        }
+
+        .icon-notification {
+            font-size: 0.85em;
+        }
+    }
+}

--- a/app/styles/components/_tables.scss
+++ b/app/styles/components/_tables.scss
@@ -98,9 +98,15 @@ TABLE {
         text-align: center;
       }
 
-      &.sortable.text-right A {
-        position: relative;
-        left: -15px;
+      &.sortable {
+        &.text-right A {
+          position: relative;
+          left: -15px;
+        }
+        
+        .icon-stack .icon-stack-1x {
+          width: initial;
+        }
       }
 
       a {

--- a/lib/global-admin/addon/clusters/index/route.js
+++ b/lib/global-admin/addon/clusters/index/route.js
@@ -1,8 +1,21 @@
 import { next } from '@ember/runloop';
+import { hash } from 'rsvp';
+import { inject as service } from '@ember/service';
+import { get } from '@ember/object';
 import Route from '@ember/routing/route';
 
 export default Route.extend({
+  globalStore: service(),
+
   shortcuts: { 'g': 'toggleGrouping', },
+
+  afterModel() {
+    return hash(
+      get(this, 'globalStore').findAll('clusterTemplateRevision'),
+      get(this, 'globalStore').findAll('clusterTemplate'),
+    );
+  },
+
   actions:   {
     toggleGrouping() {
       let choices = ['list', 'grouped'];

--- a/lib/global-admin/addon/components/cluster-row/template.hbs
+++ b/lib/global-admin/addon/components/cluster-row/template.hbs
@@ -34,6 +34,8 @@
         <i class="icon icon-alert text-warning" />
       {{/tooltip-element}}
     {{/if}}
+
+    {{cluster-template-revision-upgrade-notification cluster=model}}
   </td>
   <td data-title="{{dt.provider}}">
     {{#if model.version.gitVersion}}

--- a/lib/monitoring/addon/components/cluster-basic-info/template.hbs
+++ b/lib/monitoring/addon/components/cluster-basic-info/template.hbs
@@ -5,8 +5,14 @@
   </div>
 
   <div class="vertical-middle">
-    <label class="acc-label vertical-middle p-0">{{t 'clustersPage.version.label'}}:</label>
+    <label class="acc-label vertical-middle p-0">{{t 'clustersPage.kubernetesVersion.label'}}:</label>
     <span>{{cluster.version.gitVersion}}</span>
+  </div>
+
+  <div class="vertical-middle">
+    <label class="acc-label vertical-middle p-0">{{t 'clustersPage.rkeTemplate.label'}}:</label>
+    <span>{{cluster.clusterTemplateDisplayName}}/{{cluster.clusterTemplateRevisionDisplayName}}</span>
+    {{cluster-template-revision-upgrade-notification cluster=cluster}}
   </div>
 
   <div class="vertical-middle">

--- a/lib/monitoring/addon/index/route.js
+++ b/lib/monitoring/addon/index/route.js
@@ -45,6 +45,13 @@ export default Route.extend({
     });
   },
 
+  afterModel() {
+    return hash(
+      get(this, 'globalStore').findAll('clusterTemplateRevision'),
+      get(this, 'globalStore').findAll('clusterTemplate'),
+    );
+  },
+
   setDefaultRoute: on('activate', function() {
     set(this, `session.${ C.SESSION.CLUSTER_ROUTE }`, 'authenticated.cluster.monitoring.index');
   }),

--- a/lib/shared/addon/components/cluster-template-revision-upgrade-notification/component.js
+++ b/lib/shared/addon/components/cluster-template-revision-upgrade-notification/component.js
@@ -1,0 +1,10 @@
+import Component from '@ember/component';
+import layout from './template';
+
+export default Component.extend({
+  layout,
+  tagName:            'span',
+  classNames:         ['cluster-template-revision-upgrade-notification'],
+
+  cluster:            null,
+});

--- a/lib/shared/addon/components/cluster-template-revision-upgrade-notification/template.hbs
+++ b/lib/shared/addon/components/cluster-template-revision-upgrade-notification/template.hbs
@@ -1,0 +1,14 @@
+{{#if cluster.isClusterTemplateUpgradeAvailable}}
+  {{#tooltip-element
+    type="tooltip-basic"
+    model=(t 'clusterTemplateRevisionUpgradeNotification.tooltip' revision=cluster.clusterTemplate.latestRevision.displayName)
+    tooltipTemplate="tooltip-static"
+    inlineBlock=true
+  }}
+    <span class="icon-stack rke-template-revision-upgrade-notification">
+      <i class="icon icon-circle icon-stack-1x"/>
+      <i class="icon icon-circle-o icon-stack-1x"/>
+      <i class="icon icon-notification icon-stack-1x"/>
+    </span>
+  {{/tooltip-element}}
+{{/if}}

--- a/lib/shared/app/components/cluster-template-revision-upgrade-notification/component.js
+++ b/lib/shared/app/components/cluster-template-revision-upgrade-notification/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/cluster-template-revision-upgrade-notification/component';

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -892,6 +892,9 @@ projectsPage:
       memberNameReq: Name is required for a member
       memberRoleReq: Role is required for a member
 
+clusterTemplateRevisionUpgradeNotification:
+  tooltip: Revision {revision} available for upgrade.
+
 clustersPage:
   header: Clusters
   newCluster: Add Cluster
@@ -903,10 +906,14 @@ clustersPage:
     new: Add Cluster
   cluster:
     label: Cluster Name
+  templateRevision:
+    label: Template/Revision
   provider:
     label: Provider
-  version:
-    label: Version
+  kubernetesVersion:
+    label: Kubernetes Version
+  rkeTemplate:
+    label: RKE Template
   nodes:
     label: Nodes
   cpu:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
We want to make it easier for someone that is managing multiple
clusters to see what template and template revision a cluster
is using. We also want to make it easy for a user to notice
that a cluster isn't using the latest revision.

To achieve this we added the template and revision to a column
in the clusters table to display both. We also indicate add
a warning badge beside a revision when the revision isn't
the latest.

Screenshots:
![Screen Shot 2019-09-24 at 12 24 33 PM](https://user-images.githubusercontent.com/55104481/65706476-6abf6380-e03f-11e9-9fee-66321a733855.png)
![Screen Shot 2019-09-24 at 12 24 20 PM](https://user-images.githubusercontent.com/55104481/65706478-6abf6380-e03f-11e9-8130-a0f064b00f74.png)

Types of changes
======
- New feature (non-breaking change which adds functionality)

Linked Issues
======
rancher/rancher#22047
