### PR TITLE
Display Atypical Tolerations Correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
+/.log*
 npm-debug.log
 testem.log
 .DS_Store

--- a/lib/shared/addon/components/scheduling-toleration/component.js
+++ b/lib/shared/addon/components/scheduling-toleration/component.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { observer } from '@ember/object'
+import { get, observer, set } from '@ember/object'
 import layout from './template';
 import C from 'ui/utils/constants';
 
@@ -20,7 +20,7 @@ export default Component.extend({
 
   actions: {
     addToleration() {
-      this.get('tolerationArray').pushObject({
+      get(this, 'tolerationArray').pushObject({
         key:               '',
         operator:          DEFAULT_OPERATOR,
         value:             '',
@@ -30,20 +30,20 @@ export default Component.extend({
     },
 
     removeToleration(rule) {
-      this.get('tolerationArray').removeObject(rule);
+      get(this, 'tolerationArray').removeObject(rule);
     },
   },
 
   inputChanged: observer('tolerationArray.@each.{key,value,operator,effect,tolerationSeconds}', function() {
-    this.set('tolerate', this.get('tolerationArray')
+    set(this, 'tolerate', get(this, 'tolerationArray')
       .filter((t) => this.isTolerationValid(t))
       .map((t) => this.convertToleration(t)));
   }),
 
   initTolerationArray() {
-    const tolerate = this.get('tolerate') || [];
+    const tolerate = get(this, 'tolerate') || [];
 
-    this.set('tolerationArray', tolerate);
+    set(this, 'tolerationArray', tolerate);
   },
 
   isTolerationValid(toleration) {

--- a/lib/shared/addon/components/scheduling-toleration/template.hbs
+++ b/lib/shared/addon/components/scheduling-toleration/template.hbs
@@ -9,40 +9,38 @@
 </div>
 {{#if tolerationArray.length}}
   <table class="table fixed no-lines mb-20">
-    {{#if editing}}
-      <thead>
-        <tr>
-          <th class="acc-label">
-            {{t "formScheduling.key"}}
-          </th>
-          <th width="40"></th>
-          <th class="acc-label">
-            {{t "formScheduling.operator"}}
-          </th>
-          <th width="40"></th>
-          <th class="acc-label">
-            {{t "formScheduling.value"}}
-          </th>
-          <th width="40"></th>
-          <th class="acc-label">
-            {{t "formScheduling.effect"}}
-          </th>
-          <th width="40"></th>
-          <th class="acc-label">
-            {{t "formScheduling.time"}}
-          </th>
-          <th width="10">&nbsp;</th>
-          <th width="40"></th>
-        </tr>
-      </thead>
-    {{/if}}
+    <thead>
+      <tr>
+        <th class="acc-label">
+          {{t "formScheduling.key"}}
+        </th>
+        <th width="40"></th>
+        <th class="acc-label">
+          {{t "formScheduling.operator"}}
+        </th>
+        <th width="40"></th>
+        <th class="acc-label">
+          {{t "formScheduling.value"}}
+        </th>
+        <th width="40"></th>
+        <th class="acc-label">
+          {{t "formScheduling.effect"}}
+        </th>
+        <th width="40"></th>
+        <th class="acc-label">
+          {{t "formScheduling.time"}}
+        </th>
+        <th width="10">&nbsp;</th>
+        <th width="40"></th>
+      </tr>
+    </thead>
     <tbody>
       {{#each tolerationArray as |toleration|}}
         <tr>
           <td>
             {{#input-or-display
-              editable=editing
-              value=toleration.key
+               editable=editing
+               value=(if (and (not toleration.key) (eq toleration.operator "Exists")) "*" toleration.key)
             }}
               {{input
                 type="text"
@@ -56,8 +54,8 @@
           </td>
           <td>
             {{#input-or-display
-              editable=editing
-              value=toleration.operator
+               editable=editing
+               value=(or toleration.operator "Equal")
             }}
               {{searchable-select
                 class="form-control input-sm pt-0"
@@ -70,16 +68,16 @@
             &nbsp;
           </td>
           <td>
-            {{#if (eq toleration.operator "Equal")}}
+            {{#if (or (eq toleration.operator "Equal") (not toleration.operator))}}
               {{#input-or-display
-                editable=editing
+              editable=editing
+              value=toleration.value
+              }}
+              {{input
+                type="text"
+                class="form-control input-sm"
                 value=toleration.value
               }}
-                {{input
-                  type="text"
-                  class="form-control input-sm"
-                  value=toleration.value
-                }}
               {{/input-or-display}}
             {{else}}
               {{t "generic.na"}}
@@ -90,8 +88,8 @@
           </td>
           <td>
             {{#input-or-display
-              editable=editing
-              value=toleration.effect
+               editable=editing
+               value=(or toleration.effect "*")
             }}
               {{searchable-select
                 class="form-control input-sm pt-0"
@@ -107,8 +105,8 @@
           <td>
             {{#if (eq toleration.effect "NoExecute")}}
               {{#input-or-display
-                editable=editing
-                value=toleration.tolerationSeconds
+                 editable=editing
+                 value=toleration.tolerationSeconds
               }}
                 <div class="input-group">
                   {{input-integer


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Tolerations have two special cases that are not represented in the UI but are still valid.

> An empty key with operator Exists matches all keys, values and effects which means this will tolerate everything.

> An empty effect matches all effects with key key.

In these cases where we target *all* of something I am using the global operator (`*`) to denote these targets. Additionally when you edit the inputs will be empty for these, which is valid because technically the field doesn't exist. This ensures that when you save the workload or pod with tolerations they are saved correctly. 

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#18605 
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
