### PR TITLE
[forwardport] Provide better node template UX

### DIFF
--- a/app/models/nodetemplate.js
+++ b/app/models/nodetemplate.js
@@ -1,4 +1,5 @@
 import Resource from '@rancher/ember-api-store/models/resource';
+import { reference } from '@rancher/ember-api-store/utils/denormalize';
 import { get, set, computed, defineProperty } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { ucFirst } from 'shared/utils/util';
@@ -8,9 +9,11 @@ import { isArray } from '@ember/array';
 export default Resource.extend({
   intl:         service(),
   modalService: service('modal'),
+  globalStore:  service(),
 
   type:         'nodeTemplate',
   canClone:     true,
+  creator:      reference('creatorId', 'user', 'globalStore'),
 
   init() {
     this._super(...arguments);

--- a/lib/nodes/addon/components/node-template-row/template.hbs
+++ b/lib/nodes/addon/components/node-template-row/template.hbs
@@ -13,6 +13,10 @@
   {{/if}}
 </td>
 
+<td data-title="{{dt.owner}}" class="clip">
+  {{model.creator.displayName}}
+</td>
+
 <td data-title="{{dt.provider}}" class="clip">
   {{model.displayProvider}}
 </td>

--- a/lib/nodes/addon/node-templates/controller.js
+++ b/lib/nodes/addon/node-templates/controller.js
@@ -15,6 +15,12 @@ const HEADERS = [
     translationKey: 'nodeTemplatesPage.table.name',
   },
   {
+    name:           'owner',
+    sort:           ['creator.displayName', 'name', 'id'],
+    translationKey: 'nodeTemplatesPage.table.owner',
+    width:          150,
+  },
+  {
     name:           'provider',
     sort:           ['displayProvider', 'name', 'id'],
     translationKey: 'nodeTemplatesPage.table.provider',

--- a/lib/nodes/addon/node-templates/route.js
+++ b/lib/nodes/addon/node-templates/route.js
@@ -9,6 +9,7 @@ export default Route.extend({
     return hash({
       nodeTemplates:   this.globalStore.findAll('nodeTemplate'),
       cloudCredential: this.globalStore.findAll('cloudcredential'),
+      users:           this.globalStore.findAll('user')
     });
   },
 });

--- a/lib/nodes/addon/node-templates/template.hbs
+++ b/lib/nodes/addon/node-templates/template.hbs
@@ -28,6 +28,8 @@
      headers=headers
      descending=descending
      extraSearchFields=extraSearchFields
+     groupByKey="creatorId"
+     groupByRef="nodetemplate"
      body=filteredNodeTemplates
      as |sortable kind row dt|
   }}
@@ -46,6 +48,10 @@
           </td>
         </tr>
       {{/if}}
+    {{else if (eq kind "group")}}
+      <tr class="group-row">
+        <td colspan="8" class="pl-20">{{t "nodeTemplatesPage.table.owner"}}: {{row.items.firstObject.creator.displayName}}</td>
+      </tr>
     {{else if (eq kind "norows")}}
       <tr>
         <td colspan="{{sortable.fullColspan}}" class="text-center text-muted pt-20 pb-20">

--- a/lib/shared/addon/components/node-pool-row/component.js
+++ b/lib/shared/addon/components/node-pool-row/component.js
@@ -1,11 +1,14 @@
 import Component from '@ember/component';
 import layout from './template';
-import { computed, set } from '@ember/object';
+import { computed, get, set } from '@ember/object';
 import { alias } from '@ember/object/computed';
-import { inject as service } from '@ember/service'
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
-  scope: service(),
+  access: service(),
+  scope:  service(),
+  intl:   service(),
+
 
   layout,
 
@@ -28,6 +31,18 @@ export default Component.extend({
 
       return value;
     },
+  }),
+
+  groupedNodeTemplates: computed('filteredNodeTemplates', function() {
+    const currentUserId = get(this, 'access.me.id');
+
+    return get(this, 'filteredNodeTemplates').map((template) => {
+      template.group = template.creatorId === currentUserId
+        ? get(this, 'intl').t('clusterNew.rke.nodes.myTemplatesGroup')
+        : get(this, 'intl').t('clusterNew.rke.nodes.othersTemplatesGroup');
+
+      return template;
+    });
   }),
 
   removePool() {

--- a/lib/shared/addon/components/node-pool-row/template.hbs
+++ b/lib/shared/addon/components/node-pool-row/template.hbs
@@ -21,11 +21,12 @@
     <div class="input-group input-sm p-10 pl-0">
       {{new-select
         class="input-sm"
-        content=filteredNodeTemplates
+        content=groupedNodeTemplates
         prompt="clusterNew.rke.nodes.templatePrompt"
         localizedPrompt=true
         optionLabelPath="displayName"
         optionValuePath="id"
+        optionGroupPath="group"
         value=pool.nodeTemplateId
       }}
       <div class="input-group-btn bg-primary">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -2660,6 +2660,7 @@ nodeTemplatesPage:
     noData: There are no node templates defined
     usedByNone: No Clusters
     unknown: Unknown
+    owner: Owner
 
 storageClassPage:
   header: Storage Classes
@@ -3968,6 +3969,8 @@ clusterNew:
       add: Add Node Pool
       addTemplate: Add Node Template
       templatePrompt: "Choose a Template..."
+      myTemplatesGroup: "My Teplates"
+      othersTemplatesGroup: "Other's Templates"
       hostnamePrefix: Name Prefix
       count: Count
       template: Template


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
We want to provide the owner as additional information when showing
node templates on the node templates page. We also want to make it so
that when selecting a node template the users templates will be grouped
and sorted to the top by default.

Types of changes
======
- New feature (non-breaking change which adds functionality)

Linked Issues
======
rancher/rancher#23747

Node Templates Page:
![Screen Shot 2019-10-28 at 2 56 43 PM](https://user-images.githubusercontent.com/55104481/67788426-8bf4e480-fa2f-11e9-9032-ea6d0f5bbe7c.png)

Node Template Selection: 
![Screen Shot 2019-10-28 at 4 35 06 PM](https://user-images.githubusercontent.com/55104481/67788448-97e0a680-fa2f-11e9-9f20-ae09a0ee3f3a.png)


