### PR TITLE
[forwardport] Repair vsphere node template editing

### DIFF
--- a/lib/nodes/addon/components/driver-vmwarevsphere/component.js
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/component.js
@@ -126,6 +126,8 @@ export default Component.extend(NodeDriver, {
     this.initVappMode();
     this.initCreationMethods();
     this.initCustomAttributes();
+    this.initTag();
+    this.initNetwork();
   },
 
   actions: {
@@ -352,7 +354,11 @@ export default Component.extend(NodeDriver, {
       },
     ]);
 
-    set(this, 'config.creationType', get(this, 'creationMethodOptions.firstObject.value'));
+    if (get(this, 'config.creationType') === 'manual') {
+      return set(this, 'creationMethod', CREATION_METHOD_RANCHER_OS_ISO);
+    }
+
+    set(this, 'creationMethod', get(this, 'creationMethodOptions.firstObject.value'));
   },
 
   initKeyValueParams(pairsKey, paramsKey) {
@@ -368,7 +374,9 @@ export default Component.extend(NodeDriver, {
   },
 
   initCustomAttributes() {
-    set(this, 'initialCustomAttributes', get(this, 'config.customAttribute').map((v) => {
+    const existingCustomAttributes = get(this, 'config.customAttribute') || [];
+
+    set(this, 'initialCustomAttributes', existingCustomAttributes.map((v) => {
       const [key, value] = v.split('=');
 
       return {
@@ -376,6 +384,18 @@ export default Component.extend(NodeDriver, {
         value,
       };
     }));
+  },
+
+  initTag() {
+    if (!get(this, 'config.tag')) {
+      set(this, 'config.tag', []);
+    }
+  },
+
+  initNetwork() {
+    if (!get(this, 'config.network')) {
+      set(this, 'config.network', []);
+    }
   },
 
   updateVappOptions(opts) {

--- a/lib/nodes/addon/components/driver-vmwarevsphere/template.hbs
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/template.hbs
@@ -319,6 +319,7 @@
     {{form-key-value
         allowEmptyValue=false
         keyContent=customAttributeContent
+        initialArray=initialCustomAttributes
         changedArray=(action "customAttributesChanged")
         addActionLabel="nodeDriver.vmwarevsphere.customAttributes.addActionLabel"
       }}


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When editing a vsphere node template that used a RancherOS ISO
creation method it crashed the page due to an array not existing.

I also noticed that the tags, custom attributes and networks weren't
loading when editing so I resolved those issues too.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#23809


