### PR TITLE
Vsphere master parity with 2.3-fixes

### DIFF
--- a/lib/nodes/addon/components/driver-vmwarevsphere/component.js
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/component.js
@@ -162,7 +162,21 @@ export default Component.extend(NodeDriver, {
     const creationType = get(this, 'creationMethod') === CREATION_METHOD_RANCHER_OS_ISO
       ? 'manual'
       : 'clone';
+
     set(this, 'config.creationType', creationType);
+
+    const isContentLibraryField = get(this, 'creationMethod') === CREATION_METHOD_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY;
+
+    if (!isContentLibraryField && get(this, 'config.contentLibrary')) {
+      set(this, 'config.contentLibrary', undefined);
+    }
+
+    const isCloneFromMethod = get(this, 'creationMethod') === CREATION_METHOD_CLONE_AN_EXISTING_VIRTUAL_MACHINE
+      || get(this, 'creationMethod') === CREATION_METHOD_DEPLOY_FROM_TEMPLATE_DATA_CENTER;
+
+    if (!isCloneFromMethod && get(this, 'config.cloneFrom')) {
+      set(this, 'config.cloneFrom', undefined);
+    }
   }),
 
   datacenterContent: computed('model.cloudCredentialId', async function() {

--- a/lib/nodes/addon/components/driver-vmwarevsphere/component.js
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/component.js
@@ -367,6 +367,17 @@ export default Component.extend(NodeDriver, {
     set(this, 'vappMode', getInitialVappMode(get(this, 'config')));
   },
 
+  initCustomAttributes() {
+    set(this, 'initialCustomAttributes', get(this, 'config.customAttribute').map((v) => {
+      const [key, value] = v.split('=');
+
+      return {
+        key,
+        value,
+      };
+    }));
+  },
+
   updateVappOptions(opts) {
     set(this, 'config.vappIpprotocol', opts.vappIpprotocol);
     set(this, 'config.vappIpallocationpolicy', opts.vappIpallocationpolicy);

--- a/lib/nodes/addon/components/driver-vmwarevsphere/component.js
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/component.js
@@ -1,5 +1,5 @@
 import { alias } from '@ember/object/computed';
-import { get, set, computed } from '@ember/object';
+import { get, set, computed, observer } from '@ember/object';
 import Component from '@ember/component';
 import NodeDriver from 'shared/mixins/node-driver';
 import layout from './template';
@@ -11,10 +11,10 @@ const CONFIG = 'vmwarevsphereConfig';
 const VAPP_MODE_DISABLED = 'disabled';
 const VAPP_MODE_AUTO = 'auto';
 const VAPP_MODE_MANUAL = 'manual';
-const CREATION_TYPE_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY = 'deployFromTemplateContentLibrary';
-const CREATION_TYPE_DEPLOY_FROM_TEMPLATE_DATA_CENTER = 'deployFromTemplateDataCenter';
-const CREATION_TYPE_CLONE_AN_EXISTING_VIRTUAL_MACHINE = 'cloneAnExistingVirtualMachine';
-const CREATION_TYPE_RANCHER_OS_ISO = 'rancherOsIso';
+const CREATION_METHOD_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY = 'deployFromTemplateContentLibrary';
+const CREATION_METHOD_DEPLOY_FROM_TEMPLATE_DATA_CENTER = 'deployFromTemplateDataCenter';
+const CREATION_METHOD_CLONE_AN_EXISTING_VIRTUAL_MACHINE = 'cloneAnExistingVirtualMachine';
+const CREATION_METHOD_RANCHER_OS_ISO = 'rancherOsIso';
 
 const stringsToParams = (params, str) => {
   const index = str.indexOf('=');
@@ -124,7 +124,8 @@ export default Component.extend(NodeDriver, {
     this.initKeyValueParams('config.cfgparam', 'initParamArray');
     this.initKeyValueParams('config.vappProperty', 'initVappArray');
     this.initVappMode();
-    this.initCreationTypes();
+    this.initCreationMethods();
+    this.initCustomAttributes();
   },
 
   actions: {
@@ -156,6 +157,13 @@ export default Component.extend(NodeDriver, {
       });
     }
   },
+
+  creationMethodObserver: observer('creationMethod', function() {
+    const creationType = get(this, 'creationMethod') === CREATION_METHOD_RANCHER_OS_ISO
+      ? 'manual'
+      : 'clone';
+    set(this, 'config.creationType', creationType);
+  }),
 
   datacenterContent: computed('model.cloudCredentialId', async function() {
     const options = await this.requestOptions('data-centers', get(this, 'model.cloudCredentialId'));
@@ -270,20 +278,20 @@ export default Component.extend(NodeDriver, {
     return this.mapPathOptionsToContent(options);
   }),
 
-  showRancherOsIso: computed('config.creationType', function() {
-    return this.config.creationType === CREATION_TYPE_RANCHER_OS_ISO;
+  showRancherOsIso: computed('creationMethod', function() {
+    return get(this, 'creationMethod') === CREATION_METHOD_RANCHER_OS_ISO;
   }),
 
-  showContentLibrary: computed('config.creationType', function() {
-    return get(this, 'config.creationType') === CREATION_TYPE_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY;
+  showContentLibrary: computed('creationMethod', function() {
+    return get(this, 'creationMethod') === CREATION_METHOD_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY;
   }),
 
-  showVirtualMachine: computed('config.creationType', function() {
-    return get(this, 'config.creationType') === CREATION_TYPE_CLONE_AN_EXISTING_VIRTUAL_MACHINE;
+  showVirtualMachine: computed('creationMethod', function() {
+    return get(this, 'creationMethod') === CREATION_METHOD_CLONE_AN_EXISTING_VIRTUAL_MACHINE;
   }),
 
-  showTemplate: computed('config.creationType', function() {
-    return get(this, 'config.creationType') === CREATION_TYPE_DEPLOY_FROM_TEMPLATE_DATA_CENTER;
+  showTemplate: computed('creationMethod', function() {
+    return get(this, 'creationMethod') === CREATION_METHOD_DEPLOY_FROM_TEMPLATE_DATA_CENTER;
   }),
 
   bootstrap() {
@@ -310,27 +318,27 @@ export default Component.extend(NodeDriver, {
     set(this, `model.${ CONFIG }`, config);
   },
 
-  initCreationTypes() {
-    set(this, 'creationTypeContent', [
+  initCreationMethods() {
+    set(this, 'creationMethodContent', [
       {
-        label: this.intl.t(`nodeDriver.vmwarevsphere.creationType.${ CREATION_TYPE_DEPLOY_FROM_TEMPLATE_DATA_CENTER }`),
-        value: CREATION_TYPE_DEPLOY_FROM_TEMPLATE_DATA_CENTER
+        label: this.intl.t(`nodeDriver.vmwarevsphere.creationMethod.${ CREATION_METHOD_DEPLOY_FROM_TEMPLATE_DATA_CENTER }`),
+        value: CREATION_METHOD_DEPLOY_FROM_TEMPLATE_DATA_CENTER
       },
       {
-        label: this.intl.t(`nodeDriver.vmwarevsphere.creationType.${ CREATION_TYPE_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY }`),
-        value: CREATION_TYPE_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY
+        label: this.intl.t(`nodeDriver.vmwarevsphere.creationMethod.${ CREATION_METHOD_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY }`),
+        value: CREATION_METHOD_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY
       },
       {
-        label: this.intl.t(`nodeDriver.vmwarevsphere.creationType.${ CREATION_TYPE_CLONE_AN_EXISTING_VIRTUAL_MACHINE }`),
-        value: CREATION_TYPE_CLONE_AN_EXISTING_VIRTUAL_MACHINE
+        label: this.intl.t(`nodeDriver.vmwarevsphere.creationMethod.${ CREATION_METHOD_CLONE_AN_EXISTING_VIRTUAL_MACHINE }`),
+        value: CREATION_METHOD_CLONE_AN_EXISTING_VIRTUAL_MACHINE
       },
       {
-        label: this.intl.t(`nodeDriver.vmwarevsphere.creationType.${ CREATION_TYPE_RANCHER_OS_ISO }`),
-        value: CREATION_TYPE_RANCHER_OS_ISO
+        label: this.intl.t(`nodeDriver.vmwarevsphere.creationMethod.${ CREATION_METHOD_RANCHER_OS_ISO }`),
+        value: CREATION_METHOD_RANCHER_OS_ISO
       },
     ]);
 
-    set(this, 'config.creationType', get(this, 'creationTypeOptions.firstObject.value'));
+    set(this, 'config.creationType', get(this, 'creationMethodOptions.firstObject.value'));
   },
 
   initKeyValueParams(pairsKey, paramsKey) {

--- a/lib/nodes/addon/components/driver-vmwarevsphere/template.hbs
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/template.hbs
@@ -179,13 +179,13 @@
     <div class="row">
       <div class="col {{if showContentLibrary "span-4" "span-6"}}">
         <label class="acc-label">
-          {{t "nodeDriver.vmwarevsphere.creationType.label"}}
+          {{t "nodeDriver.vmwarevsphere.creationMethod.label"}}
         </label>
         <NewSelect
             @class="form-control"
             @useContentForDefaultValue={{true}}
-            @content={{creationTypeContent}}
-            @value={{config.creationType}}
+            @content={{creationMethodContent}}
+            @value={{creationMethod}}
         />
       </div>
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -8159,8 +8159,8 @@ nodeDriver:
     hostOptions:
       any:
         label: 'Any'
-    creationType:
-      label: Creation type
+    creationMethod:
+      label: Creation method
       deployFromTemplateContentLibrary: "Deploy from template: Content Library"
       deployFromTemplateDataCenter: "Deploy from template: Data Center"
       cloneAnExistingVirtualMachine: "Clone an existing virtual machine"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
1. Parse the 'key=value' format of custom attributes
   1. We weren't initializing custom attributes because we were not parsing the backend format appropriately. We needed to parse the 'key=value'.
1. Remove cloneFrom and contentLibrary while not used
   1. If cloneFrom and contentLibrary shouldn't be used we delete them from the config to prevent them from going being a part of the request.
1. Make creationType use the appropriate values
   1. creationType was using the wrong values after refactoring to combine two dropdowns into one. I renamed the existing config.creationType to creationMethod and now observe creationMethod to properly set config.creationType.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#23714


