### PR TITLE
[2.3.x] Display k8s version in all modes of rke driver

### DIFF
--- a/lib/shared/addon/components/check-override-allowed/template.hbs
+++ b/lib/shared/addon/components/check-override-allowed/template.hbs
@@ -11,5 +11,9 @@
     </div>
   {{/if}}
 {{else}}
-  {{yield}}
+  {{#if (and (eq mode "view") (get clusterTemplateRevision paramName)) }}
+    {{get clusterTemplateRevision paramName}}
+  {{else}}
+    {{yield}}
+  {{/if}}
 {{/if}}

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -653,18 +653,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       });
     }
 
-    const partialResult = [
-      ...out,
-      ...patchedOut
-    ];
-
-    // We want to include the current version if it's not
-    // present in the current choices to make it displayable.
-    const currentVersion = get(this, 'config.kubernetesVersion');
-
-    return currentVersion && partialResult.indexOf(currentVersion) === -1
-      ? [...partialResult, currentVersion]
-      : partialResult;
+    return [...out, ...patchedOut];
   }),
 
   isNodeNameValid: computed('nodeName', function() {

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -155,6 +155,7 @@
                 @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
                 @paramName="rancherKubernetesEngineConfig.kubernetesVersion"
                 @questions={{model.clusterTemplateRevision.questions}}
+                @mode={{mode}}
               >
                 <FormVersions
                   @applyClusterTemplate={{applyClusterTemplate}}


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

the check-override-allowed component did not know how to deal with the k8s
version question because of its tri state and how we deal with the patch version
that is an override but not really an override. I added a check to verify the
mode is view and we have the param then display param so we don't initialize the
form-version component which has logic to inject the current version into its
versions dropdown (code we added yesterday) but only if we're new, editing, or cloning.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======

rancher/rancher#23478
rancher/rancher#23465

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
