### PR TITLE
Use current template version for app upgrades

### DIFF
--- a/app/catalog-tab/launch/route.js
+++ b/app/catalog-tab/launch/route.js
@@ -152,6 +152,8 @@ export default Route.extend({
           });
         }
 
+        let catalogTemplateUrlKey = def;
+
         if ( neuApp.id ) {
           const v = get(neuApp, 'externalIdInfo.version');
           const currentVersion = verArr.filter((ver) => ver.version === v);
@@ -166,6 +168,7 @@ export default Route.extend({
             currentVersion.forEach((ver) => {
               set(ver, 'version', `${ ver.version } (current)`);
             });
+            catalogTemplateUrlKey = v;
           }
         }
 
@@ -177,7 +180,7 @@ export default Route.extend({
           catalogTemplate,
           namespace,
           catalogApp:         neuApp,
-          catalogTemplateUrl: links[def], // catalogTemplateUrl gets qp's added and this needs with out
+          catalogTemplateUrl: links[catalogTemplateUrlKey], // catalogTemplateUrl gets qp's added and this needs with out
           namespaces:         results.namespaces,
           tpl:                results.tpl,
           tplKind:            kind,


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When upgrading an application the template version was set to the
default version instead of the apps current version.

When a current version is present we now use it instead of the
default.


Types of changes
======
What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#23051
