### PR TITLE
Fix Partner/Experimental Tag Translation

### DIFF
--- a/app/models/template.js
+++ b/app/models/template.js
@@ -123,7 +123,7 @@ const Template = Resource.extend({
     }
   }),
 
-  certified: computed('certifiedType', 'catalogId', 'labels', function() {
+  certified: computed('certifiedType', 'catalogId', 'labels', 'intl.locale', function() {
     let out = null;
     let labels = get(this, 'labels');
 
@@ -145,7 +145,7 @@ const Template = Resource.extend({
     }
 
     // For the standard labels, use translations
-    if ( [C.LABEL.CERTIFIED_RANCHER, C.LABEL.CERTIFIED_PARTNER].includes(out) ) {
+    if ( [C.LABEL.CERTIFIED_RANCHER, C.LABEL.CERTIFIED_PARTNER, C.LABEL.CERTIFIED_RANCHER_EXPERIMENTAL].includes(out) ) {
       let pl = 'pl';
 
       if ( get(this, 'settings.isRancher') ) {

--- a/lib/global-admin/addon/multi-cluster-apps/catalog/index/controller.js
+++ b/lib/global-admin/addon/multi-cluster-apps/catalog/index/controller.js
@@ -24,7 +24,7 @@ export default Controller.extend({
     },
 
     refresh() {
-      let catalogTab = getOwner(this).lookup('route:catalog-tab');
+      let catalogTab = getOwner(this).lookup('route:multi-cluster-apps.catalog');
 
       catalogTab.send('refresh');
     },

--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -121,9 +121,10 @@ var C = {
     PER_HOST_SUBNET:         'io.rancher.network.per_host_subnet.subnet',
 
     // Catalog
-    CERTIFIED:               'io.rancher.certified',
-    CERTIFIED_PARTNER:       'partner',
-    CERTIFIED_RANCHER:       'rancher',
+    CERTIFIED:                      'io.rancher.certified',
+    CERTIFIED_PARTNER:              'partner',
+    CERTIFIED_RANCHER:              'rancher',
+    CERTIFIED_RANCHER_EXPERIMENTAL: 'experimental',
 
     // Host
     DOCKER_VERSION: 'io.rancher.host.docker_version',

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -724,9 +724,11 @@ catalogPage:
       rancher:
         rancher: Rancher Labs
         partner: Partner
+        experimental: "Experimental"
       pl:
         rancher: Core
         partner: Partner
+        experimental: "Experimental"
     noData:
       singular: There are no compatible templates.
       plural: There are no compatible templates in this catalog.


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

The certified property on the catalog template model was not watching the intl.locale so when switching languages these keys never updated. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

rancher/rancher#23322
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

Bugfix
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

I believe this bug caused the side effect of the translation for partner/experimental being borked when the backend refreshed the templates and the view reloaded. I could not reproduce it locally and it only happens intermittently for others with no JS Errors so I am not 100% sure this will resolve that but it was a bug and needed to be fixed. 
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
