### PR TITLE
[2.3.2] Ensure project-member-row uses same identicon as principal model

### DIFF
--- a/lib/shared/addon/components/form-members/component.js
+++ b/lib/shared/addon/components/form-members/component.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import layout from './template';
-import { computed, get, set } from '@ember/object';
+import { computed, get, set, setProperties } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { all as PromiseAll } from 'rsvp';
 import $ from 'jquery';
@@ -28,7 +28,9 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
+
     this.buildUpdateList(get(this, 'primaryResource'))
+
     if (this.registerHook) {
       this.registerHook(this.saveMembers.bind(this), 'saveMembers');
     }
@@ -49,8 +51,10 @@ export default Component.extend({
     },
 
     removeMember(obj) {
-      set(obj, 'pendingDelete', true);
-      set(obj, 'bindings', []);
+      setProperties(obj, {
+        pendingDelete: true,
+        bindings:      [],
+      });
     },
   },
 
@@ -192,7 +196,7 @@ export default Component.extend({
         });
       });
     } else {
-      this.set('errors', [get(this, 'intl').t('formMembers.members.errors.ownerReq')]);
+      set(this, 'errors', [get(this, 'intl').t('formMembers.members.errors.ownerReq')]);
 
       return reject();
     }

--- a/lib/shared/addon/components/form-members/template.hbs
+++ b/lib/shared/addon/components/form-members/template.hbs
@@ -2,8 +2,8 @@
   <table class="table fixed">
     <thead>
       <tr>
-        <th>{{t 'formMembers.members.name.label'}}</th>
-        <th>{{t 'formMembers.members.role.label'}}</th>
+        <th>{{t "formMembers.members.name.label"}}</th>
+        <th>{{t "formMembers.members.role.label"}}</th>
         <th width="10">&nbsp;</th>
         <th width="40"></th>
       </tr>
@@ -11,51 +11,48 @@
     <tbody>
       {{#if isNew}}
         {{#each defaultRoles as |defRole|}}
-          <tr class="main-row">
-            <td class="pr-10">
-              {{creator.displayName}}
-            </td>
-            <td class="pr-10">
-              {{defRole.name}}
-            </td>
-            <td>&nbsp;</td>
-          </tr>
+          <ProjectMemberRow
+            @principal={{creator}}
+            @roleTemplate={{defRole}}
+            @pageType={{primaryResource.type}}
+            @noUpdate={{true}}
+          />
         {{/each}}
       {{/if}}
       {{#each memberArray as |member|}}
         {{#unless member.pendingDelete}}
-          {{project-member-row
-              member=member
-              editing=editing
-              resource=primaryResource
-              roles=filteredRoles
-              users=filteredUsers
-              pageType=primaryResource.type
-              remove=(action "removeMember")
-          }}
+          <ProjectMemberRow
+            @member={{member}}
+            @editing={{editing}}
+            @resource={{primaryResource}}
+            @roles={{filteredRoles}}
+            @users={{filteredUsers}}
+            @pageType={{primaryResource.type}}
+            @remove={{action "removeMember"}}
+          />
         {{/unless}}
       {{/each}}
     </tbody>
   </table>
 
   <div class="mt-10">
-    {{#if (and (eq filteredUsers.length 0) (eq access.provider 'local'))}}
+    {{#if (and (lte filteredUsers.length 1) (eq access.provider "local"))}}
       {{#tooltip-element
-           type="tooltip-basic"
-           model=(t 'formMembers.members.noAddUser')
-           tooltipTemplate='tooltip-static'
-           aria-describedby="tooltip-base"
-           tooltipFor="tooltipNoUsers"
+         type="tooltip-basic"
+         model=(t "formMembers.members.noAddUser")
+         tooltipTemplate="tooltip-static"
+         aria-describedby="tooltip-base"
+         tooltipFor="tooltipNoUsers"
       }}
         <button class="btn bg-link icon-btn p-0" disabled=true>
           <span class="darken"><i class="icon icon-plus text-small"/></span>
-          <span>{{t 'formMembers.members.addMember'}}</span>
+          <span>{{t "formMembers.members.addMember"}}</span>
         </button>
       {{/tooltip-element}}
     {{else}}
       <button class="btn bg-link icon-btn p-0" {{action "addMember" "User"}}>
         <span class="darken"><i class="icon icon-plus text-small"/></span>
-        <span>{{t 'formMembers.members.addMember'}}</span>
+        <span>{{t "formMembers.members.addMember"}}</span>
       </button>
     {{/if}}
   </div>

--- a/lib/shared/addon/components/project-member-row/component.js
+++ b/lib/shared/addon/components/project-member-row/component.js
@@ -42,7 +42,6 @@ export default Component.extend({
 
   member:               null,
   roles:                null,
-  owner:                null,
   type:                 null,
   pageType:             null,
   editing:              false,
@@ -79,7 +78,10 @@ export default Component.extend({
           }
 
           if ( xhr.body && typeof xhr.body === 'object') {
-            set(this, 'principal', set(this, 'external', xhr.body));
+            let nuePrincipal = this.globalStore.createRecord(xhr.body);
+
+            set(this, 'principal', nuePrincipal);
+
             this.principalChanged();
           }
 
@@ -110,6 +112,9 @@ export default Component.extend({
           this.openModal(false);
         });
       }
+    },
+    remove() {
+      this.remove(this.member);
     },
   },
 
@@ -200,7 +205,12 @@ export default Component.extend({
 
     return neuRoles;
   }),
+
   modalCanceled() {
+  },
+
+  remove(/* member */) {
+    // remove is not required as the noUpdate case will not allow you to remove a member
   },
 
   doneAdding(customs) {

--- a/lib/shared/addon/components/project-member-row/template.hbs
+++ b/lib/shared/addon/components/project-member-row/template.hbs
@@ -1,62 +1,54 @@
 <td class="pr-10">
-  {{#if owner}}
-    {{owner.displayName}}
-  {{else}}
-    {{#if noUpdate}}
-      {{#if principal}}
-        {{identity-block principal=principal}}
-      {{else if principalId}}
-        <div class="gh-block">
-          <div class="gh-avatar">
-            <img
-              src="{{principalGravatarSrc}}"
-              width="34"
-              height="34"
-            >
-          </div>
-          <div class="gh-block-content">
-            <div class="clip gh-block-name">
-              {{principalId}}
-            </div>
+  {{#if noUpdate}}
+    {{#if principal}}
+      {{identity-block principal=principal}}
+    {{else if principalId}}
+      <div class="gh-block">
+        <div class="gh-avatar">
+          <img
+            src="{{principalGravatarSrc}}"
+            width="34"
+            height="34"
+          >
+        </div>
+        <div class="gh-block-content">
+          <div class="clip gh-block-name">
+            {{principalId}}
           </div>
         </div>
-      {{else}}
-        {{!-- we should never get here, but if we did you can start with a error in principal search by id --}}
-        {{t "generic.unknown"}}&nbsp;{{t "generic.user"}}
-      {{/if}}
+      </div>
     {{else}}
-      {{input-identity
-        allowTeams=true
-        action=(action "addAuthorized")
-        onError=(action "gotError")
-      }}
+      {{!-- we should never get here, but if we did you can start with a error in principal search by id --}}
+      {{t "generic.unknown"}}&nbsp;{{t "generic.user"}}
     {{/if}}
+  {{else}}
+    {{input-identity
+      allowTeams=true
+      action=(action "addAuthorized")
+      onError=(action "gotError")
+    }}
   {{/if}}
 </td>
 <td class="pr-10">
-  {{#if owner}}
-    {{t "generic.owner"}}
-  {{else}}
-    {{#if noUpdate}}
-      {{#if roleTemplate}}
-        {{roleTemplate.displayName}}
-      {{else}}
-        {{t "generic.custom"}}
-      {{/if}}
+  {{#if noUpdate}}
+    {{#if roleTemplate}}
+      {{roleTemplate.displayName}}
     {{else}}
-      {{searchable-select
-        change=(action "onSelect")
-        content=choices
-        value=roleTemplateId
-        readOnly=noUpdate
-      }}
+      {{t "generic.custom"}}
     {{/if}}
+  {{else}}
+    {{searchable-select
+      change=(action "onSelect")
+      content=choices
+      value=roleTemplateId
+      readOnly=noUpdate
+    }}
   {{/if}}
 </td>
 <td>&nbsp;</td>
 <div class="input-group-btn">
-  {{#unless owner}}
-    <button class="btn bg-primary btn-sm" {{action remove member}}>
+  {{#unless noUpdate}}
+    <button class="btn bg-primary btn-sm" {{action "remove"}}>
       <i class="icon icon-minus" />
     </button>
   {{/unless}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4928,7 +4928,9 @@ formGlobalRoles:
       detail: Allows the user to deploy new Nodes using any existing Node Templates.
     base:
       label: Login Access
+
 formMembers:
+  owner: '{type} Owner'
   members:
     user: User
     group: Group


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
project-member-row was using `avatarSrc` on its component which was slightly
different then the same code used in the principal model but really should have
been the same. I got rid of the duplicate code in the component since the model
is the data owner. It really should manage the avatar source building.

I also updated single quotes to doubles in template and refactored the owner
logic since it wasn't doing anything extra that the noUpdate flag was doing.

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#21440

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
