### PR TITLE
[Forwardport] Convert Existing Cluster to RKE Cluster Template

### DIFF
--- a/lib/global-admin/addon/cluster-templates/detail/template.hbs
+++ b/lib/global-admin/addon/cluster-templates/detail/template.hbs
@@ -2,6 +2,13 @@
   <h1 class="pull-left">
     {{model.clusterTemplate.displayName}}: {{model.clusterTemplateRevision.displayName}}
   </h1>
+  <div class="right-buttons">
+    <ActionMenu
+      class="pull-right"
+      @size="sm"
+      @model={{model.clusterTemplateRevision}}
+    />
+  </div>
 </section>
 
 <CruClusterTemplate

--- a/lib/shared/addon/components/modal-save-rke-template/component.js
+++ b/lib/shared/addon/components/modal-save-rke-template/component.js
@@ -1,0 +1,62 @@
+import Component from '@ember/component';
+import ModalBase from 'shared/mixins/modal-base';
+import layout from './template';
+import { inject as service } from '@ember/service';
+import { computed, set } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import { isEmpty } from '@ember/utils';
+
+const DEFAULT_REV_NAME = 'v1';
+
+export default Component.extend(ModalBase, {
+  globalStore:  service(),
+  growl:        service(),
+  modalService: service('modal'),
+  router:       service(),
+
+  layout,
+
+  classNames: ['modal-container', 'medium-modal'],
+
+  clusterTemplateName:         null,
+  clusterTemplateRevisionName: null,
+  cluster:                     alias('modalService.modalOpts.cluster'),
+
+  init() {
+    this._super(...arguments);
+
+    set(this, 'clusterTemplateRevisionName', DEFAULT_REV_NAME);
+  },
+
+
+  actions: {
+    save() {
+      const {
+        cluster,
+        clusterTemplateName,
+        clusterTemplateRevisionName,
+      } = this;
+
+      return cluster.doAction('saveAsTemplate', {
+        clusterTemplateName,
+        clusterTemplateRevisionName,
+      }).then(() => {
+        return this.cluster.waitForClusterTemplateToBeAttached().then(() => {
+          return this.router.transitionTo('global-admin.cluster-templates.detail', this.cluster.clusterTemplateRevisionId);
+        });
+      }).catch((err) => {
+        return this.growl.fromError(err);
+      });
+    },
+  },
+
+  saveDisabled: computed('clusterTemplateName', 'clusterTemplateRevisionName', function() {
+    const { clusterTemplateName, clusterTemplateRevisionName } = this;
+
+    if (isEmpty(clusterTemplateName) && isEmpty(clusterTemplateRevisionName)) {
+      return true;
+    }
+
+    return false;
+  }),
+});

--- a/lib/shared/addon/components/modal-save-rke-template/template.hbs
+++ b/lib/shared/addon/components/modal-save-rke-template/template.hbs
@@ -1,0 +1,33 @@
+<section class="header">
+  <h1>
+    {{t "modalSaveRkeTemplate.title" clusterName=cluster.displayName}}
+  </h1>
+  <p class="help-block">
+    {{t "modalSaveRkeTemplate.subtitle"}}
+  </p>
+</section>
+<section class="horizontal-form container-fluid">
+  <div class="row inline-form">
+    <div class="col span-6">
+      <label for="save-rke-template-cluster-template-name">
+        {{t "modalSaveRkeTemplate.name"}}{{field-required}}
+      </label>
+      <div>
+        {{input
+          type="text"
+          value=clusterTemplateName
+          id="save-rke-template-cluster-template-name"
+        }}
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="footer-actions">
+  <SaveCancel
+    @save={{action "save"}}
+    @cancel={{action "cancel"}}
+    @saveDisabled={{saveDisabled}}
+    @cancelLabel="generic.closeModal"
+  />
+</div>

--- a/lib/shared/app/components/modal-save-rke-template/component.js
+++ b/lib/shared/app/components/modal-save-rke-template/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/modal-save-rke-template/component';

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -7583,6 +7583,11 @@ modalRollbackApp:
   difference:
     label: Differences
 
+modalSaveRkeTemplate:
+  title: "Create RKE Template from {clusterName}"
+  subtitle: Create a new RKE cluster template and initial revision from the current cluster configuration. This will modify the current cluster, setting up the cluster to use the newly created cluster template and revision.
+  name: Cluster Template Name
+  revName: Cluster Template Revision Name
 modalShell:
   title: "Shell: "
 
@@ -9223,6 +9228,7 @@ action:
   rotate: Rotate Certificates
   rerun: Rerun
   run: Run
+  saveAsTemplate: Save As RKE Template
   setDefault: Set as Login Environment
   setDefaultRevision:
     success:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

This exposes the `saveAsTemplate` action on an RKE based cluster. This action is available in the actions drop down on a cluster resource. Selecting the action opens a new modal where the user is asked for the name of the cluster template, the cluster template revision is given a default name of `v1`. After successful action we wait for the `clusterTemplateRevisionId` to be populated on the cluster object where the user is then redirected to the detail view of this revision. On the detail page we've exposed the action menu for the revision where in the user can select the normal actions on a cluster template revision. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
New Feature
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#23752
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
