### PR TITLE
[forwardport] Use pspEnabled to gate project PodSecurityPolicy

### DIFF
--- a/app/components/new-edit-project/template.hbs
+++ b/app/components/new-edit-project/template.hbs
@@ -17,8 +17,7 @@
     nameRequired=true
     namePlaceholder="projectsPage.name.placeholder"
   }}
-
-  {{#if model.project.cluster.isRKE}}
+  {{#if model.project.cluster.capabilities.pspEnabled}}
     <label class="acc-label">
       {{t "projectsPage.psp.label"}}
     </label>


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When creating and editing a Project we wanted to only reveal the
PodSecurityPolicy selector if the cluster had the pspEnabled field
set to true.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#23705
