### PR TITLE
[2.2.9] Backport 2.2: Add UI element to invalidate User API Keys when resetting password

### DIFF
--- a/app/components/input-edit-password/component.js
+++ b/app/components/input-edit-password/component.js
@@ -76,6 +76,7 @@ export default Component.extend({
         if ( get(this, 'deleteTokens') ) {
           return get(this, 'globalStore').findAll('token').then((tokens) => {
             const promises = [];
+
             tokens.forEach((token) => {
               if ( !token.current ) {
                 promises.push(token.delete());

--- a/app/components/input-edit-password/template.hbs
+++ b/app/components/input-edit-password/template.hbs
@@ -1,6 +1,10 @@
 <form class="horizontal-form container-fluid text-left" {{action 'save' on="submit"}}>
   <input type="text" name="username" autocomplete="username" value={{user.username}} style="display: none;" />
   <div class="content">
+    {{#if showDeleteTokens}}
+      <label>{{input type="checkbox" checked=deleteTokens}} {{t 'modalEditPassword.deleteTokens'}}</label>
+    {{/if}}
+
     {{#if showCurrent}}
       <div class="row mb-20">
         <div class="col span-12">

--- a/app/components/modal-edit-password/template.hbs
+++ b/app/components/modal-edit-password/template.hbs
@@ -7,6 +7,7 @@
 {{input-edit-password
     complete=(action "complete")
     showCurrent=true
+    showDeleteTokens=true
     cancel=(action "cancel")
     editButton='modalEditPassword.actionButton'
     user=user

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -5567,6 +5567,7 @@ modalEditPassword:
   mode:
     generate: 'Use a new randomly generated password:'
     manual: 'Set a specific password to use:'
+  deleteTokens: Delete all existing API keys
 
 modalFeedback:
   header: Welcome to {appName}!


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Backporting checkbox option to delete all existing API keys (that the user can see) when changing your password.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
n/a
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
