### PR TITLE
[forwardport] Improve kube version inspection on cluster edit

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -514,10 +514,19 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
       // editing a cluster not a template
       if (this.isEdit && this.cluster.type === 'cluster') {
-        let kubeVersion = coerceVersion(get(originalCluster, 'rancherKubernetesEngineConfig.kubernetesVersion'));
+        const originalKubeVersion = coerceVersion(get(originalCluster, 'rancherKubernetesEngineConfig.kubernetesVersion'));
+        const rawRevisionKubeVersion = clusterTemplateRevision.clusterConfig.rancherKubernetesEngineConfig.kubernetesVersion;
+        const revisionKubeVersion = coerceVersion(rawRevisionKubeVersion);
+        const validRange = rawRevisionKubeVersion.endsWith('.x') && Semver.validRange(`<=${ rawRevisionKubeVersion }`);
+        // Filter revisions with kube versions that are downgrades from the original kube version. We're using satisfies here so
+        // that we can support semvers with a .x suffix. When the revision kube version is coerced and ends in .x (which signifies latest patch)
+        // it gets coerced into .0 which makes the simple lt check erroenously think the revision version is less than the original version. We
+        // still use lt just incase the rawRevisionKubeVersion isn't a valid range and needs to be coereced.
+        const isRevisionKubeVersionCompatible =  validRange
+          ? Semver.satisfies(originalKubeVersion, validRange)
+          : Semver.lte(originalKubeVersion, revisionKubeVersion)
 
-        // filter revisions with kube version lower
-        if (Semver.lt(coerceVersion(clusterTemplateRevision.clusterConfig.rancherKubernetesEngineConfig.kubernetesVersion), kubeVersion)) {
+        if (!isRevisionKubeVersionCompatible) {
           set(out, 'disabled', true);
         }
       }


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
While editing a cluster properly support .x kube version comparisons when
filtering out cluster template revisions.

Coercing a .x version converts it to a .0 which made the revision look like
it was a kube downgrade. By making use of .satisfies when the revision
kube version ends with a '.x' we're now better able to check if the
kube version is a downgrade and filter appropriately.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#23578

