### PR TITLE
[forwardport] Gauges in cluster dashboard are missing when monitoring enabled in 2.3.0

### DIFF
--- a/lib/shared/addon/components/used-percent-gauge/component.js
+++ b/lib/shared/addon/components/used-percent-gauge/component.js
@@ -4,7 +4,6 @@ import layout from './template';
 import { get, set, observer } from '@ember/object'
 import { next } from '@ember/runloop';
 import PercentGauge from 'monitoring/components/percent-gauge/component';
-import $ from 'jquery';
 
 export default PercentGauge.extend(ThrottledResize, {
   layout,
@@ -19,7 +18,7 @@ export default PercentGauge.extend(ThrottledResize, {
 
   didInsertElement() {
     set(this, 'svg', initGraph({
-      el:        $()[0],
+      el:        this.element,
       value:     get(this, 'value'),
       live:      get(this, 'live'),
       title:     get(this, 'title'),


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Fix cluster dashboard cannot display after enable monitoring.

Types of changes
======

- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/23300


<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 
Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->

Related commit:
https://github.com/rancher/ui/commit/0f85e74fecc42181d69f9a3b6af77310233f4e9e
