### PR TITLE
expose name param on workload port mapping

### DIFF
--- a/app/components/container/form-ports/template.hbs
+++ b/app/components/container/form-ports/template.hbs
@@ -24,6 +24,9 @@
       <thead>
         <tr class="hidden-sm">
           <th class="{{unless editing "acc-label"}}">
+            {{t "formServicePorts.name.label"}}
+          </th>
+          <th class="{{unless editing "acc-label"}}">
             {{t "formPorts.containerPort.label"}}
             {{#if editing}}
               {{field-required}}
@@ -52,6 +55,13 @@
       <tbody>
         {{#each ports as |port|}}
           <tr>
+            <td data-title="{{t 'formServicePorts.name.label'}}">
+              {{#if editing}}
+                {{input class="form-control input-sm public" value=port.name placeholder=(t 'formServicePorts.name.placeholder')}}
+              {{else}}
+                {{port.name}}
+              {{/if}}
+            </td>
             <td data-title="{{t "formPorts.containerPort.label"}}">
               {{#if editing}}
                 {{input-integer


### PR DESCRIPTION



<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
when deploying workloads with an Istio sidecar the port maps require a specific
name to be entered by the user, http. I've exposed the name param  but do not
autofill the name, this will be a documentation concern.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#23105

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
