### PR TITLE
[2.3.2] Add # Node Templates column to cloud credentials

### DIFF
--- a/app/components/modal-edit-setting/component.js
+++ b/app/components/modal-edit-setting/component.js
@@ -71,7 +71,7 @@ export default Component.extend(ModalBase, {
 
     done() {
       this.send('cancel');
-      window.location.href = window.location.href;
+      window.location.href = window.location.href; // eslint-disable-line no-self-assign
     },
 
     updateJson(json) {

--- a/app/models/cloudcredential.js
+++ b/app/models/cloudcredential.js
@@ -2,9 +2,12 @@ import Resource from '@rancher/ember-api-store/models/resource';
 import { computed } from '@ember/object';
 import { notEmpty } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import { hasMany } from '@rancher/ember-api-store/utils/denormalize';
+import { get } from '@ember/object';
 
 const cloudCredential = Resource.extend({
   modal:    service(),
+  globalStore:    service(),
   type:     'cloudCredential',
 
   canClone: false,
@@ -15,6 +18,7 @@ const cloudCredential = Resource.extend({
   isDo:     notEmpty('digitaloceancredentialConfig'),
   isLinode: notEmpty('linodecredentialConfig'),
   isVMware: notEmpty('vmwarevspherecredentialConfig'),
+  nodeTemplates: hasMany('id', 'nodetemplate', 'cloudCredentialId', 'globalStore'),
 
   displayType: computed('amazonec2credentialConfig', 'azurecredentialConfig', 'digitaloceancredentialConfig', 'linodecredentialConfig', 'vmwarevspherecredentialConfig', function() {
     const {
@@ -38,6 +42,9 @@ const cloudCredential = Resource.extend({
     }
   }),
 
+  numberOfNodeTemplateAssociations: computed('nodeTemplates.[]', function() {
+    return get(this, 'nodeTemplates').length;
+  }),
 
   actions: {
     edit() {

--- a/app/models/cloudcredential.js
+++ b/app/models/cloudcredential.js
@@ -6,20 +6,20 @@ import { hasMany } from '@rancher/ember-api-store/utils/denormalize';
 import { get } from '@ember/object';
 
 const cloudCredential = Resource.extend({
-  modal:    service(),
+  modal:         service(),
   globalStore:    service(),
+  nodeTemplates: hasMany('id', 'nodetemplate', 'cloudCredentialId', 'globalStore'),
+
   type:     'cloudCredential',
 
   canClone: false,
   canEdit:  true,
 
-  isAmazon: notEmpty('amazonec2credentialConfig'),
-  isAzure:  notEmpty('azurecredentialConfig'),
-  isDo:     notEmpty('digitaloceancredentialConfig'),
-  isLinode: notEmpty('linodecredentialConfig'),
-  isVMware: notEmpty('vmwarevspherecredentialConfig'),
-  nodeTemplates: hasMany('id', 'nodetemplate', 'cloudCredentialId', 'globalStore'),
-
+  isAmazon:    notEmpty('amazonec2credentialConfig'),
+  isAzure:     notEmpty('azurecredentialConfig'),
+  isDo:        notEmpty('digitaloceancredentialConfig'),
+  isLinode:    notEmpty('linodecredentialConfig'),
+  isVMware:    notEmpty('vmwarevspherecredentialConfig'),
   displayType: computed('amazonec2credentialConfig', 'azurecredentialConfig', 'digitaloceancredentialConfig', 'linodecredentialConfig', 'vmwarevspherecredentialConfig', function() {
     const {
       isAmazon,

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -100,7 +100,7 @@ export default Resource.extend({
     deactivate() {
       return this.doAction('deactivate').then(() => {
         if ( get(this, 'scope.currentProject') === this ) {
-          window.location.href = window.location.href;
+          window.location.href = window.location.href; // eslint-disable-line no-self-assign
         }
       });
     },
@@ -122,7 +122,7 @@ export default Resource.extend({
 
     return promise.then(() => {
       if (get(this, 'active')) {
-        window.location.href = window.location.href;
+        window.location.href = window.location.href; // eslint-disable-line no-self-assign
       }
     }).catch((err) => {
       get(this, 'growl').fromError('Error deleting', err);

--- a/lib/global-admin/addon/components/registry-catalog/component.js
+++ b/lib/global-admin/addon/components/registry-catalog/component.js
@@ -266,7 +266,7 @@ export default Component.extend(CrudCatalog, ReservationCheck, {
         .then(() => {
           this.setGlobalRegistryEnabled('false', () => {
             setTimeout(() => {
-              window.location.href = window.location.href;
+              window.location.href = window.location.href; // eslint-disable-line no-self-assign
             }, 1000);
           })
         })

--- a/lib/global-admin/addon/security/cloud-credentials/index/controller.js
+++ b/lib/global-admin/addon/security/cloud-credentials/index/controller.js
@@ -12,6 +12,12 @@ const HEADERS = [
     type:           'string',
   },
   {
+    name:           'numberOfNodeTemplateAssociations',
+    sort:           ['numberOfNodeTemplateAssociations'],
+    searchField:    'numberOfNodeTemplateAssociations',
+    translationKey: 'cloudCredentialsPage.numberNodeTemplates',
+  },
+  {
     classNames:     'text-right pr-20',
     name:           'created',
     sort:           ['created'],

--- a/lib/global-admin/addon/security/cloud-credentials/index/template.hbs
+++ b/lib/global-admin/addon/security/cloud-credentials/index/template.hbs
@@ -46,6 +46,9 @@
         <td data-title="{{t "generic.name"}}:" class="clip">
           {{row.displayName}}
         </td>
+        <td data-title="{{t "cloudCredentialsPage.numberNodeTemplates"}}:">
+          {{row.numberOfNodeTemplateAssociations}}
+        </td>
         <td data-title="{{t "generic.created"}}:" class="text-right pr-20">
           {{date-calendar row.created}}
         </td>

--- a/lib/istio/addon/components/modal-delete-istio/component.js
+++ b/lib/istio/addon/components/modal-delete-istio/component.js
@@ -45,7 +45,7 @@ export default Component.extend(ModalBase, {
 
       PromiseAll(promises).then(() => {
         setTimeout(() => {
-          window.location.href = window.location.href;
+          window.location.href = window.location.href; // eslint-disable-line no-self-assign
         }, 1000);
       }).catch((err) => {
         get(this, 'growl').fromError(get(err, 'body.message'));

--- a/lib/shared/addon/azure-ad/service.js
+++ b/lib/shared/addon/azure-ad/service.js
@@ -105,7 +105,7 @@ export default Service.extend({
         }
 
         return azureADConfig.save().then(() => {
-          window.location.href = window.location.href;
+          window.location.href = window.location.href; // eslint-disable-line no-self-assign
         });
       });
     }).catch((err) => cb(err));

--- a/lib/shared/addon/mixins/crud-catalog.js
+++ b/lib/shared/addon/mixins/crud-catalog.js
@@ -46,7 +46,7 @@ export default Mixin.create({
         })
         .then(() => {
           setTimeout(() => {
-            window.location.href = window.location.href;
+            window.location.href = window.location.href; // eslint-disable-line no-self-assign
           }, 1000);
         })
         .catch((err) => {

--- a/lib/shared/addon/oauth/service.js
+++ b/lib/shared/addon/oauth/service.js
@@ -163,7 +163,7 @@ export default Service.extend({
       }
 
       return currentConfig.save().then(() => {
-        window.location.href = window.location.href;
+        window.location.href = window.location.href; // eslint-disable-line no-self-assign
       });
     })
       .catch((err) => {

--- a/lib/shared/addon/saml/service.js
+++ b/lib/shared/addon/saml/service.js
@@ -86,7 +86,7 @@ export default Service.extend({
 
 
     return authConfig.save().then(() => {
-      window.location.href = window.location.href;
+      window.location.href = window.location.href; // eslint-disable-line no-self-assign
     }).catch((err) => {
       cb(err);
     });

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -744,6 +744,7 @@ cloudCredentialsPage:
     table:
       noData: There are no cloud credentials defined.
       noMatch: No cloud credentials match the current search
+  numberNodeTemplates: "# Node Templates"
 
 clusterCatalogPage:
   header: Catalogs


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
We want to provide a quick way to delete unused cloud credentials.
To do this we're going to show the user the number of node templates
that each cloud credential is associated with.

![Screen Shot 2019-10-01 at 11 33 45 AM](https://user-images.githubusercontent.com/55104481/65990172-f66e3100-e43f-11e9-85e9-157c35636116.png)


Types of changes
======
- New feature (non-breaking change which adds functionality)

Linked Issues
======
rancher/rancher#23064
