### PR TITLE
[forwardport] Fix EKS cluster creation transition

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
@@ -233,13 +233,21 @@ export default Component.extend(ClusterDriver, {
 
   vpcsChanged: observer('config.virtualNetwork', 'vpcSubnetMode', function() {
     const vnet = get(this, 'config.virtualNetwork');
+    const subnets = get(this, 'config.subnets');
     const mode = get(this, 'vpcSubnetMode');
+
+    const hasInitializedValues = vnet || subnets;
 
     if (vnet && mode === 'custom') {
       this.loadSubnets(this.authCreds()).catch((err) => {
         get(this, 'errors').pushObject(err);
       });
-    } else if (mode === 'default') {
+    // We check for initialized values here because as part of
+    // the saving process this observer gets triggered with
+    // uninitialized values. This was causing a save to switch
+    // the step to step 3 rather than remaining on the last
+    // page until the saving was complete.
+    } else if (mode === 'default' && hasInitializedValues) {
       setProperties(get(this, 'config'), {
         virtualNetwork: null,
         subnets:        [],


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
After pressing the 'create' button of the EKS driver the user was being
transitioned back to step 3 (Vpc & Subnet) rather than waiting on the
final page until the save is complete and returning to the cluster page.

An observer was being triggered by the save process which subsequently
set the step back to 3. To resolve this we will only enter the branch if
there are initialized values that need to be set back to default.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Links to issues
======
rancher/rancher#23609

