### PR TITLE
Deprecate array constructor usage

### DIFF
--- a/lib/shared/addon/helpers/array-includes.js
+++ b/lib/shared/addon/helpers/array-includes.js
@@ -18,7 +18,7 @@ export default Helper.extend({
     let _haystack = this.get('_haystack');
 
     if (haystack !== _haystack) {
-      _haystack = new EmberA(haystack);
+      _haystack = EmberA(haystack);
       this.set('_haystack', _haystack);
     }
 


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Invoking the constructor instead of just a method causes an error.
This resolves that error.

Types of changes
- Bugfix (non-breaking change which fixes an issue)

