### PR TITLE
Use more appropriate keys to watch on @computed

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -66,7 +66,7 @@ export default Resource.extend(Grafana, ResourceUsage, {
     return displayName || revisionId;
   }),
 
-  isClusterTemplateUpgradeAvailable: computed('clusterTemplate.latestRevision.id', 'clusterTemplateRevision.id', function() {
+  isClusterTemplateUpgradeAvailable: computed('clusterTemplate.latestRevision', 'clusterTemplate.latestRevision.id', 'clusterTemplateRevision.id', function() {
     const latestClusterTemplateRevisionId = get(this, 'clusterTemplate.latestRevision.id');
     const currentClusterTemplateRevisionId = get(this, 'clusterTemplateRevision.id');
 

--- a/app/models/clustertemplate.js
+++ b/app/models/clustertemplate.js
@@ -30,7 +30,7 @@ const ClusterTemplate =  Resource.extend({
     return isNaN(get(this, 'revisions.length')) ? 0 : get(this, 'revisions.length');
   }),
 
-  latestRevision: computed('revisions.[]', function() {
+  latestRevision: computed('revisions.[]', 'revisions.@each.enabled', function() {
     const revisions = (get(this, 'revisions') || []).filter((revision) => revision.enabled);
 
     return get(revisions, 'length') === 0


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The cluster upgrade notification wasn't properly updating when
the user enabled and disabled a revision. It required that the
page was refreshed before display the fresh data.

This resolves this issue by watching more appropriate keys
int he relevant computed properties. The most relevant
being the revision.@each.enabled on the latestRevision property.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#23126
