### PR TITLE
Improve robustness of showing template/revision

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -53,13 +53,17 @@ export default Resource.extend(Grafana, ResourceUsage, {
   })),
 
   clusterTemplateDisplayName: computed('clusterTemplate.name', 'clusterTemplateId', function() {
-    return get(this, 'clusterTemplate.displayName')
-      || get(this, 'clusterTemplateId').replace(CLUSTER_TEMPLATE_ID_PREFIX, '');
+    const displayName = get(this, 'clusterTemplate.displayName');
+    const clusterTemplateId = (get(this, 'clusterTemplateId') || '').replace(CLUSTER_TEMPLATE_ID_PREFIX, '');
+
+    return displayName || clusterTemplateId;
   }),
 
   clusterTemplateRevisionDisplayName: computed('clusterTemplateRevision.name', 'clusterTemplateRevisionId', function() {
-    return get(this, 'clusterTemplateRevision.displayName')
-      || get(this, 'clusterTemplateRevisionId').replace(CLUSTER_TEMPLATE_ID_PREFIX, '');
+    const displayName = get(this, 'clusterTemplateRevision.displayName');
+    const revisionId = (get(this, 'clusterTemplateRevisionId') || '').replace(CLUSTER_TEMPLATE_ID_PREFIX, '')
+
+    return displayName || revisionId;
   }),
 
   isClusterTemplateUpgradeAvailable: computed('clusterTemplate.latestRevision.id', 'clusterTemplateRevision.id', function() {

--- a/app/models/clustertemplate.js
+++ b/app/models/clustertemplate.js
@@ -31,9 +31,11 @@ const ClusterTemplate =  Resource.extend({
   }),
 
   latestRevision: computed('revisions.[]', function() {
-    return isNaN(get(this, 'revisions.length'))
+    const revisions = (get(this, 'revisions') || []).filter((revision) => revision.enabled);
+
+    return get(revisions, 'length') === 0
       ? null
-      : get(this, 'revisions').sortBy('createdTS').get('lastObject');
+      : revisions.sortBy('createdTS').get('lastObject');
   }),
 
   displayDefaultRevisionId: computed('revisionsCount', 'revisions.[]', function() {

--- a/lib/monitoring/addon/components/cluster-basic-info/template.hbs
+++ b/lib/monitoring/addon/components/cluster-basic-info/template.hbs
@@ -9,11 +9,13 @@
     <span>{{cluster.version.gitVersion}}</span>
   </div>
 
-  <div class="vertical-middle">
-    <label class="acc-label vertical-middle p-0">{{t 'clustersPage.rkeTemplate.label'}}:</label>
-    <span>{{cluster.clusterTemplateDisplayName}}/{{cluster.clusterTemplateRevisionDisplayName}}</span>
-    {{cluster-template-revision-upgrade-notification cluster=cluster}}
-  </div>
+  {{#if cluster.clusterTemplateId}}
+    <div class="vertical-middle">
+      <label class="acc-label vertical-middle p-0">{{t 'clustersPage.rkeTemplate.label'}}:</label>
+      <span>{{cluster.clusterTemplateDisplayName}}/{{cluster.clusterTemplateRevisionDisplayName}}</span>
+      {{cluster-template-revision-upgrade-notification cluster=cluster}}
+    </div>
+  {{/if}}
 
   <div class="vertical-middle">
     <label class="acc-label vertical-middle p-0">{{t 'generic.created'}}:</label>


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
- We will only conditionally render template/revision section on the
monitoring page if the cluster is using a template. This was
crashing the page before.
- We will now make sure there's a string when invoking replace
when generating the template and revision display names.
- We will now respect the enable flag of template revisions
when determining if an upgrade is available.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#23126