### PR TITLE
[Backport] Move Grafana options to own section

### DIFF
--- a/lib/monitoring/addon/components/enable-monitoring/template.hbs
+++ b/lib/monitoring/addon/components/enable-monitoring/template.hbs
@@ -84,12 +84,6 @@
           </label>
           {{schema/input-boolean value=enablePrometheusPersistence}}
         </div>
-        <div class="col span-6">
-          <label class="acc-label">
-            {{t "monitoringPage.config.grafana.enablePersistence.label"}}
-          </label>
-          {{schema/input-boolean value=enableGrafanaPersistence}}
-        </div>
       </div>
 
       {{#if enablePrometheusPersistence}}
@@ -108,26 +102,6 @@
               {{t "monitoringPage.config.prometheus.storageClass.label"}}
             </label>
             {{schema/input-storageclass value=prometheusStorageClass}}
-          </div>
-        </div>
-      {{/if}}
-
-      {{#if enableGrafanaPersistence}}
-        <div class="row">
-          <div class="col span-6">
-            <label class="acc-label">
-              {{t "monitoringPage.config.grafana.size.label"}}
-            </label>
-            {{schema/input-string
-              value=grafanaPersistenceSize
-              placeholder=(t "monitoringPage.config.grafana.size.placeholder")
-            }}
-          </div>
-          <div class="col span-6">
-            <label class="acc-label">
-              {{t "monitoringPage.config.grafana.storageClass.label"}}
-            </label>
-            {{schema/input-storageclass value=grafanaStorageClass}}
           </div>
         </div>
       {{/if}}
@@ -297,6 +271,34 @@
           }}
         </div>
       </div>
+
+      <div class="row">
+        <div class="col span-6">
+          <label class="acc-label">
+            {{t "monitoringPage.config.grafana.enablePersistence.label"}}
+          </label>
+          {{schema/input-boolean value=enableGrafanaPersistence}}
+        </div>
+      </div>
+      {{#if enableGrafanaPersistence}}
+        <div class="row">
+          <div class="col span-6">
+            <label class="acc-label">
+              {{t "monitoringPage.config.grafana.size.label"}}
+            </label>
+            {{schema/input-string
+              value=grafanaPersistenceSize
+              placeholder=(t "monitoringPage.config.grafana.size.placeholder")
+            }}
+          </div>
+          <div class="col span-6">
+            <label class="acc-label">
+              {{t "monitoringPage.config.grafana.storageClass.label"}}
+            </label>
+            {{schema/input-storageclass value=grafanaStorageClass}}
+          </div>
+        </div>
+      {{/if}}
 
       {{#advanced-section advanced=advanced}}
         {{form-key-value


### PR DESCRIPTION



<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The Grafana storage options were confusingly in the middle of the
Prometheus options on the Cluster Monitoring Configuration page.
To resolve this we moved the Grafana options to be below the
Prometheus options and above the advanced otpions.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#22885

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
