### PR TITLE
Use current template version for app upgrades

### DIFF
--- a/lib/global-admin/addon/components/new-multi-cluster-app/component.js
+++ b/lib/global-admin/addon/components/new-multi-cluster-app/component.js
@@ -735,19 +735,12 @@ export default Component.extend(NewOrEdit, CatalogApp, {
   },
 
   initSelectedTemplateModel() {
-    let def     = get(this, 'templateResource.defaultVersion');
+    let def = get(this, 'templateResource.defaultVersion');
     const latest = get(this, 'templateResource.latestVersion');
-
+    const current = get(this, 'primaryResource.externalIdInfo.version');
     const links = get(this, 'versionLinks');
-    const app   = get(this, 'primaryResource');
 
-    if (get(app, 'id') && !get(this, 'upgrade')) {
-      def = get(app, 'externalIdInfo.version');
-    }
-
-    set(this, 'selectedTemplateUrl', links[def] || links[latest] || null)
-
-    return;
+    set(this, 'selectedTemplateUrl', links[current] || links[def] || links[latest] || null);
   },
 
   initUpgradeStrategy() {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When upgrading a multi-cluster-application the template version was set
to the default version instead of the apps current version.

When a current version is present we now use it before using the
default.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#23101
