### PR TITLE
Prevent App editing from modifying state on cancel

### DIFF
--- a/app/components/new-catalog/component.js
+++ b/app/components/new-catalog/component.js
@@ -65,6 +65,7 @@ export default Component.extend(NewOrEdit, CatalogApp, ChildHook, {
   pastedAnswers:            null,
   noAppReadme:              null,
   selectedFileContetnt:     null,
+  editable:              { selectedTemplateUrl: null },
 
   isGKE:                    alias('scope.currentCluster.isGKE'),
 
@@ -98,6 +99,7 @@ export default Component.extend(NewOrEdit, CatalogApp, ChildHook, {
           set(this, 'selectedTemplateUrl', null);
         }
       }
+      set(this, 'editable.selectedTemplateUrl', get(this, 'selectedTemplateUrl'));
     });
   },
 
@@ -201,7 +203,7 @@ export default Component.extend(NewOrEdit, CatalogApp, ChildHook, {
   }),
 
   getTemplate: task(function * () {
-    var url = get(this, 'selectedTemplateUrl');
+    var url = get(this, 'editable.selectedTemplateUrl');
 
     if ( url === 'default' ) {
       let defaultUrl = get(this, 'defaultUrl');

--- a/app/components/new-catalog/template.hbs
+++ b/app/components/new-catalog/template.hbs
@@ -110,7 +110,7 @@
           localizedPrompt=true
           optionLabelPath="version"
           optionValuePath="link"
-          value=selectedTemplateUrl
+          value=editable.selectedTemplateUrl
           disabled=getTemplate.isRunning
         }}
         <p class="text-info">

--- a/lib/global-admin/addon/components/new-multi-cluster-app/component.js
+++ b/lib/global-admin/addon/components/new-multi-cluster-app/component.js
@@ -85,6 +85,10 @@ export default Component.extend(NewOrEdit, CatalogApp, {
   isClone:                   false,
   projectsToAddOnUpgrade:    null,
   projectsToRemoveOnUpgrade: null,
+  editable:                  {
+    selectedTemplateUrl:     null,
+    multiClusterApp:     { targets: [], },
+  },
 
   overridesHeaders:          OVERRIDE_HEADERS,
 
@@ -105,7 +109,11 @@ export default Component.extend(NewOrEdit, CatalogApp, {
       } else {
         this.initSelectedTemplateModel();
       }
+      set(this, 'editable.selectedTemplateUrl', get(this, 'selectedTemplateUrl'));
     });
+    if (get(this, 'multiClusterApp.targets')) {
+      set(this, 'editable.multiClusterApp.targets', [...get(this, 'multiClusterApp.targets')]);
+    }
   },
 
   didRender() {
@@ -116,8 +124,9 @@ export default Component.extend(NewOrEdit, CatalogApp, {
     addTarget(targetIn) {
       if (targetIn && !get(targetIn, 'type')) {
         const {
-          multiClusterApp, editing, projectsToAddOnUpgrade, projectsToRemoveOnUpgrade
+          editing, projectsToAddOnUpgrade, projectsToRemoveOnUpgrade
         }    = this;
+        const multiClusterApp = this.editable.multiClusterApp;
 
         let target = null;
         let toRemoveMatch = (projectsToRemoveOnUpgrade || []).findBy('projectId', get(targetIn, 'value'));
@@ -162,7 +171,7 @@ export default Component.extend(NewOrEdit, CatalogApp, {
         }
       }
 
-      get(this, 'multiClusterApp.targets').removeObject(target);
+      get(this, 'editable.multiClusterApp.targets').removeObject(target);
     },
 
     addRole(roleId, roleToRemove) {
@@ -475,7 +484,7 @@ export default Component.extend(NewOrEdit, CatalogApp, {
 
 
   getTemplate: task(function * () {
-    let url = get(this, 'selectedTemplateUrl');
+    let url = get(this, 'editable.selectedTemplateUrl');
 
     if ( url === 'default' ) {
       let defaultUrl = get(this, 'defaultUrl');
@@ -588,7 +597,7 @@ export default Component.extend(NewOrEdit, CatalogApp, {
 
   validateTargetsProjectIds() {
     let errors = [];
-    let targets = get(this, 'multiClusterApp.targets');
+    let targets = get(this, 'editable.multiClusterApp.targets');
 
     if (targets && targets.length >= 1) {
       targets.forEach((target) => {
@@ -603,8 +612,10 @@ export default Component.extend(NewOrEdit, CatalogApp, {
 
   willSave() {
     set(this, 'errors', null);
+
     const { primaryResource } = this;
 
+    set(primaryResource, 'targets', this.editable.multiClusterApp.targets);
     set(primaryResource, 'answers', this.buildAnswerMap())
 
     const ok = this.validate();

--- a/lib/global-admin/addon/components/new-multi-cluster-app/template.hbs
+++ b/lib/global-admin/addon/components/new-multi-cluster-app/template.hbs
@@ -109,7 +109,7 @@
           optionLabelPath="version"
           optionValuePath="link"
           prompt="newMultiClusterApp.version.prompt"
-          value=selectedTemplateUrl
+          value=editable.selectedTemplateUrl
         }}
       </div>
     </div>
@@ -123,7 +123,7 @@
     {{form-project-targets
       addTarget=(action "addTarget")
       removeTarget=(action "removeTarget")
-      targets=multiClusterApp.targets
+      targets=editable.multiClusterApp.targets
       projects=projects
       readOnly=readOnly
     }}

--- a/lib/shared/addon/mixins/catalog-app.js
+++ b/lib/shared/addon/mixins/catalog-app.js
@@ -34,7 +34,7 @@ export default Mixin.create({
     });
   }),
 
-  templateChanged: observer('selectedTemplateUrl', 'templateResource.defaultVersion', function() {
+  templateChanged: observer('editable.selectedTemplateUrl', 'templateResource.defaultVersion', function() {
     return this.getTemplate.perform();
   }),
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When editing both single and multi-cluster apps if you modified the
Template Version or the Target Projects and then cancelled it the
underlying store was still modified which then reflected those changes
on other pages like the single and multi-Cluster Apps pages.

To change this I cloned and nested the fields into a nested object named
'editable' and updated the primarySource on willSave for the relevant
targets subfield.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#21228
