### PR TITLE
Move Grafana options to own section

### DIFF
--- a/lib/monitoring/addon/components/enable-monitoring/template.hbs
+++ b/lib/monitoring/addon/components/enable-monitoring/template.hbs
@@ -84,12 +84,6 @@
           </label>
           {{schema/input-boolean value=enablePrometheusPersistence}}
         </div>
-        <div class="col span-6">
-          <label class="acc-label">
-            {{t "monitoringPage.config.grafana.enablePersistence.label"}}
-          </label>
-          {{schema/input-boolean value=enableGrafanaPersistence}}
-        </div>
       </div>
 
       {{#if enablePrometheusPersistence}}
@@ -108,26 +102,6 @@
               {{t "monitoringPage.config.prometheus.storageClass.label"}}
             </label>
             {{schema/input-storageclass value=prometheusStorageClass}}
-          </div>
-        </div>
-      {{/if}}
-
-      {{#if enableGrafanaPersistence}}
-        <div class="row">
-          <div class="col span-6">
-            <label class="acc-label">
-              {{t "monitoringPage.config.grafana.size.label"}}
-            </label>
-            {{schema/input-string
-              value=grafanaPersistenceSize
-              placeholder=(t "monitoringPage.config.grafana.size.placeholder")
-            }}
-          </div>
-          <div class="col span-6">
-            <label class="acc-label">
-              {{t "monitoringPage.config.grafana.storageClass.label"}}
-            </label>
-            {{schema/input-storageclass value=grafanaStorageClass}}
           </div>
         </div>
       {{/if}}
@@ -297,6 +271,34 @@
           }}
         </div>
       </div>
+
+      <div class="row">
+        <div class="col span-6">
+          <label class="acc-label">
+            {{t "monitoringPage.config.grafana.enablePersistence.label"}}
+          </label>
+          {{schema/input-boolean value=enableGrafanaPersistence}}
+        </div>
+      </div>
+      {{#if enableGrafanaPersistence}}
+        <div class="row">
+          <div class="col span-6">
+            <label class="acc-label">
+              {{t "monitoringPage.config.grafana.size.label"}}
+            </label>
+            {{schema/input-string
+              value=grafanaPersistenceSize
+              placeholder=(t "monitoringPage.config.grafana.size.placeholder")
+            }}
+          </div>
+          <div class="col span-6">
+            <label class="acc-label">
+              {{t "monitoringPage.config.grafana.storageClass.label"}}
+            </label>
+            {{schema/input-storageclass value=grafanaStorageClass}}
+          </div>
+        </div>
+      {{/if}}
 
       {{#advanced-section advanced=advanced}}
         {{form-key-value


### PR DESCRIPTION
Proposed changes
======
The Grafana storage options were confusingly in the middle of the
Prometheus options on the Cluster Monitoring Configuration page.
To resolve this we moved the Grafana options to be below the
Prometheus options and above the advanced otpions.

![43103c29 ngrok io_c_local_monitoring_cluster-setting](https://user-images.githubusercontent.com/55104481/66005468-6d1b2680-e460-11e9-8278-322086095972.png)

Types of changes
======
- New feature (non-breaking change which adds functionality)

Linked Issues
======
rancher/rancher#22885
