### PR TITLE
[forwardport] Ensure istio member type is correct on add

### DIFF
--- a/lib/shared/addon/components/form-members-catalog-access/component.js
+++ b/lib/shared/addon/components/form-members-catalog-access/component.js
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
 import layout from './template';
-import { get } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 const MEMBERS_HEADERS = [
@@ -33,18 +32,8 @@ export default Component.extend({
 
   actions: {
     addPrincipal(principal) {
-      if (principal) {
-        const { principalType, id } = principal;
-
-        const nue = {
-          type:        'member',
-          displayType: get(principal, 'displayType') || principalType,
-          displayName: get(principal, 'displayName') || get(principal, 'loginName') || get(principalType, 'id'),
-          principalType,
-          id,
-        };
-
-        this.addAuthorizedPrincipal(nue);
+      if (principal && this.addAuthorizedPrincipal) {
+        this.addAuthorizedPrincipal(principal);
       }
     },
   },


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When adding a github group to be an instio member we wanted the
appropriate Member Type to be displayed. We wanted 'Organization'
instead of 'group'.

We noticed that addAuthorizedPrincipal was being invoked with a newly
created member object instead of just passing the principal. Since
everything we could inspect code wise expected a principal instead
of a member I went ahead and just passed the principal.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#23612


