### PR TITLE
[forwardport] Fix FormContextualSelectArray to accept 1 option

### DIFF
--- a/lib/shared/addon/components/form-contextual-select-array/component.js
+++ b/lib/shared/addon/components/form-contextual-select-array/component.js
@@ -32,7 +32,7 @@ export default Component.extend({
       get(this, 'values').removeAt(index);
     }
   },
-  lastValue: computed('values', {
+  lastValue: computed('values', 'values.[]', {
     get() {
       return get(this, 'values').objectAt(get(this, 'values.length') - 1);
     },
@@ -43,7 +43,8 @@ export default Component.extend({
     }
   }),
   canAddMore: computed('filteredContent', function() {
-    return get(this, 'filteredContent.length') > 1;
+    return get(this, 'filteredContent.length') > 1
+      || get(this, 'filteredContent.length') > 0 && get(this, 'values.length') === 0;
   }),
   lastIndex: computed('values.[]', function() {
     return get(this, 'values.length') - 1;


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When there was only one option we the add button was disabled and
we couldn't add the one option.

This change fixes it so that we can still select the single option if
desired.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#23793