### PR TITLE
fix issue with angle bracket link-to in old version of ember

### DIFF
--- a/lib/global-admin/addon/settings/template.hbs
+++ b/lib/global-admin/addon/settings/template.hbs
@@ -1,14 +1,14 @@
 <section class="header has-tabs clearfix p-0">
   <ul class="tab-nav">
     <li>
-      <LinkTo @route="settings.advanced">
+      {{#link-to "settings.advanced"}}
         {{t "settingsPage.tabs.settings"}}
-      </LinkTo>
+      {{/link-to}}
     </li>
     <li>
-      <LinkTo @route="settings.features">
+      {{#link-to "settings.features"}}
         {{t "settingsPage.tabs.feature"}}
-      </LinkTo>
+      {{/link-to}}
     </li>
   </ul>
 </section>


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
There appears to be an issue in the old versions of ember regarding angle bracket link-to's, since this isn't required and was  a nicety that was backported it makes sense to just revert to the old component style. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#23771

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
