### PR TITLE
[Forwardport]Incorrect node memory usage gauge when cluster monitoring is enabled

### DIFF
--- a/lib/monitoring/addon/components/nodes-live/component.js
+++ b/lib/monitoring/addon/components/nodes-live/component.js
@@ -99,29 +99,6 @@ export default NodesReservation.extend(Metrics, {
     this.fetchMetrics();
   }),
 
-  cpuLive: computed('graphs.[]', function() {
-    if (!get(this, 'graphs')) {
-      return
-    }
-    const cpuGraph = (get(this, 'graphs')).filter((g) => g.graph.title === CPU_GRAPH_TITLE)[0]
-
-    if (!cpuGraph || cpuGraph === undefined) {
-      return
-    }
-
-    const { series = [] } = cpuGraph
-    const { nodes = [] } = this
-    let out = 0
-
-    const filtered = series.filter((s) => {
-      return nodes.filter((n) => n.nodeName === s.name).length > 0
-    })
-
-    filtered.map((s) => out += (s.points[1] && s.points[1][0] || 0))
-
-    return Math.round(out / filtered.length * 100)
-  }),
-
   cpuTicks: computed('graphs.[]', 'nodes.[]', function() {
     if (!get(this, 'graphs') || !get(this, 'showTicks')) {
       return
@@ -168,37 +145,14 @@ export default NodesReservation.extend(Metrics, {
     })
   }),
 
-  memoryLive: computed('graphs.[]', function() {
-    if (!get(this, 'graphs')) {
-      return
-    }
-
-    const memoryGraph = (get(this, 'graphs')).filter((g) => g.graph.title === MOMORY_GRAPH_TITLE)[0]
-
-    if (!memoryGraph || memoryGraph === undefined) {
-      return
-    }
-
-    const { series = [] } = memoryGraph
-    const { nodes = [] } = this
-    let out = 0
-
-    const filtered = series.filter((s) => {
-      return nodes.filter((n) => n.nodeName === s.name).length > 0
-    })
-
-    filtered.map((s) => out += (s.points[1] && s.points[1][0] || 0))
-
-    return Math.round((out / filtered.length) * 100)
-  }),
-
   cpuLiveTitle: computed('nodeCapcity', 'graphs.[]', 'cluster.capacity', 'intl.locale', function() {
-    const { cpuLive, nodes = [] } = this
+    const { graphs, nodes = [] } = this
 
-    if (!cpuLive) {
+    if (!graphs) {
       return 'loading'
     }
-    const { nodeCapcity = {}, graphs = [] } = this
+
+    const { nodeCapcity = {} } = this
     const cpuGraph = graphs.filter((g) => g.graph.title === CPU_GRAPH_TITLE)[0]
 
     if (!cpuGraph || cpuGraph === undefined) {
@@ -221,7 +175,11 @@ export default NodesReservation.extend(Metrics, {
     })
 
     total = formatSi(total, 1000, '', '', 0, exponentNeeded(total), 1)
-    set(this, 'cpuUsedTotal', parseSi(total))
+
+    setProperties(this, {
+      cpuUsedTotal: parseSi(total),
+      cpuLive:      Math.round(used / total * 100),
+    })
 
     return get(this, 'intl').t('clusterDashboard.liveTitle', {
       total,
@@ -230,12 +188,12 @@ export default NodesReservation.extend(Metrics, {
   }),
 
   meomoryLiveTitle: computed('nodes.@each.{memory}', 'memoryLive', 'intl.locale', function() {
-    const { memoryLive, nodes = [] } = this
+    const { graphs, nodes = [] } = this
 
-    if (!memoryLive) {
+    if (!graphs) {
       return 'loading'
     }
-    const { nodeCapcity = {}, graphs = [] } = this
+    const { nodeCapcity = {} } = this
     const graph = graphs.filter((g) => g.graph.title === MOMORY_GRAPH_TITLE)[0]
 
     if (!graph || graph === undefined) {
@@ -257,7 +215,10 @@ export default NodesReservation.extend(Metrics, {
       total += parseSi(capacity.memory)
     })
 
-    set(this, 'memoryUsedTotal', total)
+    setProperties(this, {
+      memoryUsedTotal: total,
+      memoryLive:      Math.round(used / total * 100),
+    })
 
     return get(this, 'intl').t('clusterDashboard.liveTitle', {
       total: formatSi(total, 1024, 'iB', 'B', 0, exponentNeeded(total), 1),

--- a/lib/shared/addon/utils/used-percent-gauge.js
+++ b/lib/shared/addon/utils/used-percent-gauge.js
@@ -48,8 +48,8 @@ export default function initGraph(options) {
 
       svg.attr('width', width).attr('height', height);
 
-      live = live ? `${ live }%` : '';
-      reserved = reserved ? `${ reserved }%` : '';
+      live = (live || live === 0) ? `${ live }%` : '';
+      reserved = (reserved || reserved === 0) ? `${ reserved }%` : '';
       valueLabel.text(live);
       reservedLabel.text(reserved);
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Forwardport PR https://github.com/rancher/ui/pull/3522
The usage percent should be used / total * 100.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/23824
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
