### PR TITLE
Fix Istio cluster owner RBAC issues

### DIFF
--- a/lib/istio/addon/components/istio-catalog/component.js
+++ b/lib/istio/addon/components/istio-catalog/component.js
@@ -254,8 +254,6 @@ export default Component.extend(CrudCatalog, ReservationCheck, CatalogUpgrade, {
         answers[HTTPS_PORT] = get(this, 'config.httpsPort')
       }
 
-      const users = get(this, 'globalStore').all('user');
-
       if (get(this, 'allowSystemGroup')) {
         answers[`${ MEMBERS }[0].kind`] = MEMBER_GROUP
         answers[`${ MEMBERS }[0].name`] = MEMBER_SYSYTEM
@@ -263,16 +261,6 @@ export default Component.extend(CrudCatalog, ReservationCheck, CatalogUpgrade, {
         (get(this, 'members') || []).map((m = {}, idx) => {
           const { principalType, id } = m
           let name = id
-
-          if (principalType === 'user') {
-            const filtered = users.filter((u = {}) => u.principalIds.includes(id)).get('firstObject')
-
-            if (filtered) {
-              name = get(filtered, 'id')
-            } else {
-              return
-            }
-          }
 
           answers[`${ MEMBERS }[${ idx }].kind`] = ucFirst(principalType)
           answers[`${ MEMBERS }[${ idx }].name`] = name


### PR DESCRIPTION
Proposed changes
======
There were two issues here:
1. When a cluster owner primary user added a member to istio nothing
   the user portion of the change wasn't sent.
2. When an admin added a member to istio the cluster owner primary user
   didn't see the member.

I removed code which was changing the id of the added member. This
resolved both issues.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
rancher/rancher#23215