### PR TITLE
Ensure istio member type is correct on add

### DIFF
--- a/lib/shared/addon/components/form-members-catalog-access/component.js
+++ b/lib/shared/addon/components/form-members-catalog-access/component.js
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
 import layout from './template';
-import { get } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 const MEMBERS_HEADERS = [
@@ -33,18 +32,8 @@ export default Component.extend({
 
   actions: {
     addPrincipal(principal) {
-      if (principal) {
-        const { principalType, id } = principal;
-
-        const nue = {
-          type:        'member',
-          displayType: get(principal, 'displayType') || principalType,
-          displayName: get(principal, 'displayName') || get(principal, 'loginName') || get(principalType, 'id'),
-          principalType,
-          id,
-        };
-
-        this.addAuthorizedPrincipal(nue);
+      if (principal && this.addAuthorizedPrincipal) {
+        this.addAuthorizedPrincipal(principal);
       }
     },
   },


### PR DESCRIPTION
When adding a github group to be an instio member we wanted the
appropriate Member Type to be displayed. We wanted 'Organization'
instead of 'group'.

We noticed that addAuthorizedPrincipal was being invoked with a newly
created member object instead of just passing the principal. Since
everything we could inspect code wise expected a principal instead
of a member I went ahead and just passed the principal.

rancher/rancher#23264

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
