### PR TITLE
[Backport] Use current template version for app upgrades

### DIFF
--- a/app/catalog-tab/launch/route.js
+++ b/app/catalog-tab/launch/route.js
@@ -145,11 +145,14 @@ export default Route.extend({
           });
         }
 
+        let catalogTemplateUrlKey = def;
+
         if ( neuApp.id ) {
           verArr.filter((ver) => ver.version === get(neuApp, 'externalIdInfo.version'))
             .forEach((ver) => {
               set(ver, 'version', `${ ver.version } (current)`);
             })
+          catalogTemplateUrlKey = get(neuApp, 'externalIdInfo.version');
         }
 
         return EmberObject.create({
@@ -157,7 +160,7 @@ export default Route.extend({
           namespace,
           allTemplates:       this.modelFor(get(this, 'parentRoute')).get('catalog'),
           catalogApp:         neuApp,
-          catalogTemplateUrl: links[def], // catalogTemplateUrl gets qp's added and this needs with out
+          catalogTemplateUrl: links[catalogTemplateUrlKey], // catalogTemplateUrl gets qp's added and this needs with out
           namespaces:         results.namespaces,
           tpl:                results.tpl,
           tplKind:            kind,


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When upgrading an application the template version was set to the
default version instead of the apps current version.

When a current version is present we now use it instead of the
default.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#23208
