### PR TITLE
Switch node sortkey on Workload page.

### DIFF
--- a/app/components/accordion-pod/component.js
+++ b/app/components/accordion-pod/component.js
@@ -13,24 +13,24 @@ export default Component.extend(ManageLabels, {
   headers:       [
     {
       name:           'displayState',
-      sort:           ['displayState'],
+      sort:           ['displayState', 'sortName', 'id'],
       translationKey: 'generic.state',
       width:          120
     },
     {
       name:           'name',
-      sort:           ['name'],
+      sort:           ['sortName', 'id'],
       translationKey: 'generic.name',
       width:          350
     },
     {
       name:           'displayImage',
-      sort:           ['displayImage'],
+      sort:           ['displayImage', 'displayIp', 'created'],
       translationKey: 'generic.image',
     },
     {
       name:           'node',
-      sort:           ['displayName'],
+      sort:           ['node.sortName', 'node.ipAddress', 'node.id'],
       translationKey: 'generic.node',
 
     },


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The node sortkey was displayname instead of node.displayName which
caused sorting to behave strangely.

I switched the correct sortkey of node.displayName.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#21218

![Screen Shot 2019-10-30 at 5 23 56 PM](https://user-images.githubusercontent.com/55104481/67908792-132e7f00-fb3a-11e9-8608-fde0512662ee.png)
