### PR TITLE
Ensure the current Kubernetes version can display

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -648,7 +648,18 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       });
     }
 
-    return [...out, ...patchedOut];
+    const partialResult = [
+      ...out,
+      ...patchedOut
+    ];
+
+    // We want to include the current version if it's not
+    // present in the current choices to make it displayable.
+    const currentVersion = get(this, 'config.kubernetesVersion');
+
+    return currentVersion && partialResult.indexOf(currentVersion) === -1
+      ? [...partialResult, currentVersion]
+      : partialResult;
   }),
 
   isNodeNameValid: computed('nodeName', function() {


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The current kubernetes version wasn't being shown if it was no
longer a part of the supported versions when in view mode. Instead
the latest version was being displayed even if that wasn't what was
deployed. To resolve this we include the current version as one of
the choices if it's not present.

Types of changes
======
What types of changes does your code introduce to Rancher?
- New feature (non-breaking change which adds functionality)

Linked Issues
======
rancher/rancher#23465
