### PR TITLE
Restrict Istio member access to groups only

### DIFF
--- a/lib/istio/addon/components/istio-catalog/template.hbs
+++ b/lib/istio/addon/components/istio-catalog/template.hbs
@@ -125,6 +125,7 @@
           members=members
           addAuthorizedPrincipal=(action "addAuthorizedPrincipal")
           removeMember=(action "removeMember")
+          searchOnlyGroups=true
         }}
       {{/unless}}
     </div>

--- a/lib/istio/translations/en-us.yaml
+++ b/lib/istio/translations/en-us.yaml
@@ -76,8 +76,8 @@ clusterIstioPage:
   existingClaim:
     label: 'Existing Claim for {component}'
   members:
-    title: Member Access
-    detail: Control who has access to Kiali and Jaeger UI.
+    title: Group Access
+    detail: Control which groups have access to Kiali and Jaeger UI.
   pilot:
     title: Pilot
     detail: Traffic management configuration.
@@ -91,8 +91,8 @@ clusterIstioPage:
     title: Ingress Gateway
     detail: Monitoring and route rules configuration.
   allowSystemGroup:
-    'true': Allow <b>all</b> members to access Kiali and Jaeger UI.
-    'false': Allow cluster owner and <b>specified</b> members to access Kiali and Jaeger UI.
+    'true': Allow <b>all</b> authenticated members to access Kiali and Jaeger UI.
+    'false': Allow cluster owner and <b>specified</b> groups to access Kiali and Jaeger UI.
   goToMonitoring: 'Monitoring needs to be on for istio to work. If you would like to modify the values please go to the <a href="/c/{clusterId}/monitoring/cluster-setting">Monitoring page</a> and save.'
   upgradeMonitoring: 'Before enabling Istio, you need to upgrade cluster monitoring to version 0.0.4 or above first. Go <a href="/c/{clusterId}/monitoring/cluster-setting">here</a> to upgrade cluster monitoring.'
   enableMonitoring:

--- a/lib/shared/addon/components/form-members-catalog-access/component.js
+++ b/lib/shared/addon/components/form-members-catalog-access/component.js
@@ -17,17 +17,18 @@ const MEMBERS_HEADERS = [
 ];
 
 export default Component.extend({
-  globalStore:          service(),
+  globalStore:      service(),
 
   layout,
 
-  membersHeaders:       MEMBERS_HEADERS,
-  sortBy:               '',
-  descending:           false,
-  excludeMember:        false,
-  resource:             null,
-  gotError:             null,
-  removeMember:         null,
+  membersHeaders:   MEMBERS_HEADERS,
+  sortBy:           '',
+  descending:       false,
+  excludeMember:    false,
+  resource:         null,
+  gotError:         null,
+  removeMember:     null,
+  searchOnlyGroups: false,
 
   actions: {
     addPrincipal(principal) {

--- a/lib/shared/addon/components/form-members-catalog-access/template.hbs
+++ b/lib/shared/addon/components/form-members-catalog-access/template.hbs
@@ -6,6 +6,7 @@
       allowLocal=true
       action=(action "addPrincipal")
       onError=gotError
+      searchOnlyGroups=searchOnlyGroups
     }}
   </div>
   <div class="col span-12">

--- a/lib/shared/addon/components/input-identity/component.js
+++ b/lib/shared/addon/components/input-identity/component.js
@@ -16,6 +16,7 @@ export default Component.extend({
   selected:          null,
   selectExactOnBlur: true,
   includeLocal:      true,
+  searchOnlyGroups:  false,
 
   init() {
     this._super(...arguments);

--- a/lib/shared/addon/components/input-identity/template.hbs
+++ b/lib/shared/addon/components/input-identity/template.hbs
@@ -8,6 +8,7 @@
       selectExact=(action "selectExact")
       selectExactOnBlur=selectExactOnBlur
       useLabel=true
+      searchOnlyGroups=searchOnlyGroups
     }}
 
     <div class="input-group-btn">

--- a/lib/shared/addon/components/principal-search/component.js
+++ b/lib/shared/addon/components/principal-search/component.js
@@ -27,6 +27,7 @@ export default SearchableSelect.extend({
   selectExactOnBlur:   true,
   includeLocal:        true,
   sendAfterLoad:       false,
+  searchOnlyGroups:    false,
 
   content:             alias('filteredPrincipals'),
   value:               alias('filter'),
@@ -294,13 +295,18 @@ export default SearchableSelect.extend({
 
 
   goSearch: task(function * (term) {
-    const globalStore = get(this, 'globalStore');
+    const { globalStore } = this;
+    const data            = { name: term };
+
+    if (this.searchOnlyGroups) {
+      set(data, 'principalType', 'group')
+    }
 
     try {
       return yield globalStore.rawRequest({
         url:    'principals?action=search',
         method: 'POST',
-        data:   { name: term, }
+        data
       });
     } catch (xhr) {
       set(this, 'errors', [`${ xhr.status }: ${ xhr.statusText }`]);


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Due to some oddities in the way that Istio currently allows access to members to
the kiali and jaeger ui's we've decided to restrict the member search to groups
only. I've changed the verbiage on the labels to reflect this. Additionally I've
also exposed the searchOnlyGroups param on the principal search component. I did
not expose the user only param because this is not something we're normally
going to be doing.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#23215


<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
I've left the original UI code that correlates the principals to users and manipulates the ID that is passed to Istio until we have a better solution on the backend to handle the RBAC.
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
