### PR TITLE
[Forwardport] Select correct k8s version when changing templates

### DIFF
--- a/lib/shared/addon/components/form-versions/component.js
+++ b/lib/shared/addon/components/form-versions/component.js
@@ -64,6 +64,7 @@ export default Component.extend({
     } = this;
 
     let out = versions;
+    let overrideMatch = null;
 
     if (initialVersion) {
       if ( !out.includes(initialVersion) && editing ) {
@@ -77,7 +78,7 @@ export default Component.extend({
     let maxVersion      = maxSatisfying(versions, defaultK8sVersionRange);
 
     if ( applyClusterTemplate ) {
-      var overrideMatch = ( clusterTemplateQuestions || [] ).findBy('variable', 'rancherKubernetesEngineConfig.kubernetesVersion');
+      overrideMatch = ( clusterTemplateQuestions || [] ).findBy('variable', 'rancherKubernetesEngineConfig.kubernetesVersion');
 
       if (overrideMatch) {
         if (isEmpty(overrideMatch.satisfies) && initialVersion.endsWith('.x')) {
@@ -166,12 +167,26 @@ export default Component.extend({
       return out;
     });
 
-    if (( !editing ) && defaultK8sVersionRange && this.value) {
-      if (this.value.endsWith('.x')) {
+    if (!editing && defaultK8sVersionRange && this.value) {
+      if (!applyClusterTemplate && this.value.endsWith('.x')) {
         set(this, 'value', this.intl.t('formVersions.dotx', { minor: this.value.replace(/\.x$/, '') }));
       } else {
         if ( maxVersion && !mappedVersions.findBy('value', get(this, 'value')) ) {
           set(this, 'value', maxVersion);
+        }
+      }
+    }
+
+    if (editing && this.value && this.value.endsWith('.x')) {
+      if (applyClusterTemplate && overrideMatch && overrideMatch.satisfies) {
+        if (!satisfies(initialVersion, overrideMatch.satisfies)) {
+          set(this, 'value', maxVersion);
+        } else {
+          set(this, 'value', initialVersion);
+        }
+      } else {
+        if (initialVersion) {
+          set(this, 'value', initialVersion);
         }
       }
     }


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

When editing a cluster that was created with a template and then selecting a new template to upgrade the cluster to we were not selecting the correct Kubernetes version from the override.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#23682
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
