### PR TITLE
Enable '.' in answer variables

### DIFF
--- a/lib/global-admin/addon/components/new-multi-cluster-app/component.js
+++ b/lib/global-admin/addon/components/new-multi-cluster-app/component.js
@@ -367,7 +367,7 @@ export default Component.extend(NewOrEdit, CatalogApp, {
         nueQuestions = Object.keys(helmQuestions).map((qk) => {
           return {
             variable: qk,
-            answer:   get(helmQuestions, qk),
+            answer:   helmQuestions[qk],
           };
         });
       }

--- a/lib/global-admin/addon/components/new-multi-cluster-app/template.hbs
+++ b/lib/global-admin/addon/components/new-multi-cluster-app/template.hbs
@@ -9,10 +9,10 @@
       </h1>
     {{else}}
       <h1>
-        {{#link-to parentRoute}}
-          {{t "newMultiClusterApp.catalog"}}
-          {{templateResource.displayName}}
-        {{/link-to}}
+      {{#link-to (unbound parentRoute)}}
+        {{t "newMultiClusterApp.catalog"}}
+        {{templateResource.displayName}}
+      {{/link-to}}
       </h1>
     {{/if}}
   </section>


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This enables '.' to be a valid character in answer varaibles.
So we can support sub.key as a key now.

This also resolves a double render issue that was ran into while
reproducing this issue.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#23379

Further comments
======
![Screen Shot 2019-10-17 at 12 09 47 PM](https://user-images.githubusercontent.com/55104481/67042025-d004f280-f0db-11e9-9e31-22a5144c8329.png)
