### PR TITLE
Addressing a number of ember deprecations

### DIFF
--- a/app/application/controller.js
+++ b/app/application/controller.js
@@ -9,6 +9,7 @@ export default Controller.extend({
 
   resourceActions:   service('resource-actions'),
   tooltipService:    service('tooltip'),
+  router:            service(),
 
   // GitHub auth params
   queryParams:       ['isPopup', 'fromAuthProvider'],
@@ -32,8 +33,8 @@ export default Controller.extend({
 
   // currentRouteName is set by Ember.Router
   // but getting the application controller to get it is inconvenient sometimes
-  currentRouteNameChanged: observer('currentRouteName', function() {
-    this.set('app.currentRouteName', this.get('currentRouteName'));
+  currentRouteNameChanged: observer('router.currentRouteName', function() {
+    this.set('app.currentRouteName', this.get('router.currentRouteName'));
   }),
 
 });

--- a/app/application/route.js
+++ b/app/application/route.js
@@ -2,7 +2,7 @@ import { cancel, next, schedule } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import C from 'ui/utils/constants';
-import { get, set } from '@ember/object';
+import { get, set, observer } from '@ember/object';
 
 export default Route.extend({
   access:   service(),
@@ -176,9 +176,9 @@ export default Route.extend({
     },
   },
 
-  updateWindowTitle: function() {
+  updateWindowTitle: observer('settings.appName', function() {
     document.title = get(this, 'settings.appName');
-  }.observes('settings.appName'),
+  }),
 
   finishLogin() {
     let session = get(this, 'session');

--- a/app/authenticated/project/certificates/index/controller.js
+++ b/app/authenticated/project/certificates/index/controller.js
@@ -1,5 +1,5 @@
 import { alias } from '@ember/object/computed';
-import { get } from '@ember/object'
+import { get, computed } from '@ember/object'
 import Controller, { inject as controller } from '@ember/controller';
 
 export default Controller.extend({
@@ -35,11 +35,11 @@ export default Controller.extend({
   group:        alias('projectController.group'),
   groupTableBy: alias('projectController.groupTableBy'),
 
-  rows: function() {
+  rows: computed('model.projectCerts.[]', 'model.namespacedCerts.[]', function() {
     const proj = get(this, 'model.projectCerts').slice();
     const ns = get(this, 'model.namespacedCerts').slice();
     const out = proj.concat(ns);
 
     return out;
-  }.property('model.projectCerts.[]', 'model.namespacedCerts.[]'),
+  }),
 });

--- a/app/authenticated/project/config-maps/index/controller.js
+++ b/app/authenticated/project/config-maps/index/controller.js
@@ -1,5 +1,5 @@
 import { alias } from '@ember/object/computed';
-import { get } from '@ember/object';
+import { get, computed } from '@ember/object';
 import Controller, { inject as controller } from '@ember/controller';
 
 export const headers = [
@@ -51,7 +51,7 @@ export default Controller.extend({
   group:        alias('projectController.group'),
   groupTableBy: alias('projectController.groupTableBy'),
 
-  rows: function() {
+  rows: computed('model.configMaps.[].type', function() {
     return get(this, 'model.configMaps').filterBy('type', 'configMap');
-  }.property('model.configMaps.[].type'),
+  }),
 });

--- a/app/authenticated/project/container-log/controller.js
+++ b/app/authenticated/project/container-log/controller.js
@@ -1,16 +1,17 @@
 import $ from 'jquery';
 import Controller from '@ember/controller';
+import { on } from '@ember/object/evented';
 import Console from 'ui/mixins/console';
 
 export default Controller.extend(Console, {
 
-  bootstrap: function() {
+  bootstrap: on('init', () => {
     let body        = $('body');
     let application = $('#application');
 
     body.css('overflow', 'hidden');
 
     application.css('padding-bottom', '0');
-  }.on('init'),
+  }),
 
 });

--- a/app/authenticated/project/controller.js
+++ b/app/authenticated/project/controller.js
@@ -1,5 +1,6 @@
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import { computed, observer } from '@ember/object';
 import Controller from '@ember/controller';
 import C from 'ui/utils/constants';
 
@@ -42,29 +43,7 @@ export default Controller.extend({
     }
   },
 
-  showClusterWelcome: function() {
-    return this.get('scope.currentCluster.state') === 'inactive' && !this.get('nodes.length');
-  }.property('scope.currentCluster.state', 'nodes.[]'),
-
-  groupTableBy: function() {
-    if ( this.get('group') === NAMESPACE ) {
-      return 'namespaceId';
-    } else if ( this.get('group') === NODE ) {
-      return 'nodeId';
-    } else {
-      return null;
-    }
-  }.property('group'),
-
-  preSorts: function() {
-    if ( this.get('groupTableBy') ) {
-      return ['namespace.isDefault:desc', 'namespace.displayName'];
-    } else {
-      return null;
-    }
-  }.property('groupTableBy'),
-
-  groupChanged: function() {
+  groupChanged: observer('group', function() {
     let key = `prefs.${ C.PREFS.CONTAINER_VIEW }`;
     let cur = this.get(key);
     let neu = this.get('group');
@@ -72,5 +51,27 @@ export default Controller.extend({
     if ( cur !== neu ) {
       this.set(key, neu);
     }
-  }.observes('group'),
+  }),
+  showClusterWelcome: computed('scope.currentCluster.state', 'nodes.[]', function() {
+    return this.get('scope.currentCluster.state') === 'inactive' && !this.get('nodes.length');
+  }),
+
+  groupTableBy: computed('group', function() {
+    if ( this.get('group') === NAMESPACE ) {
+      return 'namespaceId';
+    } else if ( this.get('group') === NODE ) {
+      return 'nodeId';
+    } else {
+      return null;
+    }
+  }),
+
+  preSorts: computed('groupTableBy', function() {
+    if ( this.get('groupTableBy') ) {
+      return ['namespace.isDefault:desc', 'namespace.displayName'];
+    } else {
+      return null;
+    }
+  }),
+
 });

--- a/app/authenticated/project/help/controller.js
+++ b/app/authenticated/project/help/controller.js
@@ -1,4 +1,4 @@
-import { computed } from '@ember/object';
+import { computed, observer } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
@@ -13,6 +13,17 @@ export default Controller.extend({
   hasHosts:      true,
   docsLink:      alias('settings.docsBase'),
 
+  modelObserver: observer('model', function() {
+    if (this.get('model.resolved')) {
+      // @@TODO@@ - need to add some error handling
+      this.set('modelResolved', true);
+    }
+
+    if (this.get('model.error') ) {
+      this.set('modelError', true);
+    }
+  }),
+
   latestAnnouncement: computed('model.announcements', function() {
     if (this.get('model.announcements.topics')) {
       let sorted = this.get('model.announcements.topics').sortBy('id');
@@ -25,17 +36,6 @@ export default Controller.extend({
       };
     }
   }),
-
-  modelObserver: function() {
-    if (this.get('model.resolved')) {
-      // @@TODO@@ - need to add some error handling
-      this.set('modelResolved', true);
-    }
-
-    if (this.get('model.error') ) {
-      this.set('modelError', true);
-    }
-  }.observes('model'),
 
   forumsLink:  C.EXT_REFERENCES.FORUM,
   companyLink: C.EXT_REFERENCES.COMPANY,

--- a/app/authenticated/project/secrets/index/controller.js
+++ b/app/authenticated/project/secrets/index/controller.js
@@ -1,5 +1,5 @@
 import { alias } from '@ember/object/computed';
-import { get } from '@ember/object';
+import { get, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Controller, { inject as controller } from '@ember/controller';
 
@@ -54,11 +54,11 @@ export default Controller.extend({
   group:        alias('projectController.group'),
   groupTableBy: alias('projectController.groupTableBy'),
 
-  rows: function() {
+  rows: computed('model.projectSecrets.[].type', 'model.namespacedSecrets.[].type', function() {
     const proj = get(this, 'model.projectSecrets').filterBy('type', 'secret');
     const ns = get(this, 'model.namespacedSecrets').filterBy('type', 'namespacedSecret');
     const out = proj.concat(ns);
 
     return out;
-  }.property('model.projectSecrets.[].type', 'model.namespacedSecrets.[].type'),
+  }),
 });

--- a/app/components/container-dot/component.js
+++ b/app/components/container-dot/component.js
@@ -1,9 +1,10 @@
-import { observer } from '@ember/object';
+import { observer, computed } from '@ember/object';
 import $ from 'jquery';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { isMore } from 'ui/utils/platform';
 import layout from './template';
+import { on } from '@ember/object/evented';
 
 export default Component.extend({
   resourceActions: service('resource-actions'),
@@ -16,15 +17,15 @@ export default Component.extend({
   classNames:      ['vertical-middle'],
   type:            'tooltip-action-menu',
   template:        'tooltip-container-dot',
-  alt:        function() {
+  alt:        computed('model.{displayState,displayName}', function() {
     return `${ this.get('model.displayName')  }: ${  this.get('model.displayState') }`;
-  }.property('model.{displayState,displayName}'),
+  }),
 
-  resourceActionsObserver: observer('resourceActions.open', function() {
+  resourceActionsObserver: on('init', observer('resourceActions.open', function() {
     if (this.get('tooltipService.openedViaContextClick')) {
       this.get('tooltipService').set('openedViaContextClick', false);
     }
-  }).on('init'),
+  })),
   click(event) {
     this.details(event);
     this.get('tooltipService').hide();

--- a/app/components/container-logs/component.js
+++ b/app/components/container-logs/component.js
@@ -7,6 +7,7 @@ import { alternateLabel } from 'ui/utils/platform';
 import layout from './template';
 import C from 'ui/utils/constants';
 import { downloadFile } from 'shared/utils/download-files';
+import $ from 'jquery';
 
 const LINES = 500;
 
@@ -48,7 +49,7 @@ export default Component.extend({
   didInsertElement() {
     this._super();
     next(this, () => {
-      const body = this.$('.log-body');
+      const body = $('.log-body');
       let lastScrollTop = 0;
 
       body.scroll(() => {
@@ -81,12 +82,12 @@ export default Component.extend({
         return el.clone().find( sel || '>*' ).remove().end();
       };
 
-      const log    = this.$('.log-body').children('.log-msg');
+      const log    = $('.log-body').children('.log-msg');
 
       let stripped = '';
 
       log.each((i, e) => {
-        stripped += `${ ignore(this.$(e), 'span').text() } \n`;
+        stripped += `${ ignore($(e), 'span').text() } \n`;
       });
 
       downloadFile('container.log', stripped);
@@ -100,14 +101,14 @@ export default Component.extend({
     },
 
     clear() {
-      var body = this.$('.log-body')[0];
+      var body = $('.log-body')[0];
 
       body.innerHTML = '';
       body.scrollTop = 0;
     },
 
     scrollToTop() {
-      this.$('.log-body').animate({ scrollTop: '0px' });
+      $('.log-body').animate({ scrollTop: '0px' });
     },
 
     followLog() {
@@ -116,7 +117,7 @@ export default Component.extend({
     },
 
     scrollToBottom() {
-      var body = this.$('.log-body');
+      var body = $('.log-body');
 
       body.stop().animate({ scrollTop: `${ body[0].scrollHeight + 1000  }px` });
     },
@@ -170,7 +171,7 @@ export default Component.extend({
 
     set(this, 'socket', socket);
 
-    var body = this.$('.log-body')[0];
+    var body = $('.log-body')[0];
     var $body = $(body); // eslint-disable-line
 
     set(this, 'status', 'initializing');

--- a/app/components/container-table/component.js
+++ b/app/components/container-table/component.js
@@ -1,5 +1,6 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 import layout from './template';
 
 export const headersAll =  [
@@ -43,7 +44,7 @@ export default Component.extend({
 
   extraSearchFields: ['displayIp', 'primaryHost.displayName'],
 
-  headers: function() {
+  headers: computed(function() {
     if ( this.get('showStats') ) {
       return headersWithStats;
     } else if ( this.get('showNode') ) {
@@ -51,11 +52,11 @@ export default Component.extend({
     } else {
       return headersWithoutHost;
     }
-  }.property(),
+  }),
 
-  filtered: function() {
+  filtered: computed('body.@each.isSystem', function() {
     let out = this.get('body') || [];
 
     return out;
-  }.property('body.@each.isSystem'),
+  }),
 });

--- a/app/components/container/form-ports/component.js
+++ b/app/components/container/form-ports/component.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { get, set, setProperties, observer } from '@ember/object';
 import Component from '@ember/component';
 import layout from './template';
+import $ from 'jquery';
 
 const KINDS = ['NodePort', 'HostPort', 'ClusterIP', 'LoadBalancer'];
 
@@ -56,7 +57,7 @@ export default Component.extend({
           return;
         }
 
-        this.$('INPUT.public').last()[0].focus();
+        $('INPUT.public').last()[0].focus();
       });
     },
 

--- a/app/components/container/new-edit/component.js
+++ b/app/components/container/new-edit/component.js
@@ -1,5 +1,5 @@
 import Errors from 'ui/utils/errors';
-import { get, set, setProperties } from '@ember/object';
+import { get, set, setProperties, observer } from '@ember/object';
 import { equal } from '@ember/object/computed';
 import { next } from '@ember/runloop';
 import { inject as service } from '@ember/service';
@@ -8,6 +8,8 @@ import NewOrEdit from 'shared/mixins/new-or-edit';
 import C from 'ui/utils/constants';
 import ChildHook from 'shared/mixins/child-hook';
 import layout from './template';
+import $ from 'jquery';
+import { on } from '@ember/object/evented';
 
 const WINDOWS_NODE_SELECTOR = 'beta.kubernetes.io/os = windows';
 const LINUX_NODE_SELECTOR = 'beta.kubernetes.io/os != windows';
@@ -120,7 +122,7 @@ export default Component.extend(NewOrEdit, ChildHook, {
   },
 
   didInsertElement() {
-    const input = this.$("INPUT[type='text']")[0];
+    const input = $("INPUT[type='text']")[0];
 
     if (input) {
       input.focus();
@@ -167,7 +169,7 @@ export default Component.extend(NewOrEdit, ChildHook, {
     },
   },
 
-  updateHeader: function() {
+  updateHeader: on('init', observer('isUpgrade', 'isSidekick', 'isGlobal', 'service.displayName', 'intl.locale', function() {
     let args = {};
     let k = 'newContainer.';
 
@@ -194,7 +196,7 @@ export default Component.extend(NewOrEdit, ChildHook, {
 
       set(this, 'header', get(this, 'intl').t(k, args));
     });
-  }.observes('isUpgrade', 'isSidekick', 'isGlobal', 'service.displayName', 'intl.locale').on('init'),
+  })),
 
   // ----------------------------------
   // ----------------------------------

--- a/app/components/cru-persistent-volume-claim/component.js
+++ b/app/components/cru-persistent-volume-claim/component.js
@@ -65,7 +65,7 @@ export default Component.extend(ViewNewEdit, ChildHook, {
     },
   },
 
-  headerToken: function() {
+  headerToken: computed('actuallySave', 'mode', function() {
     let k = 'cruPersistentVolumeClaim.';
 
     if ( get(this, 'actuallySave' ) ) {
@@ -77,7 +77,7 @@ export default Component.extend(ViewNewEdit, ChildHook, {
     k += get(this, 'mode');
 
     return k;
-  }.property('actuallySave', 'mode'),
+  }),
 
   persistentVolumeChoices: computed('persistentVolumes.@each.{name,state}', function() {
     return get(this, 'persistentVolumes').map((v) => {

--- a/app/components/form-key-to-path/component.js
+++ b/app/components/form-key-to-path/component.js
@@ -3,6 +3,7 @@ import { next, debounce } from '@ember/runloop';
 import Component from '@ember/component';
 import EmberObject, { get, set, observer } from '@ember/object';
 import layout from './template';
+import $ from 'jquery';
 const SECRET = 'secret';
 const CONFIG_MAP = 'configmap';
 
@@ -74,7 +75,7 @@ export default Component.extend({
           return;
         }
 
-        let elem = this.$('INPUT.key').last()[0];
+        let elem = $('INPUT.key').last()[0];
 
         if (elem) {
           elem.focus();

--- a/app/components/form-scoped-roles/component.js
+++ b/app/components/form-scoped-roles/component.js
@@ -6,6 +6,7 @@ import { computed, get, set, setProperties } from '@ember/object';
 import layout from './template';
 import NewOrEdit from 'ui/mixins/new-or-edit';
 import { next } from '@ember/runloop';
+import $ from 'jquery';
 
 const CUSTOM = 'custom';
 
@@ -46,7 +47,7 @@ export default Component.extend(NewOrEdit, {
         return;
       }
 
-      const elem = this.$('INPUT')[0]
+      const elem = $('INPUT')[0]
 
       if ( elem ) {
         setTimeout(() => {

--- a/app/components/form-service-ports/component.js
+++ b/app/components/form-service-ports/component.js
@@ -3,6 +3,7 @@ import { alias } from '@ember/object/computed';
 import { get, set } from '@ember/object';
 import Component from '@ember/component';
 import layout from './template';
+import $ from 'jquery';
 
 const PROTOCOL_OPTIONS = [
   {
@@ -42,7 +43,7 @@ export default Component.extend({
           return;
         }
 
-        this.$('INPUT.public').last()[0].focus();
+        $('INPUT.public').last()[0].focus();
       });
     },
 

--- a/app/components/input-files/component.js
+++ b/app/components/input-files/component.js
@@ -1,8 +1,9 @@
 import { inject as service } from '@ember/service';
-import { get, observer } from '@ember/object';
+import { get, observer, computed } from '@ember/object';
 import Component from '@ember/component';
 import { isSafari } from 'ui/utils/platform';
 import layout from './template';
+import $ from 'jquery';
 
 export default Component.extend({
   growl: service(),
@@ -42,7 +43,7 @@ export default Component.extend({
     },
 
     upload() {
-      this.$('.input-files')[0].click();
+      $('.input-files')[0].click();
     },
 
     remove(file) {
@@ -64,13 +65,13 @@ export default Component.extend({
     }
   }),
 
-  actualAccept: function() {
+  actualAccept: computed('accept', function() {
     if ( isSafari ) {
       return '';
     } else {
       return this.get('accept');
     }
-  }.property('accept'),
+  }),
 
   change(event) {
     let ary = this.get('ary');

--- a/app/components/input-random-port/component.js
+++ b/app/components/input-random-port/component.js
@@ -2,6 +2,7 @@ import { set, get } from '@ember/object';
 import Component from '@ember/component';
 import layout from './template';
 import { next } from '@ember/runloop';
+import $ from 'jquery';
 
 export default Component.extend({
   layout,
@@ -30,7 +31,7 @@ export default Component.extend({
           return;
         }
 
-        this.$('INPUT').last()[0].focus();
+        $('INPUT').last()[0].focus();
       });
     }
   }

--- a/app/components/modal-edit-apikey/component.js
+++ b/app/components/modal-edit-apikey/component.js
@@ -8,6 +8,7 @@ import {
   get, set, computed, observer, setProperties
 } from '@ember/object';
 import moment from 'moment';
+import $ from 'jquery';
 
 export default Component.extend(ModalBase, NewOrEdit, {
   endpointService: service('endpoint'),
@@ -36,7 +37,7 @@ export default Component.extend(ModalBase, NewOrEdit, {
 
   didInsertElement() {
     setTimeout(() => {
-      this.$('TEXTAREA')[0].focus();
+      $('TEXTAREA')[0].focus();
     }, 250);
   },
 

--- a/app/components/modal-edit-setting/component.js
+++ b/app/components/modal-edit-setting/component.js
@@ -6,6 +6,7 @@ import { normalizeName } from 'shared/settings/service';
 import ModalBase from 'shared/mixins/modal-base';
 import layout from './template';
 import { get, set } from '@ember/object';
+import $ from 'jquery';
 
 const cmOpts = {
   autofocus:       true,
@@ -50,7 +51,7 @@ export default Component.extend(ModalBase, {
         return;
       }
 
-      const elem = this.$('.form-control')[0]
+      const elem = $('.form-control')[0]
 
       if ( elem ) {
         setTimeout(() => {

--- a/app/components/modal-shortcuts/component.js
+++ b/app/components/modal-shortcuts/component.js
@@ -32,7 +32,7 @@ export default Component.extend(ModalBase, {
   willDestroyElement() {
     clearInterval(this.get('timer'));
   },
-  containerCount: function() {
+  containerCount: computed('pods.length', function() {
     let count = this.get('pods.length');
 
     if ( count > 9 ) {
@@ -40,7 +40,7 @@ export default Component.extend(ModalBase, {
     } else {
       return `0${  count }`;
     }
-  }.property('pods.length'),
+  }),
 
   currentTheme: computed(`prefs.${ C.PREFS.THEME }`, function() {
     return this.get(`prefs.${ C.PREFS.THEME }`);

--- a/app/components/new-catalog/component.js
+++ b/app/components/new-catalog/component.js
@@ -16,6 +16,7 @@ import { isNumeric } from 'shared/utils/util';
 import convertDotAnswersToYaml from 'shared/utils/convert-yaml';
 import ChildHook from 'shared/mixins/child-hook';
 import flatMap from 'shared/utils/flat-map';
+import $ from 'jquery';
 
 export default Component.extend(NewOrEdit, CatalogApp, ChildHook, {
   catalog:                  service(),
@@ -104,11 +105,11 @@ export default Component.extend(NewOrEdit, CatalogApp, ChildHook, {
     if (!this.get('srcSet')) {
       set(this, 'srcSet', true);
 
-      const $icon = this.$('img');
+      const $icon = $('img');
 
       $icon.attr('src', $icon.data('src'));
 
-      this.$('img').on('error', () => {
+      $('img').on('error', () => {
         $icon.attr('src', `${ this.get('app.baseAssets') }assets/images/generic-catalog.svg`);
       });
     }

--- a/app/components/notifier/modal-new-edit/component.js
+++ b/app/components/notifier/modal-new-edit/component.js
@@ -3,7 +3,7 @@ import { alias, reads } from '@ember/object/computed';
 import ModalBase from 'ui/mixins/modal-base';
 import { resolve } from 'rsvp';
 import layout from './template';
-import { get, set, computed } from '@ember/object'
+import { get, set, computed, observer } from '@ember/object'
 import { inject as service } from '@ember/service';
 import NewOrEdit from 'ui/mixins/new-or-edit';
 import C from 'ui/utils/constants';
@@ -141,7 +141,11 @@ export default Component.extend(ModalBase, NewOrEdit, {
         });
     },
   },
-  addBtnLabel: function() {
+  currentTypeChanged: observer('currentType', function() {
+    set(this, 'errors', null);
+  }),
+
+  addBtnLabel: computed('mode', function() {
     const mode = get(this, 'mode');
 
     if (mode === 'edit') {
@@ -151,11 +155,7 @@ export default Component.extend(ModalBase, NewOrEdit, {
     } else if (mode === 'add') {
       return 'generic.add';
     }
-  }.property('mode'),
-
-  currentTypeChanged: function() {
-    set(this, 'errors', null);
-  }.observes('currentType'),
+  }),
 
   isSelectType: computed('currentType', function() {
     const types = TYPES.map((t) => t.type)

--- a/app/components/notifier/notifier-row/component.js
+++ b/app/components/notifier/notifier-row/component.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
-import { get } from '@ember/object';
+import { get, computed } from '@ember/object';
 import layout from './template'
 
 export default Component.extend({
@@ -12,9 +12,9 @@ export default Component.extend({
   classNames:  'main-row',
   bulkActions: true,
 
-  showNotifierValue: function() {
+  showNotifierValue: computed('model.notifierType', function() {
     const t = get(this, 'model.notifierType');
 
     return t === 'slack' || t === 'email';
-  }.property('model.notifierType'),
+  }),
 });

--- a/app/components/notifier/notifier-table/component.js
+++ b/app/components/notifier/notifier-table/component.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { reads } from '@ember/object/computed';
-import { get } from '@ember/object';
+import { get, computed } from '@ember/object';
 import layout from './template';
 
 const headers = [
@@ -42,10 +42,10 @@ export default Component.extend({
   headers,
 
   clusterId:         reads('scope.currentCluster.id'),
-  filteredNotifiers: function() {
+  filteredNotifiers: computed('model.@each.{clusterId}', 'clusterId', function() {
     const data = this.get('model') || [];
     const clusterId = get(this, 'clusterId')
 
     return data.filterBy('clusterId', clusterId);
-  }.property('model.@each.{clusterId}', 'clusterId'),
+  }),
 });

--- a/app/components/page-header-project/component.js
+++ b/app/components/page-header-project/component.js
@@ -78,8 +78,8 @@ export default Component.extend(ThrottledResize, {
 
       next(() => {
         if (!this.isTransitioning()) {
-          const menu = this.$('.project-menu');
-          const clusters = this.$('.clusters');
+          const menu = $('.project-menu');
+          const clusters = $('.clusters');
 
           $(document).on('mousemove', this.boundMouseMove);
 
@@ -89,19 +89,19 @@ export default Component.extend(ThrottledResize, {
           clusters.on('focus', 'LI', this.boundEnterCluster);
           clusters.on('mouseenter', 'LI', this.boundEnterCluster);
 
-          this.$('.clusters, .projects').on('mouseenter', this.boundEnterScrollers);
-          this.$('.clusters, .projects').on('mouseleave', this.boundLeaveScrollers);
+          $('.clusters, .projects').on('mouseenter', this.boundEnterScrollers);
+          $('.clusters, .projects').on('mouseleave', this.boundLeaveScrollers);
 
-          this.$('.search INPUT')[0].focus();
+          $('.search INPUT')[0].focus();
 
-          this.$('.clusters UL')[0].scrollTop = 0;
-          this.$('.projects UL')[0].scrollTop = 0;
+          $('.clusters UL')[0].scrollTop = 0;
+          $('.projects UL')[0].scrollTop = 0;
 
           const currentClusterId = get(this, 'cluster.id');
           const currentProjectId = get(this, 'project.id');
 
           if ( currentClusterId ) {
-            const li = this.$(`.clusters LI[data-cluster-id="${ currentClusterId }"]`)[0];
+            const li = $(`.clusters LI[data-cluster-id="${ currentClusterId }"]`)[0];
             const entry = get(this, 'byCluster').findBy('clusterId', currentClusterId);
 
             ensureVisible(li);
@@ -114,7 +114,7 @@ export default Component.extend(ThrottledResize, {
 
           if ( currentProjectId ) {
             next(() => {
-              const li = this.$(`.projects LI[data-project-id="${ currentProjectId }"]`)[0];
+              const li = $(`.projects LI[data-project-id="${ currentProjectId }"]`)[0];
 
               ensureVisible(li);
             });
@@ -134,11 +134,11 @@ export default Component.extend(ThrottledResize, {
       });
 
       $(document).off('mousemove', this.boundMouseMove);
-      this.$('.project-menu').off('click', this.boundClickMenu);
-      this.$('.project-menu').off('click', 'LI', this.boundClickItem);
-      this.$('.clusters').off('mouseenter', 'LI', this.boundEnterCluster);
-      this.$('.clusters, .projects').off('mouseenter', this.boundEnterScrollers);
-      this.$('.clusters, .projects').off('mouseleave', this.boundLeaveScrollers);
+      $('.project-menu').off('click', this.boundClickMenu);
+      $('.project-menu').off('click', 'LI', this.boundClickItem);
+      $('.clusters').off('mouseenter', 'LI', this.boundEnterCluster);
+      $('.clusters, .projects').off('mouseenter', this.boundEnterScrollers);
+      $('.clusters, .projects').off('mouseleave', this.boundLeaveScrollers);
     },
   },
 
@@ -273,8 +273,8 @@ export default Component.extend(ThrottledResize, {
       const project      = 'project';
       const cluster      = 'cluster';
       const code         = e.keyCode;
-      let clusterTabList = this.$('.project-menu .clusters a:first-of-type');
-      let projectTabList = this.$('.project-menu .projects a:first-of-type')
+      let clusterTabList = $('.project-menu .clusters a:first-of-type');
+      let projectTabList = $('.project-menu .projects a:first-of-type')
       let tabList        = [];
       let $target        = $(e.target).hasClass('ember-basic-dropdown-trigger') ? $(e.target).find('a') : e.target;
       let currentFocusIndex;
@@ -285,7 +285,7 @@ export default Component.extend(ThrottledResize, {
       let { clusterEntry } = this;
 
       if (clusterEntry) {
-        activeClusterNode = this.$(`.project-menu [data-cluster-id="${ clusterEntry.clusterId }"]`);
+        activeClusterNode = $(`.project-menu [data-cluster-id="${ clusterEntry.clusterId }"]`);
       }
 
       if (clusterTabList.index($target) >= 0) {
@@ -445,7 +445,7 @@ export default Component.extend(ThrottledResize, {
   getHoverDelay() {
     const entry  = get(this, 'activeClusterEntry');
     const points = this.mousePoints;
-    const $menu  = this.$('.clusters');
+    const $menu  = $('.clusters');
 
     if ( !entry ) {
       // console.log('No entry');
@@ -536,7 +536,7 @@ export default Component.extend(ThrottledResize, {
 
         if ( scrollToId ) {
           next(() => {
-            const li = this.$(`.projects LI[data-project-id="${ scrollToId }"]`)[0];
+            const li = $(`.projects LI[data-project-id="${ scrollToId }"]`)[0];
 
             ensureVisible(li);
           });

--- a/app/components/page-header/component.js
+++ b/app/components/page-header/component.js
@@ -95,7 +95,7 @@ export default Component.extend({
 
   didInsertElement() {
     run.scheduleOnce('afterRender', this, function() {
-      this.get('router').on('willTransition', () => {
+      this.get('router').on('routeWillChange', () => {
         $('header > nav').removeClass('nav-open');// eslint-disable-line
       });
     });
@@ -181,7 +181,7 @@ export default Component.extend({
 
   keyUp(e) {
     const code            = e.keyCode;
-    let tabList           = this.$(`.nav-item a:first-of-type`);
+    let tabList           = $(`.nav-item a:first-of-type`);
     let $target           = $(e.target).hasClass('ember-basic-dropdown-trigger') ? $(e.target).find('a') : e.target;
     let currentFocusIndex = tabList.index($target);
     let nextIndex;

--- a/app/components/progress-bar-multi/component.js
+++ b/app/components/progress-bar-multi/component.js
@@ -1,6 +1,7 @@
 import { defineProperty, computed, get, observer } from '@ember/object';
 import Component from '@ember/component';
 import layout from './template';
+import $ from 'jquery';
 
 function toPercent(value, min, max) {
   value = Math.max(min, Math.min(max, value));
@@ -107,7 +108,7 @@ export default Component.extend({
   },
 
   zIndexDidChange: observer('zIndex', function() {
-    this.$().css('zIndex', get(this, 'zIndex') || 'inherit');
+    $().css('zIndex', get(this, 'zIndex') || 'inherit');
   }),
 
 });

--- a/app/components/settings/server-url/component.js
+++ b/app/components/settings/server-url/component.js
@@ -4,6 +4,7 @@ import { get, set } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import { next } from '@ember/runloop';
+import $ from 'jquery';
 
 const SCHEME = 'https://';
 
@@ -40,7 +41,7 @@ export default Component.extend({
         return;
       }
 
-      const elem = this.$('INPUT')[0]
+      const elem = $('INPUT')[0]
 
       if ( elem ) {
         elem.focus();

--- a/app/components/volume-source/source-custom-log-path/component.js
+++ b/app/components/volume-source/source-custom-log-path/component.js
@@ -1,4 +1,4 @@
-import { get, set } from '@ember/object';
+import { get, set, computed, observer } from '@ember/object';
 import Component from '@ember/component';
 import layout from './template';
 import VolumeSource from 'shared/mixins/volume-source';
@@ -44,11 +44,7 @@ export default Component.extend(VolumeSource, {
       set(this, 'useCustomRegex', !get(this, 'useCustomRegex'));
     },
   },
-  mount: function() {
-    return get(this, 'mounts').get('firstObject');
-  }.property('mounts.[]'),
-
-  useCustomRegexChange: function() {
+  useCustomRegexChange: observer('useCustomRegex', function() {
     const useCustomRegex = get(this, 'useCustomRegex');
 
     if (useCustomRegex) {
@@ -57,6 +53,10 @@ export default Component.extend(VolumeSource, {
     } else {
       set(this, 'config.options.format', get(this, 'cachedFormat'));
     }
-  }.observes('useCustomRegex'),
+  }),
+
+  mount: computed('mounts.[]', function() {
+    return get(this, 'mounts').get('firstObject');
+  }),
 
 });

--- a/app/containers/index/controller.js
+++ b/app/containers/index/controller.js
@@ -2,6 +2,7 @@ import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Controller, { inject as controller } from '@ember/controller';
 import { searchFields as containerSearchFields } from 'ui/components/pod-dots/component';
+import { computed } from '@ember/object';
 
 export const headers = [
   {
@@ -62,7 +63,7 @@ export default Controller.extend({
     },
   },
 
-  rows: function() {
+  rows: computed('group', 'model.workloads.@each.{namespaceId,isBalancer}', 'model.pods.@each.{workloadId,namespaceId}', function() {
     const groupBy = this.get('group');
     let out = [];
 
@@ -78,9 +79,9 @@ export default Controller.extend({
     }
 
     return out;
-  }.property('group', 'model.workloads.@each.{namespaceId,isBalancer}', 'model.pods.@each.{workloadId,namespaceId}'),
+  }),
 
-  groupByRef: function() {
+  groupByRef: computed('group', function() {
     const group = this.get('group');
 
     if (group === 'node') {
@@ -88,5 +89,5 @@ export default Controller.extend({
     } else if (group === 'namespace') {
       return 'namespace'
     }
-  }.property('group'),
+  }),
 });

--- a/app/ie/controller.js
+++ b/app/ie/controller.js
@@ -1,12 +1,13 @@
 import $ from 'jquery';
 import { schedule } from '@ember/runloop';
 import Controller from '@ember/controller';
+import { on } from '@ember/object/evented';
 
 export default Controller.extend({
-  bootstrap: function() {
+  bootstrap: on('init', function() {
     schedule('afterRender', this, () => {
       $('#loading-overlay').hide();
       $('#loading-underlay').hide();
     });
-  }.on('init')
+  })
 });

--- a/app/initializers/extend-ember-link.js
+++ b/app/initializers/extend-ember-link.js
@@ -1,5 +1,7 @@
 import LinkComponent from '@ember/routing/link-component';
-import { get } from '@ember/object'
+import { get } from '@ember/object';
+import { on } from '@ember/object/evented';
+import $ from 'jquery';
 
 export function initialize(/* application */) {
   LinkComponent.reopen({
@@ -9,20 +11,20 @@ export function initialize(/* application */) {
     // class to the parent element of that tag name (like <li>{{link-to}}</li>)
     activeParent: null,
 
-    addActiveObserver: function() {
+    addActiveObserver: on('didInsertElement', function() {
       if ( this.get('activeParent') ) {
         this.addObserver('active', this, 'activeChanged');
         this.addObserver('application.currentRouteName', this, 'activeChanged');
         this.activeChanged();
       }
-    }.on('didInsertElement'),
+    }),
 
     activeChanged() {
       if ( this.isDestroyed || this.isDestroying ) {
         return;
       }
 
-      const parent = this.$().closest(get(this, 'activeParent'));
+      const parent = $().closest(get(this, 'activeParent'));
 
       if ( !parent || !parent.length ) {
         return;

--- a/app/models/catalogtemplate.js
+++ b/app/models/catalogtemplate.js
@@ -2,38 +2,39 @@ import { inject as service } from '@ember/service';
 import Resource from '@rancher/ember-api-store/models/resource';
 import { parseExternalId } from 'ui/utils/parse-externalid';
 import C from 'ui/utils/constants';
+import { computed } from '@ember/object';
 
 export default Resource.extend({
   catalog: service(),
 
   type: 'catalogTemplate',
 
-  externalId: function() {
+  externalId: computed('templateVersionId', 'templateId', function() {
     let id = this.get('templateVersionId') || this.get('templateId');
 
     if ( id ) {
       return C.EXTERNAL_ID.KIND_CATALOG + C.EXTERNAL_ID.KIND_SEPARATOR + id;
     }
-  }.property('templateVersionId', 'templateId'),
+  }),
 
-  externalIdInfo: function() {
+  externalIdInfo: computed('externalId', function() {
     return parseExternalId(this.get('externalId'));
-  }.property('externalId'),
+  }),
 
   // These only works if the templates have already been loaded elsewhere...
-  catalogTemplate: function() {
+  catalogTemplate: computed('externalIdInfo.templateId', function() {
     return this.get('catalog').getTemplateFromCache(this.get('externalIdInfo.templateId'));
-  }.property('externalIdInfo.templateId'),
+  }),
 
-  icon: function() {
+  icon: computed('catalogTemplate', function() {
     let tpl = this.get('catalogTemplate');
 
     if ( tpl ) {
       return tpl.linkFor('icon');
     }
-  }.property('catalogTemplate'),
+  }),
 
-  categories: function() {
+  categories: computed('catalogTemplate.categories', function() {
     let tpl = this.get('catalogTemplate');
 
     if ( tpl ) {
@@ -41,5 +42,5 @@ export default Resource.extend({
     }
 
     return [];
-  }.property('catalogTemplate.categories'),
+  }),
 });

--- a/app/models/node.js
+++ b/app/models/node.js
@@ -227,7 +227,6 @@ var Node = Resource.extend(Grafana, StateCounts, ResourceUsage, {
       .split(/\s*,\s*/)
       .filter((x) => x.length > 0 && x !== C.LABEL.SYSTEM_TYPE);
   }),
-
   actions: {
     activate() {
       return this.doAction('activate');

--- a/app/models/pod.js
+++ b/app/models/pod.js
@@ -84,9 +84,9 @@ var Pod = Resource.extend(Grafana, DisplayImage, {
     }
   }),
 
-  isOn: function() {
+  isOn: computed('state', function() {
     return ['running', 'migrating', 'restarting'].indexOf(get(this, 'state')) >= 0;
-  }.property('state'),
+  }),
 
   displayState: computed('_displayState', 'exitCode', function() {
     let out = get(this, '_displayState');
@@ -113,9 +113,9 @@ var Pod = Resource.extend(Grafana, DisplayImage, {
     return envs;
   }),
 
-  displayIp: function() {
+  displayIp: computed('status.podIp', function() {
     return get(this, 'status.podIp') || null;
-  }.property('status.podIp'),
+  }),
 
   dislayContainerMessage: computed('containers.@each.showTransitioningMessage', function() {
     return !!get(this, 'containers').findBy('showTransitioningMessage', true);
@@ -131,11 +131,11 @@ var Pod = Resource.extend(Grafana, DisplayImage, {
     return out;
   }),
 
-  nodeIp: function() {
+  nodeIp: computed('status.nodeIp', function() {
     return get(this, 'status.nodeIp') || null;
-  }.property('status.nodeIp'),
+  }),
 
-  sortIp: function() {
+  sortIp: computed('primaryIpAddress', 'primaryAssociatedIpAddress', function() {
     var ip = get(this, 'primaryAssociatedIpAddress') || get(this, 'primaryIpAddress');
 
     if ( !ip ) {
@@ -147,11 +147,11 @@ var Pod = Resource.extend(Grafana, DisplayImage, {
       return match.slice(1).map((octet) => strPad(octet, 3, '0', false))
         .join('.');
     }
-  }.property('primaryIpAddress', 'primaryAssociatedIpAddress'),
+  }),
 
-  isGlobalScale: function() {
+  isGlobalScale: computed('labels', function() {
     return `${ (get(this, 'labels') || {})[C.LABEL.SCHED_GLOBAL]  }` === 'true';
-  }.property('labels'),
+  }),
 
   actions: {
     clone() {

--- a/app/models/port.js
+++ b/app/models/port.js
@@ -1,9 +1,10 @@
 import Resource from '@rancher/ember-api-store/models/resource';
+import { computed } from '@ember/object';
 
 var Port = Resource.extend({
   _publicIp:       null,
   _publicIpState:  null,
-  displayPublicIp: function() {
+  displayPublicIp: computed('_publicIpState', '_publicIp', 'publicIpAddressId', 'bindAddress', 'publicPort', function() {
     var bind = this.get('bindAddress');
 
     if ( bind ) {
@@ -32,7 +33,7 @@ var Port = Resource.extend({
     }
 
     return null;
-  }.property('_publicIpState', '_publicIp', 'publicIpAddressId', 'bindAddress', 'publicPort'),
+  }),
 });
 
 export default Port;

--- a/app/models/scalehost.js
+++ b/app/models/scalehost.js
@@ -1,7 +1,8 @@
 import Resource from '@rancher/ember-api-store/models/resource';
+import { computed } from '@ember/object';
 
 export default Resource.extend({
-  hostSelectorStr: function() {
+  hostSelectorStr: computed('hostSelector', function() {
     let all = this.get('hostSelector') || [];
 
     return Object.keys(all).map((key) => {
@@ -10,7 +11,7 @@ export default Resource.extend({
       return key + (val ? `=${  val }` : '');
     })
       .join(', ');
-  }.property('hostSelector'),
+  }),
 
   validationErrors() {
     let errors = this._super(...arguments);

--- a/app/models/sourcecodecredential.js
+++ b/app/models/sourcecodecredential.js
@@ -1,15 +1,15 @@
 import Resource from '@rancher/ember-api-store/models/resource';
-import { get } from '@ember/object';
+import { get, computed } from '@ember/object';
 
 export default Resource.extend({
   type:     'sourcecodecredential',
-  username: function(){
+  username: computed('displayName', function(){
     return get(this, 'displayName');
-  }.property('displayName'),
-  profilePicture: function(){
+  }),
+  profilePicture: computed('avatarUrl', function(){
     return get(this, 'avatarUrl');
-  }.property('avatarUrl'),
-  profileUrl: function(){
+  }),
+  profileUrl: computed('htmlUrl', function(){
     return get(this, 'htmlUrl');
-  }.property('htmlUrl'),
+  }),
 });

--- a/app/models/workload.js
+++ b/app/models/workload.js
@@ -76,7 +76,7 @@ var Workload = Resource.extend(Grafana, DisplayImage, StateCounts, EndpointPorts
     return !!get(this, 'links.update') && ( lcType !== 'job' );
   }),
 
-  availableActions: function() {
+  availableActions: computed('actionLinks.{activate,deactivate,pause,restart,rollback,garbagecollect}', 'links.{update,remove}', 'podForShell', 'isPaused', 'canEdit', function() {
     const a = get(this, 'actionLinks') || {};
 
     const podForShell = get(this, 'podForShell');
@@ -130,21 +130,19 @@ var Workload = Resource.extend(Grafana, DisplayImage, StateCounts, EndpointPorts
     ];
 
     return choices;
-  }.property('actionLinks.{activate,deactivate,pause,restart,rollback,garbagecollect}', 'links.{update,remove}',
-    'podForShell', 'isPaused', 'canEdit'
-  ),
+  }),
 
-  displayType: function() {
+  displayType: computed('type', function() {
     let type = this.get('type');
 
     return get(this, 'intl').t(`servicePage.serviceType.${ type }`);
-  }.property('type'),
+  }),
 
-  sortName: function() {
+  sortName: computed('displayName', function() {
     return sortableNumericSuffix(get(this, 'displayName'));
-  }.property('displayName'),
+  }),
 
-  combinedState: function() {
+  combinedState: computed('state', 'healthState', function() {
     var service = get(this, 'state');
     var health = get(this, 'healthState');
 
@@ -155,25 +153,25 @@ var Workload = Resource.extend(Grafana, DisplayImage, StateCounts, EndpointPorts
 
     // Return the service for anything else
     return service;
-  }.property('state', 'healthState'),
+  }),
 
-  isGlobalScale: function() {
+  isGlobalScale: computed('lcType', function() {
     let lcType = get(this, 'lcType');
 
     return lcType === 'daemonset';
-  }.property('lcType'),
+  }),
 
-  canScaleDown: function() {
+  canScaleDown: computed('canScale', 'scale', function() {
     return get(this, 'canScale') && get(this, 'scale') > 0;
-  }.property('canScale', 'scale'),
+  }),
 
-  displayScale: function() {
+  displayScale: computed('scale', 'isGlobalScale', 'lcType', function() {
     if ( get(this, 'isGlobalScale') ) {
       return get(this, 'intl').t('servicePage.multistat.daemonSetScale');
     } else {
       return get(this, 'scale');
     }
-  }.property('scale', 'isGlobalScale', 'lcType'),
+  }),
 
   canScale: computed('lcType', function() {
     let lcType = get(this, 'lcType');
@@ -181,9 +179,9 @@ var Workload = Resource.extend(Grafana, DisplayImage, StateCounts, EndpointPorts
     return lcType !== 'cronjob' && lcType !== 'daemonset' && lcType !== 'job';
   }),
 
-  activeIcon: function() {
+  activeIcon: computed('lcType', function() {
     return activeIcon(this);
-  }.property('lcType'),
+  }),
 
   memoryReservationBlurb: computed('launchConfig.memoryReservation', function() {
     if ( get(this, 'launchConfig.memoryReservation') ) {

--- a/lib/alert/addon/components/alert-select/component.js
+++ b/lib/alert/addon/components/alert-select/component.js
@@ -4,6 +4,7 @@ import { next } from '@ember/runloop';
 import {
   get, set, computed, observer, setProperties
 } from '@ember/object';
+import $ from 'jquery';
 
 const MAX_HEIGHT = 285;
 
@@ -19,13 +20,13 @@ export default Select.extend({
         return;
       }
 
-      const toBottom = $('body').height() - $(this.$()[0]).offset().top - 60; // eslint-disable-line
+      const toBottom = $('body').height() - $($()[0]).offset().top - 60; // eslint-disable-line
 
       set(this, 'maxHeight', toBottom < MAX_HEIGHT ? toBottom : MAX_HEIGHT)
 
       next(() => {
-        const checked = this.$('.searchable-option .icon-check');
-        const options = this.$('.searchable-options');
+        const checked = $('.searchable-option .icon-check');
+        const options = $('.searchable-options');
 
         if ( options.length && checked.length ) {
           options.animate({ scrollTop: `${ checked.parent().offset().top - options.offset().top }px` });
@@ -167,7 +168,7 @@ export default Select.extend({
     }
 
     next(() => {
-      const input = this.$('.input-search');
+      const input = $('.input-search');
 
       if ( input ) {
         input.focus();

--- a/lib/global-admin/addon/components/form-fsgroup-policy/component.js
+++ b/lib/global-admin/addon/components/form-fsgroup-policy/component.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import layout from './template';
+import { observer } from '@ember/observer';
 
 export default Component.extend({
   globalStore: service(),
@@ -44,7 +45,7 @@ export default Component.extend({
     },
   },
 
-  ruleDidChange: function() {
+  ruleDidChange: observer('model.fsGroup.rule', function() {
     const rule = this.get('model.fsGroup.rule');
 
     if (rule === 'MustRunAs') {
@@ -53,6 +54,6 @@ export default Component.extend({
     } else {
       this.set('model.fsGroup.ranges', null);
     }
-  }.observes('model.fsGroup.rule'),
+  }),
 
 });

--- a/lib/global-admin/addon/components/form-hostpath-policy/component.js
+++ b/lib/global-admin/addon/components/form-hostpath-policy/component.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import layout from './template';
+import { observer } from '@ember/object'
 
 
 export default Component.extend({
@@ -44,8 +45,8 @@ export default Component.extend({
     },
   },
 
-  pathDidChange: function() {
+  pathDidChange: observer('paths.@each.pathPrefix', function() {
     this.set('model.allowedHostPaths', this.get('paths').filter((p) => p.pathPrefix));
-  }.observes('paths.@each.pathPrefix'),
+  }),
 
 });

--- a/lib/global-admin/addon/components/form-runasuser-policy/component.js
+++ b/lib/global-admin/addon/components/form-runasuser-policy/component.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import layout from './template';
+import { observer } from '@ember/object';
 
 export default Component.extend({
   globalStore: service(),
@@ -45,7 +46,7 @@ export default Component.extend({
     },
   },
 
-  ruleDidChange: function() {
+  ruleDidChange: observer('model.runAsUser.rule', function() {
     const rule = this.get('model.runAsUser.rule');
 
     if (rule === 'MustRunAs') {
@@ -54,6 +55,6 @@ export default Component.extend({
     } else {
       this.set('model.runAsUser.ranges', null);
     }
-  }.observes('model.runAsUser.rule'),
+  }),
 
 });

--- a/lib/global-admin/addon/components/form-selinux-policy/component.js
+++ b/lib/global-admin/addon/components/form-selinux-policy/component.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import layout from './template';
+import { observer } from '@ember/object';
 
 export default Component.extend({
   globalStore: service(),
@@ -29,7 +30,7 @@ export default Component.extend({
     }
   },
 
-  ruleDidChange: function() {
+  ruleDidChange: observer('model.seLinux.rule', function() {
     const rule = this.get('model.seLinux.rule');
 
     if (rule === 'RunAsAny') {
@@ -44,6 +45,6 @@ export default Component.extend({
         }));
       }
     }
-  }.observes('model.seLinux.rule'),
+  }),
 
 });

--- a/lib/global-admin/addon/components/form-supplementalgroups-policy/component.js
+++ b/lib/global-admin/addon/components/form-supplementalgroups-policy/component.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import layout from './template';
+import { observer } from '@ember/object';
 
 export default Component.extend({
   globalStore: service(),
@@ -44,7 +45,7 @@ export default Component.extend({
     },
   },
 
-  ruleDidChange: function() {
+  ruleDidChange: observer('model.supplementalGroups.rule', function() {
     const rule = this.get('model.supplementalGroups.rule');
 
     if (rule === 'MustRunAs') {
@@ -53,6 +54,6 @@ export default Component.extend({
     } else {
       this.set('model.supplementalGroups.ranges', null);
     }
-  }.observes('model.supplementalGroups.rule'),
+  }),
 
 });

--- a/lib/global-admin/addon/components/new-multi-cluster-app/component.js
+++ b/lib/global-admin/addon/components/new-multi-cluster-app/component.js
@@ -17,6 +17,7 @@ import { isEmpty } from '@ember/utils';
 import CatalogApp from 'shared/mixins/catalog-app';
 import { all } from 'rsvp';
 import { evaluate } from 'shared/utils/evaluate';
+import $ from 'jquery';
 
 const OVERRIDE_HEADERS = [
   {
@@ -724,11 +725,11 @@ export default Component.extend(NewOrEdit, CatalogApp, {
     if (!this.get('srcSet')) {
       set(this, 'srcSet', true);
 
-      const $icon = this.$('img');
+      const $icon = $('img');
 
       $icon.attr('src', $icon.data('src'));
 
-      this.$('img').on('error', () => {
+      $('img').on('error', () => {
         $icon.attr('src', `${ this.get('app.baseAssets') }assets/images/generic-catalog.svg`);
       });
     }

--- a/lib/global-admin/addon/security/authentication/shibboleth/controller.js
+++ b/lib/global-admin/addon/security/authentication/shibboleth/controller.js
@@ -1,4 +1,4 @@
-import EmberObject from '@ember/object';
+import { default as EmberObject, computed } from '@ember/object';
 import { later } from '@ember/runloop';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
@@ -99,13 +99,13 @@ export default Controller.extend({
     },
 
   },
-  numUsers:       function() {
+  numUsers: computed('model.allowedIdentities.@each.externalIdType', 'wasRestricted', function() {
     return (this.get('model.allowedIdentities') || []).filterBy('externalIdType', C.PROJECT.TYPE_SHIBBOLETH_USER).get('length');
-  }.property('model.allowedIdentities.@each.externalIdType', 'wasRestricted'),
+  }),
 
-  numOrgs: function() {
+  numOrgs: computed('model.allowedIdentities.@each.externalIdType', 'wasRestricted', function() {
     return (this.get('model.allowedIdentities') || []).filterBy('externalIdType', C.PROJECT.TYPE_SHIBBOLETH_GROUP).get('length');
-  }.property('model.allowedIdentities.@each.externalIdType', 'wasRestricted'),
+  }),
   validate() {
     let model = EmberObject.create(this.get('config'));
     let errors = [];

--- a/lib/istio/addon/components/form-labels/component.js
+++ b/lib/istio/addon/components/form-labels/component.js
@@ -2,6 +2,7 @@ import { next } from '@ember/runloop';
 import Component from '@ember/component';
 import ManageLabels from 'shared/mixins/manage-labels';
 import layout from './template';
+import $ from 'jquery';
 
 export default Component.extend(ManageLabels, {
   layout,
@@ -27,7 +28,7 @@ export default Component.extend(ManageLabels, {
           return;
         }
 
-        this.$('INPUT.key').last()[0].focus();
+        $('INPUT.key').last()[0].focus();
       });
     },
   },

--- a/lib/istio/addon/components/modal-delete-istio/component.js
+++ b/lib/istio/addon/components/modal-delete-istio/component.js
@@ -5,6 +5,7 @@ import Component from '@ember/component';
 import ModalBase from 'ui/mixins/modal-base';
 import layout from './template';
 import { all as PromiseAll } from 'rsvp';
+import $ from 'jquery';
 
 export default Component.extend(ModalBase, {
   settings:       service(),
@@ -23,7 +24,7 @@ export default Component.extend(ModalBase, {
   didRender() {
     setTimeout(() => {
       try {
-        this.$('BUTTON')[0].focus();
+        $('BUTTON')[0].focus();
       } catch (e) {}
     }, 500);
   },

--- a/lib/logging/addon/components/logging/form-log-format/component.js
+++ b/lib/logging/addon/components/logging/form-log-format/component.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { observer } from '@ember/object';
 import { reads } from '@ember/object/computed';
+import $ from 'jquery';
 
 export default Component.extend({
   scope:                   service(),
@@ -13,8 +14,8 @@ export default Component.extend({
   }),
 
   setCodeBlockHeight() {
-    const h = this.$('.additional-logging-configuration-content').height() + 12;
+    const h = $('.additional-logging-configuration-content').height() + 12;
 
-    this.$('.logging-format pre').height(`${ h  }px`);
+    $('.logging-format pre').height(`${ h  }px`);
   },
 });

--- a/lib/logging/addon/components/logging/input-logging-config/component.js
+++ b/lib/logging/addon/components/logging/input-logging-config/component.js
@@ -7,6 +7,7 @@ import { get, set, observer, computed } from '@ember/object';
 import ThrottledResize from 'shared/mixins/throttled-resize';
 import { alias } from '@ember/object/computed'
 import C from 'ui/utils/constants';
+import $ from 'jquery';
 
 export default Component.extend(ThrottledResize, {
   settings:         service(),
@@ -46,7 +47,7 @@ export default Component.extend(ThrottledResize, {
 
   actions: {
     click() {
-      this.$('INPUT[type=file]')[0].click();
+      $('INPUT[type=file]')[0].click();
     },
 
     updateValue(value) {
@@ -270,7 +271,7 @@ ${ fieldsStr }
 
   fit() {
     if ( get(this, 'autoResize') ) {
-      var container = this.$('.codemirror-container');
+      var container = $('.codemirror-container');
 
       if ( !container ) {
         return;
@@ -282,7 +283,7 @@ ${ fieldsStr }
         return;
       }
 
-      const desired = this.$(window).height() - position.top - get(this, 'resizeFooter');
+      const desired = $(window).height() - position.top - get(this, 'resizeFooter');
 
       container.css('max-height', Math.max(get(this, 'minHeight'), desired));
     }

--- a/lib/logging/addon/components/logging/target-elasticsearch/component.js
+++ b/lib/logging/addon/components/logging/target-elasticsearch/component.js
@@ -3,6 +3,7 @@ import es from 'logging/mixins/target-elasticsearch';
 import { get, computed, setProperties, set } from '@ember/object';
 import { alias } from '@ember/object/computed'
 import parseUri from 'shared/utils/parse-uri';
+import $ from 'jquery';
 
 const endpointText = {
   hostError:     'loggingPage.elasticsearch.endpointHostError',
@@ -17,7 +18,7 @@ export default Component.extend(es, {
   config:        alias('model.config'),
   sslVerify:     alias('model.config.sslVerify'),
   didInsertElement() {
-    this.$('#elasticsearch-endpoint').focus()
+    $('#elasticsearch-endpoint').focus()
   },
 
   actions: {

--- a/lib/logging/addon/components/logging/target-flentd/component.js
+++ b/lib/logging/addon/components/logging/target-flentd/component.js
@@ -3,6 +3,7 @@ import Component from '@ember/component';
 import { alias } from '@ember/object/computed'
 import parseUri from 'shared/utils/parse-uri';
 import { inject as service } from '@ember/service';
+import $ from 'jquery';
 
 const endpointText = {
   hostError:     'loggingPage.fluentd.endpointHostError',
@@ -32,7 +33,7 @@ export default Component.extend({
   },
 
   didInsertElement() {
-    this.$('.fluentd-endpoint:first').focus()
+    $('.fluentd-endpoint:first').focus()
   },
 
   didUpdateAttrs() {

--- a/lib/logging/addon/components/logging/target-kafka/component.js
+++ b/lib/logging/addon/components/logging/target-kafka/component.js
@@ -4,6 +4,7 @@ import {
   get, set, computed, setProperties, observer
 } from '@ember/object'
 import { inject as service } from '@ember/service';
+import $ from 'jquery';
 
 export default Component.extend({
   scope:            service(),
@@ -42,7 +43,7 @@ export default Component.extend({
   },
 
   didInsertElement() {
-    this.$('#kafka-endpoint').focus()
+    $('#kafka-endpoint').focus()
   },
 
   actions: {

--- a/lib/logging/addon/components/logging/target-splunk/component.js
+++ b/lib/logging/addon/components/logging/target-splunk/component.js
@@ -1,13 +1,14 @@
 import { get, computed } from '@ember/object';
 import Component from '@ember/component';
 import { alias } from '@ember/object/computed'
+import $ from 'jquery';
 
 export default Component.extend({
   showAdvanced: false,
 
   config:        alias('model.config'),
   didInsertElement() {
-    this.$('#splunk-endpoint').focus()
+    $('#splunk-endpoint').focus()
   },
 
   enableSSLConfig: computed('config.endpoint', function() {

--- a/lib/logging/addon/components/logging/target-syslog/component.js
+++ b/lib/logging/addon/components/logging/target-syslog/component.js
@@ -2,6 +2,7 @@ import Component from '@ember/component'
 import { alias } from '@ember/object/computed'
 import { get, set, computed, setProperties } from '@ember/object'
 import moment from 'moment';
+import $ from 'jquery';
 
 const SEVERITIES = [
   {
@@ -54,7 +55,7 @@ export default Component.extend({
   },
 
   didInsertElement() {
-    this.$('#syslog-endpoint').focus()
+    $('#syslog-endpoint').focus()
   },
 
   didReceiveAttrs() {

--- a/lib/logging/addon/components/logging/targets-nav/component.js
+++ b/lib/logging/addon/components/logging/targets-nav/component.js
@@ -15,7 +15,7 @@ export default Component.extend({
     return targetType === 'fluentForwarder' ? 'fluentd output forward' : targetType
   }),
 
-  hasCurrentTarget: function() {
+  hasCurrentTarget: computed('currentTarget', function() {
     const ol = this.get('originalModel');
 
     if (!ol) {
@@ -24,7 +24,7 @@ export default Component.extend({
     const currentTarget = this.get('currentTarget');
 
     return  currentTarget && currentTarget !== 'none';
-  }.property('currentTarget'),
+  }),
 
   targets: computed('isClusterLevel', 'currentTarget', function() {
     return [

--- a/lib/logging/addon/mixins/target-elasticsearch.js
+++ b/lib/logging/addon/mixins/target-elasticsearch.js
@@ -1,7 +1,7 @@
 import Mixin from '@ember/object/mixin';
 import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';
-import { get, set } from '@ember/object'
+import { get, set, computed } from '@ember/object'
 import moment from 'moment';
 
 export default Mixin.create({
@@ -20,7 +20,7 @@ export default Mixin.create({
     }
   },
 
-  defaultIndexPrefix: function() {
+  defaultIndexPrefix: computed('project.name', 'cluster.name', function() {
     const pageScope = get(this, 'pageScope')
     const prefix = get(this, 'cluster.name') || get(this, 'cluster.id');
 
@@ -29,9 +29,9 @@ export default Mixin.create({
     } else {
       return `${ prefix  }_${  get(this, 'project.name') }`.toLowerCase();
     }
-  }.property('project.name', 'cluster.name'),
+  }),
 
-  logPreview: function() {
+  logPreview: computed('esIndex', 'outputTags', function() {
     const index = get(this, 'esIndex');
     const outputTags = get(this, 'outputTags');
     const template = `{
@@ -56,9 +56,9 @@ ${ outputTags }
 }`;
 
     return template
-  }.property('esIndex', 'outputTags'),
+  }),
 
-  outputTags: function() {
+  outputTags: computed('model.outputTags', function() {
     const keyValueMap = get(this, 'model.outputTags');
 
     if (!keyValueMap) {
@@ -66,15 +66,15 @@ ${ outputTags }
     }
 
     return Object.keys(keyValueMap).map((key) => `    "${ key }": "${ keyValueMap[key] }"`).join(',\n');
-  }.property('model.outputTags'),
+  }),
 
-  dateFormatString: function() {
+  dateFormatString: computed('config.dateFormat', function() {
     const fmt = this.get('config.dateFormat');
 
     return moment().format(fmt);
-  }.property('config.dateFormat'),
+  }),
 
-  esIndex: function() {
+  esIndex: computed('config.indexPrefix', 'dateFormatString', function() {
     return `${ get(this, 'config.indexPrefix')  }-${  get(this, 'dateFormatString') }`;
-  }.property('config.indexPrefix', 'dateFormatString'),
+  }),
 });

--- a/lib/login/addon/components/login-user-pass/component.js
+++ b/lib/login/addon/components/login-user-pass/component.js
@@ -3,6 +3,7 @@ import { next } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import C from 'ui/utils/constants';
+import $ from 'jquery';
 
 export default Component.extend({
   access:  service(),
@@ -117,10 +118,10 @@ export default Component.extend({
       return;
     }
 
-    let elem = this.$('#login-username');
+    let elem = $('#login-username');
 
     if ( get(this, 'username') ) {
-      elem = this.$('#login-password');
+      elem = $('#login-password');
     }
 
     if ( elem && elem[0] ) {

--- a/lib/nodes/addon/components/driver-exoscale/component.js
+++ b/lib/nodes/addon/components/driver-exoscale/component.js
@@ -3,6 +3,7 @@ import Driver from 'shared/mixins/node-driver';
 import { get, set } from '@ember/object';
 import { ajaxPromise } from '@rancher/ember-api-store/utils/ajax-promise';
 import Component from '@ember/component';
+import { on } from '@ember/object/evented';
 import layout from './template';
 import { eachSeries } from 'async';
 
@@ -300,7 +301,7 @@ export default Component.extend(Driver, {
     }
   },
 
-  afterInit: function() {
+  afterInit: on('init', function() {
     this._super();
 
     let cur = get(this, 'config.securityGroup');
@@ -316,7 +317,7 @@ export default Component.extend(Driver, {
         securityGroup:      [cur]
       });
     }
-  }.on('init'),
+  }),
 
   bootstrap() {
     let config = get(this, 'globalStore').createRecord({

--- a/lib/pipeline/addon/components/log-view/component.js
+++ b/lib/pipeline/addon/components/log-view/component.js
@@ -4,6 +4,7 @@ import { set, get, observer } from '@ember/object';
 import ThrottledResize from 'shared/mixins/throttled-resize';
 import C from 'shared/utils/pipeline-constants';
 import { inject as service } from '@ember/service';
+import $ from 'jquery';
 
 export default Component.extend(ThrottledResize, {
   scope:      service(),
@@ -33,11 +34,11 @@ export default Component.extend(ThrottledResize, {
 
   actions: {
     scrollToBottom() {
-      this.$('.anchor-bottom')[0].scrollIntoView(false);
+      $('.anchor-bottom')[0].scrollIntoView(false);
     },
 
     scrollToTop() {
-      this.$('.anchor-top')[0].scrollIntoView(true);
+      $('.anchor-top')[0].scrollIntoView(true);
     },
 
     toggleLogMode() {
@@ -81,7 +82,7 @@ export default Component.extend(ThrottledResize, {
   },
 
   connect() {
-    var body = this.$('.log-body')[0];
+    var body = $('.log-body')[0];
     var $body = $(body); // eslint-disable-line
 
     $body.empty();
@@ -149,9 +150,9 @@ export default Component.extend(ThrottledResize, {
 
   onResize() {
     const amount = get(this, 'activity.amount')
-    this.$('.log-body').css('min-height', Math.max(($(window).height() - get(this, 'logHeight'))) + 'px'); // eslint-disable-line
+    $('.log-body').css('min-height', Math.max(($(window).height() - get(this, 'logHeight'))) + 'px'); // eslint-disable-line
     if (amount) {
-      this.$('.log-body').css('min-height', `${ (amount.countStep + amount.countStage) * 82  }px`);
+      $('.log-body').css('min-height', `${ (amount.countStep + amount.countStage) * 82  }px`);
     }
   },
 

--- a/lib/pipeline/addon/components/pipeline-input-var-hint/component.js
+++ b/lib/pipeline/addon/components/pipeline-input-var-hint/component.js
@@ -4,6 +4,7 @@ import { singleton } from 'shared/utils/pipelineStep';
 import { set, get } from '@ember/object';
 import { htmlSafe } from '@ember/string';
 import { computed } from '@ember/object';
+import $ from 'jquery';
 
 export default Component.extend({
   codeMirror: service(),
@@ -24,7 +25,7 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
     singleton.hintAry = get(this, 'hintAry');
-    this.$(document).on('keyup.hint', 'input:not(.js-disable-hint)', (e) => {
+    $(document).on('keyup.hint', 'input:not(.js-disable-hint)', (e) => {
       $.fn.E_INPUT_HINT.startHint(e.target, ( /* hint*/ ) => {});
     });
   },
@@ -65,18 +66,18 @@ export default Component.extend({
 
       var originalCoordinates = get(this, 'originalCoordinates');
 
-      this.showHint(originalCoordinates.top - this.$(window).scrollTop(), originalCoordinates.left);
+      this.showHint(originalCoordinates.top - $(window).scrollTop(), originalCoordinates.left);
     };
 
-    this.$(document).on('click.hint', clickHiden).on('scroll.hint', scrollPosition);
+    $(document).on('click.hint', clickHiden).on('scroll.hint', scrollPosition);
   },
 
   willDestroyElement() {
     this._super();
-    this.$(document).off('click.hint');
-    this.$(document).off('scroll.hint');
-    this.$(document).off('keyup.hint');
-    this.$(document).off('keyup.hint-return');
+    $(document).off('click.hint');
+    $(document).off('scroll.hint');
+    $(document).off('keyup.hint');
+    $(document).off('keyup.hint-return');
   },
 
   actions: {
@@ -157,7 +158,7 @@ export default Component.extend({
       return false;
     }
 
-    var $el = this.$(el);
+    var $el = $(el);
     var value = $el.val();
     var cursorPosition = $el.getCursorPosition();
 
@@ -187,7 +188,7 @@ export default Component.extend({
 
         set(this, 'matchedArry', matchedArry);
         var cursorCoordinates = this.getCursorCoordinates(cursorValue);
-        var oT = this.$(window).scrollTop();
+        var oT = $(window).scrollTop();
         var originalCoordinates = {
           top:  offset.top + cursorCoordinates.y,
           left: offset.left + cursorCoordinates.x

--- a/lib/shared/addon/all-dns-records/service.js
+++ b/lib/shared/addon/all-dns-records/service.js
@@ -1,4 +1,4 @@
-import { get, set } from '@ember/object';
+import { get, set, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import Service, { inject as service } from '@ember/service';
 
@@ -32,17 +32,17 @@ export default Service.extend({
     set(this, '_allDnsRecords', store.all('service'));
   },
 
-  dnsRecords: function() {
+  dnsRecords: computed('_allDnsRecords.@each.{id,namespaceId,displayName,type}', function() {
     const intl = get(this, 'intl');
 
     return get(this, '_allDnsRecords').filter((x) => get(x, 'ownerReferences.firstObject.kind') !== 'Ingress').map((x) => convert(x, intl)).sortBy('combined');
-  }.property('_allDnsRecords.@each.{id,namespaceId,displayName,type}'),
+  }),
 
   list: alias('dnsRecords'),
 
-  grouped: function() {
+  grouped: computed('list.[]', function() {
     return this.group(get(this, 'list'));
-  }.property('list.[]'),
+  }),
 
   byId(id) {
     return get(this, '_allDnsRecords').findBy('id', id);

--- a/lib/shared/addon/all-workloads/service.js
+++ b/lib/shared/addon/all-workloads/service.js
@@ -1,4 +1,4 @@
-import { get, set } from '@ember/object';
+import { get, set, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import Service, { inject as service } from '@ember/service';
 
@@ -33,36 +33,36 @@ export default Service.extend({
     set(this, '_allPods', store.all('pod'));
   },
 
-  workloads: function() {
+  workloads: computed('_allWorkloads.@each.{id,namespaceId,displayName,type}', function() {
     const intl = get(this, 'intl');
 
     return get(this, '_allWorkloads').map((x) => convert(x, intl)).sortBy('combined');
-  }.property('_allWorkloads.@each.{id,namespaceId,displayName,type}'),
+  }),
 
-  pods: function() {
+  pods: computed('_allPods.@each.{id,namespaceId,displayName,type}', function() {
     const intl = get(this, 'intl');
 
     return get(this, '_allPods').map((x) => convert(x, intl)).sortBy('combined');
-  }.property('_allPods.@each.{id,namespaceId,displayName,type}'),
+  }),
 
   list: alias('workloads'),
 
-  listWithPods: function() {
+  listWithPods: computed('workloads', 'pods', function() {
     const intl = get(this, 'intl');
     const out = get(this, '_allWorkloads').map((x) => convert(x, intl));
 
     out.pushObjects(get(this, '_allPods').map((x) => convert(x, intl)));
 
     return out.sortBy('combined');
-  }.property('workloads', 'pods'),
+  }),
 
-  grouped: function() {
+  grouped: computed('list.[]', function() {
     return this.group(get(this, 'list'));
-  }.property('list.[]'),
+  }),
 
-  groupedWithPods: function() {
+  groupedWithPods: computed('listWithPods.[]', function() {
     return this.group(get(this, 'listWithPods'));
-  }.property('listWithPods.[]'),
+  }),
 
   byId(id) {
     return this.get('_allWorkloads').findBy('id', id);

--- a/lib/shared/addon/components/action-menu-item/component.js
+++ b/lib/shared/addon/components/action-menu-item/component.js
@@ -3,6 +3,7 @@ import layout from './template';
 import { inject as service } from '@ember/service'
 import C from 'shared/utils/constants';
 import { isAlternate } from 'shared/utils/platform';
+import { observer } from '@ember/object';
 
 export default Component.extend({
   resourceActions: service('resource-actions'),
@@ -29,9 +30,9 @@ export default Component.extend({
   },
 
 
-  iconChanged: function() {
+  iconChanged: observer('icon', function() {
     this.rerender();
-  }.observes('icon'),
+  }),
 
   click(event) {
     let actionArg = null;

--- a/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
@@ -7,6 +7,7 @@ import {
 } from '@ember/object';
 import { Promise, resolve } from 'rsvp';
 import { equal } from '@ember/object/computed';
+import $ from 'jquery';
 
 const REGIONS = ['us-east-2', 'us-east-1', 'us-west-2', 'ap-east-1', 'ap-south-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-southeast-1', 'ap-southeast-2', 'me-south-1', 'eu-central-1', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'eu-north-1'];
 const RANCHER_GROUP         = 'rancher-nodes';
@@ -77,7 +78,7 @@ export default Component.extend(ClusterDriver, {
 
   actions: {
     multiSecurityGroupSelect() {
-      let options = Array.prototype.slice.call(this.$('.existing-security-groups')[0], 0);
+      let options = Array.prototype.slice.call($('.existing-security-groups')[0], 0);
       let selectedOptions = [];
 
       options.filterBy('selected', true).forEach((cap) => {
@@ -88,7 +89,7 @@ export default Component.extend(ClusterDriver, {
     },
 
     multiSubnetGroupSelect() {
-      let options = Array.prototype.slice.call(this.$('.existing-subnet-groups')[0], 0);
+      let options = Array.prototype.slice.call($('.existing-subnet-groups')[0], 0);
       let selectedOptions = [];
 
       options.filterBy('selected', true).forEach((cap) => {

--- a/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
@@ -9,6 +9,7 @@ import { sortableNumericSuffix } from 'shared/utils/util';
 import { reject, all } from 'rsvp';
 import { inject as service } from '@ember/service';
 import { equal } from '@ember/object/computed'
+import $ from 'jquery';
 
 const times = [
   {
@@ -210,7 +211,7 @@ export default Component.extend(ClusterDriver, {
 
   actions: {
     clickNext() {
-      this.$('BUTTON[type="submit"]').click();
+      $('BUTTON[type="submit"]').click();
     },
 
     checkServiceAccount(cb) {

--- a/lib/shared/addon/components/cluster-driver/driver-huaweicce/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-huaweicce/component.js
@@ -7,6 +7,7 @@ import {
   get, set, computed, observer, setProperties
 } from '@ember/object';
 import { inject as service } from '@ember/service';
+import $ from 'jquery';
 
 export default Component.extend(ClusterDriver, {
   intl:        service(),
@@ -217,7 +218,7 @@ export default Component.extend(ClusterDriver, {
 
   actions: {
     multiEipSelect() {
-      let options = Array.prototype.slice.call(this.$('.existing-eips')[0], 0);
+      let options = Array.prototype.slice.call($('.existing-eips')[0], 0);
       let selectedOptions = [];
 
       options.filterBy('selected', true).forEach((cap) => {

--- a/lib/shared/addon/components/code-block/component.js
+++ b/lib/shared/addon/components/code-block/component.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import layout from './template';
-import { observer } from '@ember/object'
+import { observer, computed } from '@ember/object'
 import prismjs from 'prismjs';
 import 'prismjs/components/prism-bash';
 import 'prismjs/components/prism-yaml';
@@ -29,12 +29,12 @@ export default Component.extend({
     this.set('highlighted', prismjs.highlight(this.get('code') || '', prismjs.languages[lang], lang));
   }),
 
-  languageClass: function() {
+  languageClass: computed('language', function() {
     var lang = this.get('language');
 
     if ( lang ) {
       return `language-${ lang }`;
     }
-  }.property('language'),
+  }),
 
 });

--- a/lib/shared/addon/components/confirm-delete/component.js
+++ b/lib/shared/addon/components/confirm-delete/component.js
@@ -7,6 +7,7 @@ import ModalBase from 'ui/mixins/modal-base';
 import layout from './template';
 import { eachLimit } from 'async';
 import C from 'ui/utils/constants';
+import $ from 'jquery';
 
 function hasSomeOfResourceType(resourceType) {
   console.log(get(this, 'resources'));
@@ -27,7 +28,7 @@ export default Component.extend(ModalBase, {
   didRender() {
     setTimeout(() => {
       try {
-        this.$('BUTTON')[0].focus();
+        $('BUTTON')[0].focus();
       } catch (e) {}
     }, 500);
   },

--- a/lib/shared/addon/components/container-shell/component.js
+++ b/lib/shared/addon/components/container-shell/component.js
@@ -9,6 +9,7 @@ import layout from './template';
 import Component from '@ember/component';
 import { Terminal } from 'xterm';
 import * as fit from 'xterm/lib/addons/fit/fit';
+import $ from 'jquery';
 
 const DEFAULT_COMMAND = ['/bin/sh', '-c', 'TERM=xterm-256color; export TERM; [ -x /bin/bash ] && ([ -x /usr/bin/script ] && /usr/bin/script -q -c "/bin/bash" /dev/null || exec /bin/bash) || exec /bin/sh'];
 const statusMap = {
@@ -191,7 +192,7 @@ export default Component.extend(ThrottledResize, {
         socket.send(`0${ AWS.util.base64.encode(data) }`);
       });
 
-      term.open(this.$('.shell-body')[0], true);
+      term.open($('.shell-body')[0], true);
 
       this.fit();
 

--- a/lib/shared/addon/components/copy-inline/component.js
+++ b/lib/shared/addon/components/copy-inline/component.js
@@ -2,6 +2,7 @@ import { later } from '@ember/runloop';
 import Component from '@ember/component';
 import { isSafari } from 'ui/utils/platform';
 import layout from './template';
+import { computed } from '@ember/object';
 
 const DELAY = 1000;
 const DEFAULT_TEXT = 'copyToClipboard.tooltip';
@@ -44,9 +45,9 @@ export default Component.extend({
       }, DELAY);
     },
   },
-  isSupported: function() {
+  isSupported: computed('clipboardText', function() {
     return this.get('clipboardText.length') && (!isSafari || document.queryCommandSupported('copy'));
-  }.property('clipboardText'),
+  }),
 
   mouseEnter() {
     this.set('model', new Object({ tooltipText: this.get('defaultText') }));

--- a/lib/shared/addon/components/copy-to-clipboard/component.js
+++ b/lib/shared/addon/components/copy-to-clipboard/component.js
@@ -53,9 +53,9 @@ export default Component.extend({
     },
   },
 
-  isSupported: function() {
+  isSupported: computed('clipboardText', function() {
     return get(this, 'clipboardText.length') && (!isSafari || document.queryCommandSupported('copy'));
-  }.property('clipboardText'),
+  }),
 
   buttonClasses: computed('status', function() {
     let status = get(this, 'status');

--- a/lib/shared/addon/components/cru-cluster/component.js
+++ b/lib/shared/addon/components/cru-cluster/component.js
@@ -9,6 +9,7 @@ import { alias, equal } from '@ember/object/computed';
 import { loadStylesheet, proxifyUrl } from 'shared/utils/load-script';
 import layout from './template';
 import { isEmpty } from '@ember/utils';
+import $ from 'jquery';
 
 const MEMBER_CONFIG = { type: 'clusterRoleTemplateBinding', };
 const BUILD_IN_UI = ['tencentkubernetesengine', 'aliyunkubernetescontainerservice', 'huaweicontainercloudengine'];
@@ -83,7 +84,7 @@ export default Component.extend(ViewNewEdit, ChildHook, {
     },
 
     clickNext() {
-      this.$('BUTTON[type="submit"]').click();
+      $('BUTTON[type="submit"]').click();
     },
 
     close(saved) {

--- a/lib/shared/addon/components/form-engine-opts/component.js
+++ b/lib/shared/addon/components/form-engine-opts/component.js
@@ -2,7 +2,7 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import C from 'ui/utils/constants';
 import layout from './template';
-import { get, set } from '@ember/object';
+import { get, set, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
 export default Component.extend({
@@ -27,7 +27,7 @@ export default Component.extend({
       set(this, 'machine.engineInstallURL', url);
     }
   },
-  engineUrlChoices: function() {
+  engineUrlChoices: computed('intl.locale', `settings.${ C.SETTING.ENGINE_URL }`, function() {
     let defaultEngine = get(this, 'defaultEngine');
     let out           = [
       {
@@ -65,6 +65,6 @@ export default Component.extend({
     ];
 
     return out;
-  }.property('intl.locale', `settings.${ C.SETTING.ENGINE_URL }`),
+  }),
 
 });

--- a/lib/shared/addon/components/form-key-value/component.js
+++ b/lib/shared/addon/components/form-key-value/component.js
@@ -4,6 +4,7 @@ import Component from '@ember/component';
 import { get, set, observer } from '@ember/object'
 import Upload from 'shared/mixins/upload';
 import layout from './template';
+import $ from 'jquery';
 
 function applyLinesIntoArray(lines, ary) {
   lines.forEach((line) => {
@@ -164,7 +165,7 @@ export default Component.extend(Upload, {
           return;
         }
 
-        let elem = this.$('INPUT.key').last()[0];
+        let elem = $('INPUT.key').last()[0];
 
         if ( elem ) {
           elem.focus();

--- a/lib/shared/addon/components/form-labels-annotations/component.js
+++ b/lib/shared/addon/components/form-labels-annotations/component.js
@@ -1,5 +1,5 @@
 import { next } from '@ember/runloop';
-import { get, set } from '@ember/object';
+import { get, set, computed, observer } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import ManageLabels from 'shared/mixins/manage-labels';
@@ -10,6 +10,7 @@ import {
 } from 'shared/components/accordion-list-item/component';
 import layout from './template';
 import C from 'ui/utils/constants';
+import $ from 'jquery';
 
 export default Component.extend(ManageLabels, {
   intl: service(),
@@ -53,7 +54,7 @@ export default Component.extend(ManageLabels, {
           return;
         }
 
-        this.$('.js-label.key').last()[0].focus();
+        $('.js-label.key').last()[0].focus();
       });
     },
     annotationsChange(annotations){
@@ -62,14 +63,14 @@ export default Component.extend(ManageLabels, {
     }
   },
 
-  observeLabelCount: function() {
+  observeLabelCount: observer('userLabelArray.@each.key', function() {
     let count = this.get('userLabelArray').filterBy('key')
       .get('length') || 0;
 
     this.set('labelsCount', count || 0);
-  }.observes('userLabelArray.@each.key'),
+  }),
 
-  status: function() {
+  status: computed('labelsCount', 'annotationsCount', function() {
     let k = STATUS.NONE;
     let annotationsCount = this.get('annotationsCount');
     let labelsCount = this.get('labelsCount');
@@ -82,7 +83,7 @@ export default Component.extend(ManageLabels, {
     this.set('statusClass', classForStatus(k));
 
     return this.get('intl').t(`${ STATUS_INTL_KEY }.${ k }`, { count });
-  }.property('labelsCount', 'annotationsCount'),
+  }),
 
   initLabelsAndAnnotations() {
     const readonlyLabels = get(this, 'readonlyLabels') || [];

--- a/lib/shared/addon/components/form-name-description/component.js
+++ b/lib/shared/addon/components/form-name-description/component.js
@@ -1,7 +1,8 @@
 import { next, once } from '@ember/runloop';
 import Component from '@ember/component';
 import layout from './template';
-import { get, set } from '@ember/object';
+import { get, set, observer } from '@ember/object';
+import $ from 'jquery';
 
 export default Component.extend({
   layout,
@@ -58,7 +59,7 @@ export default Component.extend({
         return;
       }
 
-      const elem = this.$('INPUT')[0]
+      const elem = $('INPUT')[0]
 
       if ( elem ) {
         elem.focus();
@@ -73,7 +74,7 @@ export default Component.extend({
           return;
         }
 
-        var el = this.$('.description')[0];
+        var el = $('.description')[0];
 
         if ( el ) {
           el.focus();
@@ -82,7 +83,7 @@ export default Component.extend({
     },
   },
 
-  modelChanged: function() {
+  modelChanged: observer('model', function() {
     this.setProperties({
       _name:        get(this, 'model.name'),
       _description: get(this, 'model.description'),
@@ -91,9 +92,9 @@ export default Component.extend({
     if ( (get(this, 'model.description') || '').length ) {
       set(this, 'descriptionExpanded', true);
     }
-  }.observes('model'),
+  }),
 
-  nameChanged: function() {
+  nameChanged: observer('_name', function() {
     once(() => {
       let val = get(this, '_name');
 
@@ -103,9 +104,9 @@ export default Component.extend({
         set(this, 'name', val);
       }
     });
-  }.observes('_name'),
+  }),
 
-  descriptionChanged: function() {
+  descriptionChanged: observer('_description', function() {
     once(() => {
       let val = get(this, '_description');
 
@@ -115,6 +116,6 @@ export default Component.extend({
         set(this, 'description', val);
       }
     });
-  }.observes('_description'),
+  }),
 
 });

--- a/lib/shared/addon/components/form-namespace/component.js
+++ b/lib/shared/addon/components/form-namespace/component.js
@@ -5,6 +5,7 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import layout from './template';
 import { resolve, reject } from 'rsvp';
+import $ from 'jquery';
 
 const REUSE = 'reuse';
 const CREATE = 'create';
@@ -89,7 +90,7 @@ export default Component.extend({
       set(this, 'mode', mode);
       if ( mode === CREATE ) {
         next(() => {
-          let elem = this.$('.new-name')[0];
+          let elem = $('.new-name')[0];
 
           if ( elem ) {
             elem.focus();

--- a/lib/shared/addon/components/form-user-labels/component.js
+++ b/lib/shared/addon/components/form-user-labels/component.js
@@ -9,6 +9,7 @@ import {
   classForStatus
 } from 'shared/components/accordion-list-item/component';
 import layout from './template';
+import $ from 'jquery';
 
 export default Component.extend(ManageLabels, {
   intl: service(),
@@ -49,7 +50,7 @@ export default Component.extend(ManageLabels, {
           return;
         }
 
-        this.$('INPUT.key').last()[0].focus();
+        $('INPUT.key').last()[0].focus();
       });
     },
   },

--- a/lib/shared/addon/components/form-value-array/component.js
+++ b/lib/shared/addon/components/form-value-array/component.js
@@ -3,6 +3,7 @@ import { get, set, observer } from '@ember/object';
 import EmberObject from '@ember/object';
 import Component from '@ember/component';
 import layout from './template';
+import $ from 'jquery';
 
 export default Component.extend({
   layout,
@@ -48,7 +49,7 @@ export default Component.extend({
           return;
         }
 
-        const elem = this.$('INPUT.value').last()[0];
+        const elem = $('INPUT.value').last()[0];
 
         if ( elem ) {
           elem.focus();

--- a/lib/shared/addon/components/graph-area/component.js
+++ b/lib/shared/addon/components/graph-area/component.js
@@ -13,6 +13,7 @@ import {
   formatKbps
 } from 'shared/utils/util';
 import layout from './template';
+import $ from 'jquery';
 
 function getFormatter(unit, full = false) {
   switch (unit) {
@@ -150,7 +151,7 @@ export default Component.extend(ThrottledResize, {
   },
 
   create() {
-    const chart = ECharts.init(this.$('.content')[0], 'walden');
+    const chart = ECharts.init($('.content')[0], 'walden');
 
     set(this, 'chart', chart);
     chart.showLoading(LOADING_PARAMS);

--- a/lib/shared/addon/components/huawei-user-labels/component.js
+++ b/lib/shared/addon/components/huawei-user-labels/component.js
@@ -9,6 +9,7 @@ import {
   classForStatus
 } from 'shared/components/accordion-list-item/component';
 import layout from './template';
+import $ from 'jquery';
 
 export default Component.extend(ManageLabels, {
   intl: service(),
@@ -50,7 +51,7 @@ export default Component.extend(ManageLabels, {
           return;
         }
 
-        this.$('INPUT.key').last()[0].focus();
+        $('INPUT.key').last()[0].focus();
       });
     },
   },

--- a/lib/shared/addon/components/input-paste/component.js
+++ b/lib/shared/addon/components/input-paste/component.js
@@ -2,6 +2,7 @@ import TextField from '@ember/component/text-field';
 import IntlPlaceholder from 'shared/mixins/intl-placeholder';
 import { get } from '@ember/object';
 import layout from './template';
+import $ from 'jquery';
 
 export default TextField.extend(IntlPlaceholder, {
   layout,
@@ -14,11 +15,11 @@ export default TextField.extend(IntlPlaceholder, {
     this._super();
 
     this.set('_onPaste', this.handlePaste.bind(this));
-    this.$().on('paste', get(this, '_onPaste'));
+    $().on('paste', get(this, '_onPaste'));
   },
 
   willDestroyElement() {
-    this.$().off('paste', get(this, '_onPaste'));
+    $().off('paste', get(this, '_onPaste'));
     this._super();
   },
 

--- a/lib/shared/addon/components/input-slider/component.js
+++ b/lib/shared/addon/components/input-slider/component.js
@@ -3,6 +3,7 @@ import Component from '@ember/component';
 import C from 'ui/utils/constants';
 import layout from './template';
 import { computed, observer, get, set } from '@ember/object';
+import $ from 'jquery';
 
 function clientX(event) {
   if ( typeof event.clientX !== 'undefined' ) {
@@ -145,7 +146,7 @@ export default Component.extend({
   },
 
   pointToValue(screenX) {
-    var $elem    = this.$();
+    var $elem    = $();
     var offset   = $elem.offset();
     var width    = $elem.outerWidth();
 
@@ -169,7 +170,7 @@ export default Component.extend({
 
     set(this, 'value', value);
 
-    this.$('.slider-handle').focus();
+    $('.slider-handle').focus();
   },
 
   mouseDown(event) {

--- a/lib/shared/addon/components/input-suggest/component.js
+++ b/lib/shared/addon/components/input-suggest/component.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import layout from './template';
+import $ from 'jquery';
 
 export default Component.extend({
   layout,
@@ -25,7 +26,7 @@ export default Component.extend({
 });
 
 function onOpen() {
-  this.$('.dropdown-menu').css({
+  $('.dropdown-menu').css({
     right:     '0',
     maxWidth:  '200px',
     maxHeight: '300px',

--- a/lib/shared/addon/components/input-text-file/component.js
+++ b/lib/shared/addon/components/input-text-file/component.js
@@ -4,6 +4,7 @@ import { isSafari } from 'ui/utils/platform';
 import layout from './template';
 import { get, set, computed } from '@ember/object';
 import { Promise as EmberPromise, all } from 'rsvp';
+import $ from 'jquery';
 
 
 export default Component.extend({
@@ -33,7 +34,7 @@ export default Component.extend({
 
   actions: {
     click() {
-      this.$('INPUT[type=file]')[0].click();
+      $('INPUT[type=file]')[0].click();
     },
 
     wantsChange() {

--- a/lib/shared/addon/components/input-yaml/component.js
+++ b/lib/shared/addon/components/input-yaml/component.js
@@ -9,6 +9,7 @@ import ThrottledResize from 'shared/mixins/throttled-resize';
 import { downloadFile } from 'shared/utils/download-files';
 import CodeMirror from 'codemirror';
 import jsyaml from 'js-yaml';
+import $ from 'jquery';
 
 export default Component.extend(ThrottledResize, {
   settings:         service(),
@@ -49,7 +50,7 @@ export default Component.extend(ThrottledResize, {
 
   actions: {
     click() {
-      this.$('INPUT[type=file]')[0].click();
+      $('INPUT[type=file]')[0].click();
     },
 
     wantsChange() {
@@ -98,7 +99,7 @@ export default Component.extend(ThrottledResize, {
 
   fit() {
     if ( get(this, 'autoResize') ) {
-      var container = this.$('.codemirror-container');
+      var container = $('.codemirror-container');
 
       if ( !container ) {
         return;
@@ -110,7 +111,7 @@ export default Component.extend(ThrottledResize, {
         return;
       }
 
-      const desired = this.$(window).height() - position.top - get(this, 'resizeFooter');
+      const desired = $(window).height() - position.top - get(this, 'resizeFooter');
 
       container.css('max-height', Math.max(get(this, 'minHeight'), desired));
     }

--- a/lib/shared/addon/components/language-dropdown/component.js
+++ b/lib/shared/addon/components/language-dropdown/component.js
@@ -38,9 +38,9 @@ export default Component.extend({
     }
   },
 
-  hideSingle: function() {
+  hideSingle: computed('locales', function() {
     return Object.keys(this.get('locales')).length <= 1;
-  }.property('locales'),
+  }),
 
   selected: computed('intl.locale', function() {
     let locale = this.get('intl.locale');

--- a/lib/shared/addon/components/modal-confirm-deactivate/component.js
+++ b/lib/shared/addon/components/modal-confirm-deactivate/component.js
@@ -5,6 +5,7 @@ import Component from '@ember/component';
 import { alternateLabel } from 'ui/utils/platform';
 import ModalBase from 'shared/mixins/modal-base';
 import layout from './template';
+import $ from 'jquery';
 
 export default Component.extend(ModalBase, {
   intl: service(),
@@ -17,7 +18,7 @@ export default Component.extend(ModalBase, {
   didRender() {
     setTimeout(() => {
       try {
-        this.$('BUTTON')[0].focus();
+        $('BUTTON')[0].focus();
       } catch (e) {}
     }, 500);
   },

--- a/lib/shared/addon/components/modal-edit-driver/component.js
+++ b/lib/shared/addon/components/modal-edit-driver/component.js
@@ -6,6 +6,7 @@ import NewOrEdit from 'shared/mixins/new-or-edit';
 import ModalBase from 'shared/mixins/modal-base';
 import { computed, get, set, setProperties } from '@ember/object';
 import layout from './template';
+import $ from 'jquery';
 
 export default Component.extend(ModalBase, NewOrEdit, {
   settings: service(),
@@ -29,7 +30,7 @@ export default Component.extend(ModalBase, NewOrEdit, {
     })
 
     scheduleOnce('afterRender', () => {
-      this.$('INPUT')[0].focus();
+      $('INPUT')[0].focus();
     });
   },
 

--- a/lib/shared/addon/components/multi-container-stats/component.js
+++ b/lib/shared/addon/components/multi-container-stats/component.js
@@ -3,6 +3,7 @@ import { alias } from '@ember/object/computed';
 import Component from '@ember/component';
 import MultiStatsSocket from 'ui/utils/multi-stats';
 import layout from './template';
+import { observer } from '@ember/object';
 
 const FIELDS = ['cpuUser', 'cpuSystem', 'cpuTotal', 'networkTx', 'networkRx', 'networkTotal', 'memory', 'storageWrite', 'storageRead', 'storageTotal'];
 
@@ -43,7 +44,7 @@ export default Component.extend({
     this.tearDown();
   },
 
-  onActiveChanged: function() {
+  onActiveChanged: observer('active', function() {
     if ( this.isDestroyed || this.isDestroying ) {
       return;
     }
@@ -51,7 +52,7 @@ export default Component.extend({
     if ( !this.get('active') ) {
       this.tearDown();
     }
-  }.observes('active'),
+  }),
 
   connect() {
     next(() => {

--- a/lib/shared/addon/components/new-select/component.js
+++ b/lib/shared/addon/components/new-select/component.js
@@ -2,6 +2,7 @@ import { defineProperty, computed, get } from '@ember/object';
 import { reads } from '@ember/object/computed';
 import Component from '@ember/component';
 import layout from './template';
+import $ from 'jquery';
 
 export default Component.extend({
   layout,
@@ -86,7 +87,7 @@ export default Component.extend({
     return this;
   },
   _change() {
-    const selectEl = this.$()[0];
+    const selectEl = $()[0];
     const selectedIndex = selectEl.selectedIndex;
     const value = get(this, 'value');
 

--- a/lib/shared/addon/components/percent-gauge/component.js
+++ b/lib/shared/addon/components/percent-gauge/component.js
@@ -4,6 +4,7 @@ import initGraph from 'ui/utils/percent-gauge';
 import layout from './template';
 import { get, set, observer } from '@ember/object'
 import { next } from '@ember/runloop';
+import $ from 'jquery';
 
 export default Component.extend(ThrottledResize, {
   layout,
@@ -19,7 +20,7 @@ export default Component.extend(ThrottledResize, {
   didInsertElement() {
     this._super(...arguments);
     this.set('svg', initGraph({
-      el:       this.$()[0],
+      el:       $()[0],
       value:    get(this, 'value'),
       title:    get(this, 'title'),
       subtitle: get(this, 'subtitle'),

--- a/lib/shared/addon/components/pretty-json/component.js
+++ b/lib/shared/addon/components/pretty-json/component.js
@@ -1,11 +1,12 @@
 import Component from '@ember/component';
 import layout from './template';
+import { computed } from '@ember/object';
 
 export default Component.extend({
   layout,
   value: null,
 
-  json: function() {
+  json: computed('value', function() {
     var value = `${ this.get('value') || '' }`;
 
     if (value === '{}' || value === '[]') {
@@ -22,5 +23,5 @@ export default Component.extend({
     }
 
     return null;
-  }.property('value'),
+  }),
 });

--- a/lib/shared/addon/components/principal-search/component.js
+++ b/lib/shared/addon/components/principal-search/component.js
@@ -10,6 +10,7 @@ import { alias } from '@ember/object/computed';
 import { later } from '@ember/runloop';
 import { on } from '@ember/object/evented';
 import { isAlternate, isMore, isRange } from 'ui/utils/platform';
+import $ from 'jquery';
 
 const DEBOUNCE_MS = 250;
 
@@ -39,7 +40,7 @@ export default SearchableSelect.extend({
   didInsertElement() {
     // Explicitly not calling super here to not show until there's content this._super(...arguments);
 
-    this.$('input').on('focus', () => {
+    $('input').on('focus', () => {
       if (this.isDestroyed || this.isDestroying) {
         return;
       }
@@ -54,7 +55,7 @@ export default SearchableSelect.extend({
       }
     });
 
-    this.$('input').on('blur', () => {
+    $('input').on('blur', () => {
       later(() => {
         if (this.isDestroyed || this.isDestroying) {
           return;
@@ -100,7 +101,7 @@ export default SearchableSelect.extend({
       if (get(this, 'showOptions') === true) {
         return;
       }
-      const toBottom = $('body').height() - $(this.$()[0]).offset().top - 60;  // eslint-disable-line
+      const toBottom = $('body').height() - $($()[0]).offset().top - 60;  // eslint-disable-line
 
       setProperties(this, {
         maxHeight:   toBottom < get(this, 'maxHeight') ? toBottom : get(this, 'maxHeight'),

--- a/lib/shared/addon/components/progress-bar/component.js
+++ b/lib/shared/addon/components/progress-bar/component.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { computed, get, observer } from '@ember/object';
 import layout from './template';
+import $ from 'jquery';
 
 export default Component.extend({
   layout,
@@ -17,11 +18,11 @@ export default Component.extend({
   },
 
   percentDidChange: observer('percent', function() {
-    this.$('.progress-bar').css('width', `${ get(this, 'percent')  }%`);
+    $('.progress-bar').css('width', `${ get(this, 'percent')  }%`);
   }),
 
   zIndexDidChange: observer('zIndex', function() {
-    this.$().css('zIndex', get(this, 'zIndex') || 'inherit');
+    $().css('zIndex', get(this, 'zIndex') || 'inherit');
   }),
 
   tooltipContent: computed('percent', function() {

--- a/lib/shared/addon/components/radio-button/component.js
+++ b/lib/shared/addon/components/radio-button/component.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import layout from './template';
+import { computed } from '@ember/object'
 
 export default Component.extend({
   layout,
@@ -8,9 +9,9 @@ export default Component.extend({
   disabled:          false,
   attributeBindings: ['name', 'type', 'checked:checked', 'disabled:disabled'],
 
-  checked: function() {
+  checked: computed('value', 'selection', function() {
     return this.get('value') === this.get('selection');
-  }.property('value', 'selection'),
+  }),
   click() {
     this.set('selection', this.get('value'));
   },

--- a/lib/shared/addon/components/schema/input-container/component.js
+++ b/lib/shared/addon/components/schema/input-container/component.js
@@ -2,6 +2,7 @@ import { isArray } from '@ember/array';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import layout from './template';
+import { computed, observer } from '@ember/object';
 
 export default Component.extend({
   allContainers: service(),
@@ -28,23 +29,7 @@ export default Component.extend({
     }
   },
 
-  grouped: function() {
-    let list = this.get('allContainers.list');
-
-    let exclude = this.get('exclude');
-
-    if ( exclude ) {
-      if ( !isArray(exclude) ) {
-        exclude = [exclude];
-      }
-
-      list = list.filter((x) => !exclude.includes(x.id));
-    }
-
-    return this.get('allContainers').group(list);
-  }.property('allContainers.list.[]', 'canBalanceTo', 'canHaveContainers'),
-
-  selectedChanged: function() {
+  selectedChanged: observer('selected', function() {
     let id = this.get('selected');
     let str = null;
 
@@ -61,5 +46,21 @@ export default Component.extend({
     }
 
     this.set('value', str);
-  }.observes('selected'),
+  }),
+  grouped: computed('allContainers.list.[]', 'canBalanceTo', 'canHaveContainers', function() {
+    let list = this.get('allContainers.list');
+
+    let exclude = this.get('exclude');
+
+    if ( exclude ) {
+      if ( !isArray(exclude) ) {
+        exclude = [exclude];
+      }
+
+      list = list.filter((x) => !exclude.includes(x.id));
+    }
+
+    return this.get('allContainers').group(list);
+  }),
+
 });

--- a/lib/shared/addon/components/schema/input-password/component.js
+++ b/lib/shared/addon/components/schema/input-password/component.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import Util from 'ui/utils/util';
 import { get, set } from '@ember/object';
 import layout from './template';
+import $ from 'jquery';
 
 export default Component.extend({
   layout,
@@ -21,7 +22,7 @@ export default Component.extend({
 
       set(this, 'value', randomStr);
 
-      var $field = this.$('INPUT');
+      var $field = $('INPUT');
 
       $field.attr('type', 'text');
       setTimeout(() => {

--- a/lib/shared/addon/components/schema/input-relative-service/component.js
+++ b/lib/shared/addon/components/schema/input-relative-service/component.js
@@ -1,5 +1,5 @@
 import { isArray } from '@ember/array';
-import { set } from '@ember/object';
+import { set, computed, observer } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import layout from './template';
@@ -48,7 +48,22 @@ export default Component.extend({
     },
   },
 
-  list: function() {
+  valueChanged: observer('value', function() {
+    let value = this.get('value');
+
+    if ( value === CUSTOM ) {
+      this.setProperties({
+        value:  '',
+        custom: true,
+        obj:    null,
+      });
+    } else if ( value ) {
+      let obj = this.get('allWorkloads').matching(value, this.get('stack'));
+
+      this.set('obj', obj);
+    }
+  }),
+  list: computed('grouped.[]', 'intl.locale', 'exclude', 'stack.name', function() {
     let stackId = this.get('stack.id');
     let list = this.get('allWorkloads.list').sortBy('combined');
 
@@ -76,21 +91,6 @@ export default Component.extend({
     }
 
     return list;
-  }.property('grouped.[]', 'intl.locale', 'exclude', 'stack.name'),
+  }),
 
-  valueChanged: function() {
-    let value = this.get('value');
-
-    if ( value === CUSTOM ) {
-      this.setProperties({
-        value:  '',
-        custom: true,
-        obj:    null,
-      });
-    } else if ( value ) {
-      let obj = this.get('allWorkloads').matching(value, this.get('stack'));
-
-      this.set('obj', obj);
-    }
-  }.observes('value'),
 });

--- a/lib/shared/addon/components/searchable-select/component.js
+++ b/lib/shared/addon/components/searchable-select/component.js
@@ -28,6 +28,7 @@ import layout from './template';
 import { htmlSafe } from '@ember/string';
 import { on } from '@ember/object/evented';
 import { escapeRegex } from 'ui/utils/util';
+import $ from 'jquery';
 
 
 const MAX_HEIGHT = 285;
@@ -74,7 +75,7 @@ export default Component.extend({
   },
 
   didInsertElement() {
-    const search = this.$('.input-search');
+    const search = $('.input-search');
 
     // Stop chrome from showing autocomplete over our options
     search.attr('autocomplete', Math.random());
@@ -113,9 +114,9 @@ export default Component.extend({
     },
 
     mouseEnter(event) {
-      this.$('.searchable-option').removeClass('searchable-option-active');
+      $('.searchable-option').removeClass('searchable-option-active');
 
-      const $target = this.$(event.target);
+      const $target = $(event.target);
 
       $target.addClass('searchable-option-active');
 
@@ -123,7 +124,7 @@ export default Component.extend({
     },
 
     mouseLeave(event) {
-      this.$(event.target).removeClass('searchable-option-active');
+      $(event.target).removeClass('searchable-option-active');
 
       set(this, '$activeTarget', null);
     },
@@ -133,14 +134,14 @@ export default Component.extend({
         return;
       }
 
-      const toBottom = $('body').height() - $(this.$()[0]).offset().top - 60; // eslint-disable-line
+      const toBottom = $('body').height() - $($()[0]).offset().top - 60; // eslint-disable-line
 
       set(this, 'maxHeight', toBottom < MAX_HEIGHT ? toBottom : MAX_HEIGHT)
       set(this, 'filter', null);
 
       next(() => {
-        const checked = this.$('.searchable-option .icon-check');
-        const options = this.$('.searchable-options');
+        const checked = $('.searchable-option .icon-check');
+        const options = $('.searchable-options');
 
         if ( options.length && checked.length ) {
           options.animate({ scrollTop: `${ checked.parent().offset().top - options.offset().top }px` });
@@ -344,7 +345,7 @@ export default Component.extend({
   },
 
   on() {
-    this.$().on('keydown.searchable-option', (event) => {
+    $().on('keydown.searchable-option', (event) => {
       const kc = event.keyCode;
 
       // Note: keyup event can't be prevented.
@@ -371,7 +372,7 @@ export default Component.extend({
           if ($activeTarget.hasClass('searchable-prompt')) {
             this.send('selectPrompt');
           } else {
-            let idx = this.$('.searchable-option').index($activeTarget);
+            let idx = $('.searchable-option').index($activeTarget);
 
             idx = !!get(this, 'prompt') ? idx - 1 : idx;
 
@@ -394,8 +395,8 @@ export default Component.extend({
   },
 
   off() {
-    if (this.$()) {
-      this.$().off('keydown.searchable-option');
+    if ($()) {
+      $().off('keydown.searchable-option');
     }
   },
 
@@ -413,7 +414,7 @@ export default Component.extend({
 
     // https://stackoverflow.com/questions/39624902/new-input-placeholder-behavior-in-safari-10-no-longer-hides-on-change-via-java
     next(() => {
-      const input = this.$('.input-search');
+      const input = $('.input-search');
 
       if ( input ) {
         input.focus();
@@ -430,7 +431,7 @@ export default Component.extend({
 
   stepThroughOptions(step) {
     const $activeTarget = get(this, '$activeTarget');
-    const $options      = this.$('.searchable-option');
+    const $options      = $('.searchable-option');
     const len           = $options.length;
 
     let currentIdx      = -1;

--- a/lib/shared/addon/components/settings/host-registration/component.js
+++ b/lib/shared/addon/components/settings/host-registration/component.js
@@ -3,6 +3,7 @@ import Component from '@ember/component';
 import C from 'ui/utils/constants';
 import layout from './template';
 import { isPrivate, isBadTld } from 'ui/utils/util';
+import { computed, observer } from '@ember/object';
 
 export default Component.extend({
   endpoint: service(),
@@ -69,23 +70,7 @@ export default Component.extend({
     },
   },
 
-  looksPrivate: function() {
-    return isPrivate(this.get('activeValue'));
-  }.property('activeValue'),
-
-  badTld: function() {
-    return isBadTld(this.get('activeValue'));
-  }.property('activeValue'),
-
-  activeValue: function() {
-    if (this.get('customRadio') === 'yes') {
-      return this.get('customValue').trim();
-    } else {
-      return this.get('thisPage');
-    }
-  }.property('customRadio', 'customValue', 'thisPage'),
-
-  customValueDidChange: function() {
+  customValueDidChange: observer('customValue', function() {
     let val = (this.get('customValue') || '').trim();
     let idx = val.indexOf('/', 8); // 8 is enough for "https://"
 
@@ -99,6 +84,22 @@ export default Component.extend({
     if (val) {
       this.set('customRadio', 'yes');
     }
-  }.observes('customValue'),
+  }),
+
+  looksPrivate: computed('activeValue', function() {
+    return isPrivate(this.get('activeValue'));
+  }),
+
+  badTld: computed('activeValue', function() {
+    return isBadTld(this.get('activeValue'));
+  }),
+
+  activeValue: computed('customRadio', 'customValue', 'thisPage', function() {
+    if (this.get('customRadio') === 'yes') {
+      return this.get('customValue').trim();
+    } else {
+      return this.get('thisPage');
+    }
+  }),
 
 });

--- a/lib/shared/addon/components/textarea-autogrow/component.js
+++ b/lib/shared/addon/components/textarea-autogrow/component.js
@@ -1,10 +1,11 @@
 import TextArea from '@ember/component/text-area';
 import { inject as service } from '@ember/service'
 import { run } from '@ember/runloop'
-import { computed, get } from '@ember/object';
+import { computed, get, observer } from '@ember/object';
 
 import { isGecko } from 'ui/utils/platform';
 import IntlPlaceholder from 'shared/mixins/intl-placeholder';
+import $ from 'jquery';
 
 export default TextArea.extend(IntlPlaceholder, {
   intl: service(),
@@ -22,23 +23,23 @@ export default TextArea.extend(IntlPlaceholder, {
     run.scheduleOnce('afterRender', this, 'initHeights');
   },
 
+  changed: observer('value', function() {
+    run.debounce(this, 'autoSize', 100);
+  }),
+
   bg: computed('disabled', function() {
     if ( get(this, 'disabled') ) {
       return 'bg-disabled'
     }
   }),
 
-  changed: function() {
-    run.debounce(this, 'autoSize', 100);
-  }.observes('value'),
-
-  isSmall: function() {
+  isSmall: computed(function() {
     if ( this.isDestroyed || this.isDestroying ) {
       return;
     }
 
-    return this.$().hasClass('input-sm');
-  }.property(),
+    return $().hasClass('input-sm');
+  }),
 
   initHeights() {
     if ( this.get('minHeight') === 0 ) {
@@ -47,7 +48,7 @@ export default TextArea.extend(IntlPlaceholder, {
 
     this.autoSize();
 
-    this.$().on('paste', () => {
+    $().on('paste', () => {
       run.later(this, 'autoSize', 100);
     });
   },

--- a/lib/shared/addon/components/tooltip-action-menu/component.js
+++ b/lib/shared/addon/components/tooltip-action-menu/component.js
@@ -4,6 +4,7 @@ import Component from '@ember/component';
 import Tooltip from 'shared/mixins/tooltip';
 import StrippedName from 'shared/mixins/stripped-name';
 import layout from './template';
+import { observer } from '@ember/object';
 
 export default Component.extend(Tooltip, StrippedName, {
   resourceActions:  service('resource-actions'),
@@ -25,12 +26,12 @@ export default Component.extend(Tooltip, StrippedName, {
     this.set('actionsOpen', false);
   },
 
-  openChanged: function() {
+  openChanged: observer('actionsOpen', function() {
     this.set('tooltipService.requireClick', this.get('actionsOpen'));
     if ( !this.get('actionsOpen') && !this.get('inTooltip') ) {
       this.get('tooltipService').leave();
     }
-  }.observes('actionsOpen'),
+  }),
 
   mouseEnter() {
     this._super();

--- a/lib/shared/addon/components/top-errors/component.js
+++ b/lib/shared/addon/components/top-errors/component.js
@@ -2,6 +2,7 @@ import { later } from '@ember/runloop';
 import Component from '@ember/component';
 import layout from './template';
 import { get, set, computed } from '@ember/object';
+import $ from 'jquery';
 
 export default Component.extend({
   layout,
@@ -19,7 +20,7 @@ export default Component.extend({
   errorsDidChange: computed('errors.[]', function() {
     if ( get(this, 'errors.length') ) {
       later(() => {
-        this.$().scrollIntoView();
+        $().scrollIntoView();
       }, 100);
     }
   }),

--- a/lib/shared/addon/components/used-percent-gauge/component.js
+++ b/lib/shared/addon/components/used-percent-gauge/component.js
@@ -4,6 +4,7 @@ import layout from './template';
 import { get, set, observer } from '@ember/object'
 import { next } from '@ember/runloop';
 import PercentGauge from 'monitoring/components/percent-gauge/component';
+import $ from 'jquery';
 
 export default PercentGauge.extend(ThrottledResize, {
   layout,
@@ -18,7 +19,7 @@ export default PercentGauge.extend(ThrottledResize, {
 
   didInsertElement() {
     set(this, 'svg', initGraph({
-      el:        this.$()[0],
+      el:        $()[0],
       value:     get(this, 'value'),
       live:      get(this, 'live'),
       title:     get(this, 'title'),

--- a/lib/shared/addon/mixins/console.js
+++ b/lib/shared/addon/mixins/console.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import { inject as controller } from '@ember/controller';
 import Mixin from '@ember/object/mixin';
+import { on } from '@ember/object/evented';
 
 export default Mixin.create({
   application: controller(),
@@ -8,11 +9,11 @@ export default Mixin.create({
   instanceId:  null,
   model:       null,
 
-  bootstrap: function() {
+  bootstrap: on('init', function() {
     if (this.get('application.isPopup')) {
       $('body').css('overflow', 'hidden');
     }
-  }.on('init'),
+  }),
 
   actions: {
     cancel() {

--- a/lib/shared/addon/mixins/container-choices.js
+++ b/lib/shared/addon/mixins/container-choices.js
@@ -1,4 +1,4 @@
-import { get } from '@ember/object';
+import { get, computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
@@ -14,7 +14,7 @@ export default Mixin.create({
     this._super(...arguments);
   },
 
-  containerChoices: function() {
+  containerChoices: computed('allHosts.@each.instances', 'intl.locale', function() {
     var list = [];
     var id = this.get('id');
     var intl = this.get('intl');
@@ -80,9 +80,9 @@ export default Mixin.create({
     }
 
     return list.sortBy('group', 'name', 'id');
-  }.property('allHosts.@each.instances', 'intl.locale'),
+  }),
 
-  containersOnRequestedHost: function() {
+  containersOnRequestedHost: computed('containerChoices.@each.hostId', 'instance.requestedHostId', function() {
     var requestedHostId = this.get('instance.requestedHostId');
     var all = this.get('containerChoices');
 
@@ -91,9 +91,9 @@ export default Mixin.create({
     } else {
       return all;
     }
-  }.property('containerChoices.@each.hostId', 'instance.requestedHostId'),
+  }),
 
-  containersOnRequestedHostIfUnmanaged: function() {
+  containersOnRequestedHostIfUnmanaged: computed('containerChoices.@each.hostId', 'instance.requestedHostId', 'isManagedNetwork', 'intl.locale', function() {
     var requestedHostId = this.get('instance.requestedHostId');
     var all = this.get('containerChoices');
     var isManagedNetwork = this.get('isManagedNetwork');
@@ -103,5 +103,5 @@ export default Mixin.create({
     } else {
       return all;
     }
-  }.property('containerChoices.@each.hostId', 'instance.requestedHostId', 'isManagedNetwork', 'intl.locale'),
+  }),
 });

--- a/lib/shared/addon/mixins/container-spark-stats.js
+++ b/lib/shared/addon/mixins/container-spark-stats.js
@@ -1,4 +1,4 @@
-import EmberObject from '@ember/object';
+import { default as EmberObject, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import Mixin from '@ember/object/mixin';
 
@@ -68,7 +68,7 @@ export default Mixin.create({
   },
 
   // for 1.2+
-  instancesByExternalId: function() {
+  instancesByExternalId: computed('sparkInstances.@each.id', function() {
     var out = EmberObject.create();
 
     (this.get('sparkInstances') || []).forEach((instance) => {
@@ -80,10 +80,10 @@ export default Mixin.create({
     });
 
     return out;
-  }.property('sparkInstances.@each.id'),
+  }),
 
   // for 1.1
-  instancesById: function() {
+  instancesById: computed('sparkInstances.@each.id', function() {
     var out = EmberObject.create();
 
     (this.get('sparkInstances') || []).forEach((instance) => {
@@ -95,7 +95,7 @@ export default Mixin.create({
     });
 
     return out;
-  }.property('sparkInstances.@each.id'),
+  }),
 
   getOrCreateDataRow(key, id) {
     var data = this.get(`${ key }Data`);

--- a/lib/shared/addon/mixins/endpoint-ports.js
+++ b/lib/shared/addon/mixins/endpoint-ports.js
@@ -1,10 +1,10 @@
-import { get } from '@ember/object';
+import { get, computed } from '@ember/object';
 import Mixin from '@ember/object/mixin';
 import Util from 'ui/utils/util';
 
 export default Mixin.create({
 
-  displayEndpoints: function() {
+  displayEndpoints: computed('publicEndpoints.@each.{address,port,protocol}', function() {
     let parts = [];
     const endpoints = (get(this, 'publicEndpoints') || []).sort(Util.compareDisplayEndpoint);
 
@@ -30,5 +30,5 @@ export default Mixin.create({
     } else {
       return '';
     }
-  }.property('publicEndpoints.@each.{address,port,protocol}'),
+  }),
 });

--- a/lib/shared/addon/mixins/grouped-instances.js
+++ b/lib/shared/addon/mixins/grouped-instances.js
@@ -1,5 +1,6 @@
 import Mixin from '@ember/object/mixin';
 import C from 'ui/utils/constants';
+import { computed } from '@ember/object';
 
 function labelsMatching(ary, key, val) {
   return ary.filter((x) => {
@@ -9,7 +10,7 @@ function labelsMatching(ary, key, val) {
 
 
 export default Mixin.create({
-  groupedInstances: function() {
+  groupedInstances: computed('filteredInstances.@each.{name,id}', function() {
     var groups = [];
 
     function getOrCreateGroup(id, name, isK8s) {
@@ -135,5 +136,5 @@ export default Mixin.create({
     });
 
     return groups;
-  }.property('filteredInstances.@each.{name,id}'),
+  }),
 });

--- a/lib/shared/addon/mixins/input-answers.js
+++ b/lib/shared/addon/mixins/input-answers.js
@@ -3,12 +3,13 @@ import { /* get,  */set, setProperties } from '@ember/object';
 import flatMap from 'shared/utils/flat-map';
 import jsyaml from 'js-yaml';
 import { isEmpty } from '@ember/utils';
+import $ from 'jquery';
 
 export default Mixin.create({
 
   actions: {
     upload() {
-      this.$('INPUT[type=file]')[0].click();
+      $('INPUT[type=file]')[0].click();
     },
     showPaste() {
       set(this, 'pasteOrUpload', true);

--- a/lib/shared/addon/mixins/intl-placeholder.js
+++ b/lib/shared/addon/mixins/intl-placeholder.js
@@ -1,12 +1,13 @@
 import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
+import { computed } from '@ember/object';
 
 export default Mixin.create({
   intl: service(),
 
   attributeBindings: ['i18nPlaceholder:placeholder'],
 
-  i18nPlaceholder: function() {
+  i18nPlaceholder: computed('placeholder', 'intl.locale', function() {
     return this.get('intl').t(this.get('placeholder'));
-  }.property('placeholder', 'intl.locale'),
+  }),
 });

--- a/lib/shared/addon/mixins/lazy-icon.js
+++ b/lib/shared/addon/mixins/lazy-icon.js
@@ -1,5 +1,6 @@
 import Mixin from '@ember/object/mixin';
 import { set, get } from '@ember/object';
+import $ from 'jquery';
 
 export default Mixin.create({
   srcSet:            false,
@@ -15,16 +16,16 @@ export default Mixin.create({
     if (!get(this, 'srcSet')) {
       set(this, 'srcSet', true);
 
-      var $icon = this.$('.catalog-icon > img');
+      var $icon = $('.catalog-icon > img');
       const $srcPath = $icon.attr('src');
 
       if ($srcPath === this.genericIconPath) {
         $icon.attr('src', $icon.data('src'));
 
-        this.$('img').on('error', () => {
+        $('img').on('error', () => {
           if ( this.isDestroyed || this.isDestroying ) {
-            if (this.$('img')) {
-              this.$('img').off('error');
+            if ($('img')) {
+              $('img').off('error');
             }
 
             return;

--- a/lib/shared/addon/mixins/manage-labels.js
+++ b/lib/shared/addon/mixins/manage-labels.js
@@ -1,5 +1,5 @@
 import { isArray } from '@ember/array';
-import EmberObject, { set, setProperties } from '@ember/object';
+import EmberObject, { set, setProperties, computed } from '@ember/object';
 import Mixin from '@ember/object/mixin';
 import C from 'ui/utils/constants';
 import { debouncedObserver } from 'ui/utils/debounce';
@@ -146,23 +146,23 @@ export default Mixin.create({
   },
 
   // User labels are actual user ones, plus system ones that have no controls in the UI so they are manually entered.
-  userLabelArray: function() {
+  userLabelArray: computed('labelArray.@each.type', function() {
     return (this.get('labelArray') || []).filter((item) => {
       return isSoftUser(item.get('type'), item.get('key'));
     });
-  }.property('labelArray.@each.type'),
+  }),
 
-  strictUserLabelArray: function() {
+  strictUserLabelArray: computed('labelArray.@each.type', function() {
     return (this.get('labelArray') || []).filterBy('type', USER);
-  }.property('labelArray.@each.type'),
+  }),
 
-  systemLabelArray: function() {
+  systemLabelArray: computed('labelArray.@each.type', function() {
     return (this.get('labelArray') || []).filterBy('type', SYSTEM);
-  }.property('labelArray.@each.type'),
+  }),
 
-  affinityLabelArray: function() {
+  affinityLabelArray: computed('labelArray.@each.type', function() {
     return (this.get('labelArray') || []).filterBy('type', AFFINITY);
-  }.property('labelArray.@each.type'),
+  }),
 
   getLabelObj(key) {
     let lcKey = (key || '').toLowerCase();

--- a/lib/shared/addon/mixins/node-driver.js
+++ b/lib/shared/addon/mixins/node-driver.js
@@ -10,6 +10,7 @@ import { ucFirst } from 'shared/utils/util';
 import { formatSi } from 'shared/utils/parse-unit';
 import C from 'ui/utils/constants';
 import { isArray } from '@ember/array';
+import $ from 'jquery';
 
 export class DynamicDependentKeysProperty {
   constructor(property) {
@@ -310,7 +311,7 @@ export default Mixin.create(NewOrEdit, ManageLabels, {
 
     next(() => {
       try {
-        const input = this.$('INPUT')[0];
+        const input = $('INPUT')[0];
 
         if ( input ) {
           input.focus();

--- a/lib/shared/addon/mixins/safe-style.js
+++ b/lib/shared/addon/mixins/safe-style.js
@@ -1,14 +1,15 @@
 import Mixin from '@ember/object/mixin';
+import { computed } from '@ember/object';
 
 export default Mixin.create({
   safeStyle:  null,
-  _safeStyle: function() {
+  _safeStyle: computed('safeStyle', function() {
     if ( this.get('safeStyle') ) {
       return this.get('safeStyle').htmlSafe();
     } else {
       return ''.htmlSafe();
     }
-  }.property('safeStyle'),
+  }),
 
   attributeBindings: ['_safeStyle:style'],
 });

--- a/lib/shared/addon/mixins/store-tweaks.js
+++ b/lib/shared/addon/mixins/store-tweaks.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
 import C from 'ui/utils/constants';
+import { computed } from '@ember/object';
 
 export default Mixin.create({
   cookies: service(),
@@ -8,7 +9,7 @@ export default Mixin.create({
   defaultPageSize:   -1,
   removeAfterDelete: false,
 
-  headers: function() {
+  headers: computed(function() {
     let out = {
       [C.HEADER.ACTIONS]:      C.HEADER.ACTIONS_VALUE,
       [C.HEADER.NO_CHALLENGE]: C.HEADER.NO_CHALLENGE_VALUE
@@ -21,5 +22,5 @@ export default Mixin.create({
     }
 
     return out;
-  }.property().volatile(),
+  }).volatile(),
 });

--- a/lib/shared/addon/mixins/stripped-name.js
+++ b/lib/shared/addon/mixins/stripped-name.js
@@ -1,10 +1,11 @@
 import { and } from '@ember/object/computed';
 import Mixin from '@ember/object/mixin';
 import C from 'ui/utils/constants';
+import { computed } from '@ember/object';
 
 export default Mixin.create({
   stripStack:   true,
-  prefixLength: function() {
+  prefixLength: computed('name', function() {
     var name = this.get('model.displayName');
     var stackName = (this.get('model.labels') || {})[C.LABEL.STACK_NAME];
 
@@ -13,10 +14,10 @@ export default Mixin.create({
     }
 
     return 0;
-  }.property('name'),
+  }),
   showEllipsis: and('stripStack', 'prefixLength'),
 
-  displayName: function() {
+  displayName: computed('stripStack', 'prefixLength', 'model.displayName', function() {
     var name = this.get('model.displayName') || '';
 
     if ( this.get('stripStack') ) {
@@ -26,5 +27,5 @@ export default Mixin.create({
     } else {
       return name;
     }
-  }.property('stripStack', 'prefixLength', 'model.displayName'),
+  }),
 });

--- a/lib/shared/addon/mixins/upload.js
+++ b/lib/shared/addon/mixins/upload.js
@@ -1,13 +1,14 @@
 import Mixin from '@ember/object/mixin';
 import { inject as service } from '@ember/service';
 import { get } from '@ember/object';
+import $ from 'jquery';
 
 export default Mixin.create({
   growl: service(),
 
   actions: {
     upload() {
-      this.$('INPUT[type=file]')[0].click();
+      $('INPUT[type=file]')[0].click();
     },
   },
 

--- a/lib/shared/addon/utils/add-view-action.js
+++ b/lib/shared/addon/utils/add-view-action.js
@@ -1,5 +1,6 @@
 import { next } from '@ember/runloop';
 import Component from '@ember/component';
+import $ from 'jquery';
 
 export function addAction(action, selector) {
   return function() {
@@ -9,8 +10,8 @@ export function addAction(action, selector) {
       this.get('controller').send(action);
     }
 
-    next(this, function() {
-      var matches = this.$(selector);
+    next(this, () => {
+      var matches = $(selector);
 
       if ( matches ) {
         var last = matches.last();

--- a/lib/shared/addon/utils/multi-stats.js
+++ b/lib/shared/addon/utils/multi-stats.js
@@ -1,5 +1,5 @@
 import { and } from '@ember/object/computed';
-import EmberObject from '@ember/object';
+import EmberObject, { computed, observer } from '@ember/object';
 import Evented from '@ember/object/evented';
 import { run } from '@ember/runloop';
 import Socket from 'shared/utils/socket';
@@ -30,23 +30,23 @@ export default EmberObject.extend(Evented, {
     this.onAvailableChanged();
   },
 
-  available: function() {
+  available: computed('resource.{state,healthState}', function() {
     return C.ACTIVEISH_STATES.indexOf(this.get('resource.state')) >= 0 && this.get('resource.healthState') !== 'started-once';
-  }.property('resource.{state,healthState}'),
+  }),
 
   active: and('available', 'connected'),
 
-  loading: function() {
+  loading: computed('available', 'connected', function() {
     return this.get('available') && !this.get('connected');
-  }.property('available', 'connected'),
+  }),
 
-  onAvailableChanged: function() {
+  onAvailableChanged: observer('available', function() {
     if ( this.get('available') ) {
       this.connect();
     } else {
       this.disconnect();
     }
-  }.observes('available'),
+  }),
 
   connect() {
     if ( this.get('socket') || this.get('closed') ) {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "json2yaml": "^1.1.0",
     "jsondiffpatch": "^0.3.11",
     "jszip": "^3.1.5",
-    "liquid-fire": "^0.29.2",
+    "liquid-fire": "^0.30.0",
     "loader.js": "^4.7.0",
     "marked": "^0.3.15",
     "moment": "~2.22.1",

--- a/vendor/ember-shortcuts.js
+++ b/vendor/ember-shortcuts.js
@@ -207,4 +207,4 @@
       }
     });
   });
-}(Ember, Ember.$));
+}(Ember, jQuery));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3293,7 +3293,7 @@ broccoli-sri-hash@^2.1.0:
     sri-toolbox "^0.2.0"
     symlink-or-copy "^1.0.1"
 
-broccoli-stew@^1.4.2, broccoli-stew@^1.5.0:
+broccoli-stew@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.6.0.tgz#01f6d92806ed6679ddbe48d405066a0e164dfbef"
   dependencies:
@@ -4799,9 +4799,9 @@ ember-auto-import@^1.5.2:
     webpack "~4.28"
 
 ember-basic-dropdown@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-1.1.2.tgz#6558eb2aa34d2feeb66e9de1feea560d46edc697"
-  integrity sha512-l38MNIUOI1nAKxSUlDI1wrP52a55HxN2dikDUwJOqx7NytK0/woPyy3uVUe7gfT2gJ4HCbRlL/7y0csvP0iMPg==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-1.1.3.tgz#0506045ccc60db4972fc78b963c1324f6415818a"
+  integrity sha512-zIFk5yzu31L4E5lz3DfXF1IGGMcMAGYssh7hCoemjB7iqkL7Sf1UhUg/yEHcr5aEdfyGc1V3G2s740cRY+VLiQ==
   dependencies:
     ember-cli-babel "^7.2.0"
     ember-cli-htmlbars "^3.0.1"
@@ -5016,7 +5016,7 @@ ember-cli-htmlbars@^1.1.1:
     json-stable-stringify "^1.0.0"
     strip-bom "^2.0.0"
 
-ember-cli-htmlbars@^2.0.1, ember-cli-htmlbars@^2.0.2, ember-cli-htmlbars@^2.0.3:
+ember-cli-htmlbars@^2.0.2, ember-cli-htmlbars@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.4.tgz#0bcda483f14271663c38756e1fd1cb89da6a50cf"
   dependencies:
@@ -5389,12 +5389,6 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
-ember-factory-for-polyfill@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz#b446ed64916d293c847a4955240eb2c993b86eae"
-  dependencies:
-    ember-cli-version-checker "^2.1.0"
-
 ember-fetch@^6.5.0:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-6.5.1.tgz#6512153b9b85042744ed5a7934c8edb4a5b02dd0"
@@ -5422,20 +5416,6 @@ ember-flatpickr@^2.7.0:
     ember-diff-attrs "^0.2.1"
     fastboot-transform "^0.1.3"
     flatpickr "^4.5.2"
-
-ember-getowner-polyfill@^2.0.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
-  dependencies:
-    ember-cli-version-checker "^2.1.0"
-    ember-factory-for-polyfill "^1.3.1"
-
-ember-hash-helper-polyfill@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/ember-hash-helper-polyfill/-/ember-hash-helper-polyfill-0.2.1.tgz#73b074d8e2f7183d2e68c3df77e951097afa907c"
-  dependencies:
-    ember-cli-babel "^6.8.2"
-    ember-cli-version-checker "^2.1.0"
 
 ember-href-to@^2.0.1:
   version "2.0.1"
@@ -8079,21 +8059,20 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
-liquid-fire@^0.29.2:
-  version "0.29.5"
-  resolved "https://registry.yarnpkg.com/liquid-fire/-/liquid-fire-0.29.5.tgz#da8e3158e3f96c34a8cf371b90b8ae941ea8960d"
+liquid-fire@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/liquid-fire/-/liquid-fire-0.30.0.tgz#20e6673f9db32d503f909592fd2c691452b07d6d"
+  integrity sha512-5ffmsrPvAzc4EQdjVHouiPc0m+c+wt4YOBgABrPgO+30cSAlYLYuIhQIQ5j+zX87oa61btq0BJVjjtxunG1Nrg==
   dependencies:
-    broccoli-funnel "^1.0.1"
-    broccoli-merge-trees "^1.0.0"
-    broccoli-stew "^1.4.2"
-    ember-cli-babel "^6.6.0"
-    ember-cli-htmlbars "^2.0.1"
-    ember-cli-version-checker "^2.0.0"
+    broccoli-funnel "^2.0.2"
+    broccoli-merge-trees "^3.0.2"
+    broccoli-stew "^2.1.0"
+    ember-cli-babel "^7.7.3"
+    ember-cli-htmlbars "^3.0.1"
+    ember-cli-version-checker "^3.1.3"
     ember-copy "^1.0.0"
-    ember-getowner-polyfill "^2.0.1"
-    ember-hash-helper-polyfill "^0.2.0"
     match-media "^0.2.0"
-    velocity-animate "^1.5.1"
+    velocity-animate "^1.5.2"
 
 livereload-js@^2.3.0:
   version "2.3.0"
@@ -11970,9 +11949,10 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 
-velocity-animate@^1.5.1:
+velocity-animate@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/velocity-animate/-/velocity-animate-1.5.2.tgz#5a351d75fca2a92756f5c3867548b873f6c32105"
+  integrity sha512-m6EXlCAMetKztO1ppBhGU1/1MR3IiEevO6ESq6rcrSQ3Q77xYSW13jkfXW88o4xMrkXJhy/U7j4wFR/twMB0Eg==
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
- Moved from Ember.$() to importing jquery.
- Moved from fn().on() to on(fn())
- Moved from fn().observes() to observer(fn())

This got /g/clusters from 27 warnings to 5 warnings for me.

Types of changes
======
- Maintenance
