### PR TITLE
dedup import yaml button when istio feature flag is enabled

### DIFF
--- a/lib/istio/addon/project-istio/template.hbs
+++ b/lib/istio/addon/project-istio/template.hbs
@@ -2,6 +2,13 @@
   {{#istio-nav
     iconDisabled=model.iconDisabled
   }}
+    <button
+      {{action "importYaml"}}
+      class="btn btn-sm bg-default mr-10"
+      disabled={{or (rbac-prevents resource="virtualservice" scope="project" permission="create") (rbac-prevents resource="destinationrule" scope="project" permission="create")}}
+    >
+      {{t "nav.containers.importCompose"}}
+    </button>
     {{#if (eq currentRouteName "authenticated.project.istio.project-istio.rules")}}
       <a
         class="btn btn-sm bg-primary mr-10"
@@ -19,14 +26,6 @@
         <span>{{t "rulesPage.new"}}</span>
       </a>
       {{else if (eq currentRouteName "authenticated.project.istio.project-istio.destination-rules.index")}}
-        <button
-          {{action "importYaml"}}
-          class="btn btn-sm bg-default mr-10"
-          disabled={{rbac-prevents resource="destinationrule" scope="project" permission="create"}}
-        >
-          {{t "nav.containers.importCompose"}}
-        </button>
-
         {{#link-to
           "project-istio.destination-rules.new"
           scope.currentProject.id
@@ -36,14 +35,6 @@
           {{t "istio.nav.destinationRules.add"}}
         {{/link-to}}
       {{else if (eq currentRouteName "authenticated.project.istio.project-istio.virtual-services.index")}}
-        <button
-          {{action "importYaml"}}
-          class="btn btn-sm bg-default mr-10"
-          disabled={{rbac-prevents resource="virtualservice" scope="project" permission="create"}}
-          >
-          {{t "nav.containers.importCompose"}}
-        </button>
-
         {{#link-to
           "project-istio.virtual-services.new"
           scope.currentProject.id
@@ -53,13 +44,6 @@
           {{t "istio.nav.virtualServices.add"}}
         {{/link-to}}
     {{/if}}
-    <button
-      {{action "importYaml"}}
-      class="btn btn-sm bg-default mr-10"
-      disabled={{or (rbac-prevents resource="virtualservice" scope="project" permission="create") (rbac-prevents resource="destinationrule" scope="project" permission="create")}}
-    >
-      {{t "nav.containers.importCompose"}}
-    </button>
   {{/istio-nav}}
   {{outlet}}
 {{else}}


### PR DESCRIPTION



<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When adding the vitual services and destination rules are enabled we were
showing the import yaml button twice. It needs to be visible on both tabs and we
should be able to pass the or to the rbac check so I removed the duplicates and
moved the button to before the potential other buttons in the istio nav.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#23155

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
