### PR TITLE
[Forwardport] Fix sorting on cloud credentials page

### DIFF
--- a/lib/global-admin/addon/security/cloud-credentials/index/controller.js
+++ b/lib/global-admin/addon/security/cloud-credentials/index/controller.js
@@ -6,10 +6,9 @@ import layout from './template';
 const HEADERS = [
   {
     name:           'name',
-    sort:           ['name'],
-    searchField:    'name',
+    sort:           ['sortName'],
+    searchField:    'displayName',
     translationKey: 'generic.name',
-    type:           'string',
   },
   {
     name:           'numberOfNodeTemplateAssociations',
@@ -33,7 +32,9 @@ export default Controller.extend({
   sortBy:            'name',
   searchText:        '',
   extraSearchFields: ['displayType'],
+  preSorts:          ['displayType'],
   headers:           HEADERS,
+  descending:        false,
 
   actions: {
     addCloudKey() {

--- a/lib/global-admin/addon/security/cloud-credentials/index/template.hbs
+++ b/lib/global-admin/addon/security/cloud-credentials/index/template.hbs
@@ -30,12 +30,12 @@
      descending=descending
      extraSearchFields=extraSearchFields
      groupByKey="displayType"
-     groupByRef="type"
      headers=headers
      rightActions=true
      searchText=searchText
      showHeader=true
      sortBy=sortBy
+     preSorts=preSorts
      as |sortable kind row dt|
   }}
     {{#if (eq kind "row")}}

--- a/lib/shared/addon/components/sortable-table/component.js
+++ b/lib/shared/addon/components/sortable-table/component.js
@@ -110,7 +110,7 @@ export default Component.extend(Sortable, StickyHeader, {
       let map = {};
 
       let groupKey = get(this, 'groupByKey');
-      let refKey   = get(this, 'groupByRef');
+      let refKey   = get(this, 'groupByRef') || '';
 
       get(this, 'pagedContent').forEach((obj) => {
         let group = get(obj, groupKey) || '';

--- a/lib/shared/addon/mixins/sortable-base.js
+++ b/lib/shared/addon/mixins/sortable-base.js
@@ -1,6 +1,7 @@
 import { alias, sort } from '@ember/object/computed';
 import Mixin from '@ember/object/mixin';
 import { get, computed } from '@ember/object';
+import { isEmpty } from '@ember/utils';
 
 export default Mixin.create({
   sortableContent: alias('model'),
@@ -34,7 +35,11 @@ export default Mixin.create({
   currentSort: computed('sortBy', 'groupByRef', 'headers.@each.{sortBy}', 'descending', function() {
     var headers = this.get('headers');
     var desc = this.get('descending');
-    let sort = this.get('preSorts') || [];
+    let sort = (this.get('preSorts') || []).slice();
+
+    if (!isEmpty(sort) && desc) {
+      sort = sort.map((s) => `${ s }:desc` );
+    }
 
     if ( get(this, 'groupByRef') ) {
       const groupSortBy = `${ get(this, 'groupByRef') }.displayName`;


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
While I was cleaning this up I found that groupByRef in cc this case did nothing
so I removed it. This exposed a bug in the sortable-table code where groupByRef
was coming back null but when we tried to get it, using embers getter, it would
fail because we passed a null value instead of an empty string.

Additionally I found that when using presorts we were continuously pushing into
the sort array on the component, which never gets reset, so I decided to clone
the array. We rarely use preSorts so it was never caught.

Additionally we never add/remove the descending key to our presorts so I've
added that. Without these when we pass the sort to embers sort we'd never
correctly sort any presorts based the descending flag.

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#23828

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
