### PR TITLE
[backport] Bumping the version of ember-api-store to 2.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@ember/jquery": "^0.5.2",
     "@ember/optional-features": "^0.6.3",
-    "@rancher/ember-api-store": "2.9.2",
+    "@rancher/ember-api-store": "2.9.4",
     "ansi_up": "^2.0.2",
     "async": "2.1.2",
     "babel-eslint": "^9.0.0",


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Bumping the version of ember-api-store to 2.9.4

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#23576
