### PR TITLE
RKE Template Bugs

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -151,6 +151,13 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
         this.initTemplateCluster();
       } else {
         this.initNonTemplateCluster();
+
+        if (this.clusterTemplateCreate && this.clusterTemplateQuestions && this.clusterTemplateQuestions.length > 0) {
+          // cloned
+          this.clusterTemplateQuestions.forEach((q) => {
+            this.send('addOverride', true, { path: q.variable });
+          })
+        }
       }
     }
   },
@@ -288,6 +295,17 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
             clusterTemplateQuestions.pushObject(question);
           }
+        } else {
+          // we've found the template override this wires up the value displayed in overrides section to the form value
+          question = clusterTemplateQuestions.findBy('variable', path);
+
+          setProperties(question, {
+            primaryResource,
+            isBuiltIn: true,
+            hideQuestion
+          });
+
+          defineProperty(question, 'default', alias(`primaryResource.${ path }`));
         }
       } else {
         if (path === 'uiOverrideBackupStrategy') {

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -1225,7 +1225,7 @@
   {{/if}} {{!-- endif (and isCustom (eq step 2)) --}}
 
 
-  {{#if (or clusterTemplateCreate applyClusterTemplate)}}
+  {{#if clusterTemplateCreate}}
     {{#if (or isEdit (eq step 1))}}
       {{#accordion-list
          expandAll=(mut forceExpandAll)

--- a/lib/shared/addon/components/cluster-templates-table/template.hbs
+++ b/lib/shared/addon/components/cluster-templates-table/template.hbs
@@ -6,7 +6,7 @@
   @groupByKey="clusterTemplateId"
   @groupByRef="clusterTemplate"
   @headers={{headers}}
-  @pagingLabel="pagination.cluster"
+  @pagingLabel="pagination.clusterTemplates"
   @searchText={{searchText}}
   @sortBy={{sortBy}}
   @extraSearchFields={{extraSearchFields}}

--- a/lib/shared/addon/components/form-versions/component.js
+++ b/lib/shared/addon/components/form-versions/component.js
@@ -57,7 +57,9 @@ export default Component.extend({
       editing,
       initialVersion,
       defaultK8sVersion,
+      showNotAllowed,
       applyClusterTemplate     = false,
+      clusterTemplateCreate    = false,
       clusterTemplateQuestions = [],
     } = this;
 
@@ -89,6 +91,11 @@ export default Component.extend({
           maxVersion = maxSatisfying(versions, supportedVersionsRange);
         }
       }
+    }
+
+    // if we're not consuming or creating a cluster template we should use the default translation for the label
+    if (!applyClusterTemplate && !clusterTemplateCreate) {
+      showNotAllowed = false;
     }
 
     out = [
@@ -131,7 +138,7 @@ export default Component.extend({
           };
         }
       } else {
-        const suffix = ( this.showNotAllowed ? 'formVersions.notallowed' : 'formVersions.unsupported' );
+        const suffix = ( showNotAllowed ? 'formVersions.notallowed' : 'formVersions.unsupported' );
 
         if (gt(version, coerceVersion(maxVersion))) {
           if (overrideMatch && !isEmpty(overrideMatch.satisfies)) {

--- a/lib/shared/addon/components/form-versions/component.js
+++ b/lib/shared/addon/components/form-versions/component.js
@@ -71,13 +71,8 @@ export default Component.extend({
       initialVersion = defaultK8sVersion;
     }
 
-    let initialWithoutX = initialVersion;
-
-    if ( initialWithoutX.endsWith('.x') ) {
-      initialWithoutX = initialWithoutX.replace(/x$/, '0');
-    }
-
-    let maxVersion = maxSatisfying(versions, defaultK8sVersionRange);
+    let initialWithoutX = initialVersion.endsWith('.x') ? initialVersion.replace(/x$/, '0') : initialVersion;
+    let maxVersion      = maxSatisfying(versions, defaultK8sVersionRange);
 
     if ( applyClusterTemplate ) {
       var overrideMatch = ( clusterTemplateQuestions || [] ).findBy('variable', 'rancherKubernetesEngineConfig.kubernetesVersion');
@@ -164,8 +159,10 @@ export default Component.extend({
       return out;
     });
 
-    if (( !editing ) && defaultK8sVersionRange) {
-      if (this.value) {
+    if (( !editing ) && defaultK8sVersionRange && this.value) {
+      if (this.value.endsWith('.x')) {
+        set(this, 'value', this.intl.t('formVersions.dotx', { minor: this.value.replace(/\.x$/, '') }));
+      } else {
         if ( maxVersion && !mappedVersions.findBy('value', get(this, 'value')) ) {
           set(this, 'value', maxVersion);
         }

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -7470,6 +7470,11 @@ pagination:
     =0 {No Roles}
     =1 {{count} {count, plural, =1 {Role} other {Roles}}}
     other {{from} - {to} of {count} Roles}}
+  clusterTemplates: |
+    {pages, plural,
+    =0 {No Template Revisions}
+    =1 {{count} {count, plural, =1 {Template Revision} other {Template Revisions}}}
+    other {{from} - {to} of {count} Template Revisions}}
   service: |
     {pages, plural,
     =0 {No Services}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This PR contains various bug fixes for RKE Templates

Hides the `Custom Clusters Overrides` section when launching a RKE cluster with a template.
Fixes pagination label for the bulk selector for RKE templates.
Fixes version displayed when cloning an RKE template that used the Major.Minor version.
Fixes data becoming out of sync between form value and override section value when cloning an RKE template. 
Fix k8s version dropdown when editing cluster with prohibited k8s version in the dropdown.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#23056
rancher/rancher#23065
rancher/rancher#23068
rancher/rancher#23069
rancher/rancher#23085
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
