### PR TITLE
Use correct AKS messaging for create cluster

### DIFF
--- a/lib/shared/addon/components/cru-cluster/template.hbs
+++ b/lib/shared/addon/components/cru-cluster/template.hbs
@@ -20,7 +20,7 @@
 {{else if (eq driverInfo.name "azureaks")}}
   {{banner-message
     color="bg-warning"
-    message=(t "clusterNew.amazoneks.ingressWarning")
+    message=(t "clusterNew.azureaks.ingressWarning")
   }}
 {{/if}}
 


### PR DESCRIPTION



<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When creating an AKS cluster an alert with an EKS message. This
simply switches the message to use the AKS message.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#23601
