### PR TITLE
Enable unique custom attribute key selection

### DIFF
--- a/app/components/form-contextual-key-value/component.js
+++ b/app/components/form-contextual-key-value/component.js
@@ -1,0 +1,71 @@
+import Component from '@ember/component';
+import { computed, get } from '@ember/object';
+import ObjectProxy from '@ember/object/proxy';
+import StatefulPromise from 'shared/utils/stateful-promise';
+
+
+
+export default Component.extend({
+  keyContent:           [],
+  keyValuePairs:               [],
+  addButtonClass:       'btn bg-link icon-btn mt-10',
+  keyLabel:             'formKeyValue.key.label',
+  valueLabel:           'formKeyValue.value.label',
+  keyPlaceholder:       'formKeyValue.key.placeholder',
+  valuePlaceholder:     'formKeyValue.value.placeholder',
+  actions:          {
+    onAdd() {
+      const keyValuePairs = get(this, 'keyValuePairs');
+
+      // We push a null keyValuePair and replace it so that we can get the filteredContent
+      // with the newly selected value visible to the provider of the contetFilter method.
+      keyValuePairs.pushObject(null);
+      keyValuePairs.replace(-1, 1, [{
+        key:   get(this, 'filteredKeyContent.firstObject.value'),
+        value: ''
+      }]);
+    },
+    onRemove(index) {
+      get(this, 'keyValuePairs').removeAt(index);
+    }
+  },
+  asyncKeyContent: computed('keyContent', function() {
+    return StatefulPromise.wrap(get(this, 'keyContent'), []);
+  }),
+  selections: computed('keyValuePairs.[]', 'asyncKeyContent.value', function() {
+    return this.keyValuePairs
+      .slice(0, -1)
+      .map((kvp) => {
+        const option = get(this, 'asyncKeyContent.value').find((v) => v.value === kvp.key);
+
+        return  ObjectProxy.create({
+          content: kvp,
+          label:   option ? option.label : '',
+        });
+      });
+  }),
+  lastValue: computed('keyValuePairs', 'keyValuePairs.[]', {
+    get() {
+      return get(this, 'keyValuePairs').objectAt(get(this, 'keyValuePairs.length') - 1);
+    },
+    set(key, value) {
+      get(this, 'keyValuePairs').set(get(this, 'keyValuePairs.length') - 1, value);
+
+      return value;
+    }
+  }),
+  canAddMore: computed('filteredKeyContent', function() {
+    return get(this, 'filteredKeyContent.length') > 1
+            || get(this, 'filteredKeyContent.length') > 0 && get(this, 'keyValuePairs.length') === 0;
+  }),
+  lastIndex: computed('keyValuePairs.[]', function() {
+    return get(this, 'keyValuePairs.length') - 1;
+  }),
+  filteredKeyContent: computed('asyncKeyContent.value', 'keyValuePairs.@each', 'keyValuePairs.[]', 'keyValuePairs', function() {
+    if (!get(this, 'keyContentFilter')) {
+      return get(this, 'asyncKeyContent.value') || [];
+    }
+
+    return this.keyContentFilter(get(this, 'asyncKeyContent.value'), get(this, 'keyValuePairs').slice(0, -1)) || [];
+  }),
+});

--- a/app/components/form-contextual-key-value/template.hbs
+++ b/app/components/form-contextual-key-value/template.hbs
@@ -1,0 +1,76 @@
+{{#if keyValuePairs.length}}
+    <table class="table fixed no-lines">
+        <thead>
+            <tr class="hidden-sm">
+                <th>{{t keyLabel}}</th>
+                <th width="30">&nbsp;</th>
+                <th>{{t valueLabel}}</th>
+                <th width="10">&nbsp;</th>
+                <th width="30">&nbsp;</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{#each selections as |selection index|}}
+            <tr>
+                <td data-title="{{selection.label}}">
+                    {{selection.label}}
+                </td>
+                <td class="valign-top text-center">{{t "formKeyValue.separator"}}</td>
+                <td data-title="{{selection.value}}">
+                    {{input class="form-control input-sm value" spellcheck="false" type="text" value=selection.value}}
+                </td>
+                <td>&nbsp;</td>
+                <td class="valign-top text-right">
+                    <button
+                        class="btn bg-primary btn-sm"
+                        {{action "onRemove" index}}>
+                        <i class="icon icon-minus"/>
+                        <span class="sr-only">
+                        {{t "generic.remove"}}
+                        </span>
+                    </button>
+                </td>
+            </tr>
+            {{/each}}
+            {{#if (and (not (eq keyValuePairs.length 0)) (not (eq filteredKeyContent.length 0)))}}
+            <tr>
+                <td data-title="{{lastValue.key}}">
+                    <NewSelect
+                    @selectFirstValueOnStart={{true}}
+                    @class="input-sm value"
+                    @content={{filteredKeyContent}}
+                    @value={{lastValue.key}}
+                    />
+                </td>
+                <td class="valign-top text-center">{{t "formKeyValue.separator"}}</td>
+                <td data-title="{{lastValue.value}}">
+                    {{input class="form-control input-sm value" spellcheck="false" type="text" value=lastValue.value}}
+                </td>
+                <td>&nbsp;</td>
+                <td class="valign-top text-right">
+                    <button
+                        class="btn bg-primary btn-sm"
+                        {{action "onRemove" lastIndex}}>
+                        <i class="icon icon-minus"/>
+                        <span class="sr-only">
+                        {{t "generic.remove"}}
+                        </span>
+                    </button>
+                </td>
+            </tr>
+            {{/if}}
+        </tbody>
+    </table>
+{{/if}}
+<button
+    class={{addButtonClass}}
+    {{action "onAdd"}}
+    disabled={{not canAddMore}}
+>
+    <span class="darken">
+        <i class="icon icon-plus text-small"/>
+    </span>
+    <span>
+        {{t addActionLabel}}
+    </span>
+</button>

--- a/lib/nodes/addon/components/driver-vmwarevsphere/component.js
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/component.js
@@ -114,6 +114,7 @@ export default Component.extend(NodeDriver, {
   initParamArray:       null,
   initVappArray:        null,
   initNetworkArray:     [''],
+  customAttribute:      [],
   vappMode:             VAPP_MODE_DISABLED,
   cache:                {},
 
@@ -137,9 +138,6 @@ export default Component.extend(NodeDriver, {
     vappPropertyChanged(array) {
       this.updateKeyValueParams('config.vappProperty', array);
     },
-    customAttributesChanged(array) {
-      set(this, 'config.customAttribute', array.map((a) => `${ a.key }=${ a.value }`));
-    },
     finishAndSelectCloudCredential(credential) {
       set(this, 'model.cloudCredentialId', get(credential, 'id'))
     },
@@ -156,6 +154,11 @@ export default Component.extend(NodeDriver, {
       return content.filter((c) => {
         return selectedSingleCategories.indexOf(c.category) === -1
           && values.indexOf(c.id) === -1;
+      });
+    },
+    customAttributeKeyContentFilter(keyContent, keyValuePairs) {
+      return keyContent.filter((keyContent) => {
+        return keyValuePairs.findIndex((kvp) => kvp.key === keyContent.value) === -1;
       });
     }
   },
@@ -197,7 +200,7 @@ export default Component.extend(NodeDriver, {
       category: categories.find((c) => c.name === option.category)
     }));
   }),
-  customAttributeContent: computed('model.cloudCredentialId', async function() {
+  customAttributeKeyContent: computed('model.cloudCredentialId', async function() {
     const options = await this.requestOptions('custom-attributes', get(this, 'model.cloudCredentialId'));
 
     return this.mapCustomAttributesToContent(options);
@@ -376,7 +379,7 @@ export default Component.extend(NodeDriver, {
   initCustomAttributes() {
     const existingCustomAttributes = get(this, 'config.customAttribute') || [];
 
-    set(this, 'initialCustomAttributes', existingCustomAttributes.map((v) => {
+    set(this, 'customAttribute', existingCustomAttributes.map((v) => {
       const [key, value] = v.split('=');
 
       return {
@@ -407,6 +410,9 @@ export default Component.extend(NodeDriver, {
   },
 
   willSave() {
+    const configCustomAttribute = get(this, 'customAttribute').map((kvp) => `${ kvp.key }=${ kvp.value }`);
+
+    set(this, 'config.customAttribute', configCustomAttribute);
     const vappMode = get(this, 'vappMode')
 
     if (vappMode === VAPP_MODE_DISABLED) {

--- a/lib/nodes/addon/components/driver-vmwarevsphere/template.hbs
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/template.hbs
@@ -316,14 +316,12 @@
      expand=(action expandFn)
      expandOnInit=true
   }}
-    {{form-key-value
-        initialArray=initialCustomAttributes
-        allowEmptyValue=false
-        keyContent=customAttributeContent
-        initialArray=initialCustomAttributes
-        changedArray=(action "customAttributesChanged")
-        addActionLabel="nodeDriver.vmwarevsphere.customAttributes.addActionLabel"
-      }}
+    <FormContextualKeyValue
+      @keyContent={{customAttributeKeyContent}}
+      @keyContentFilter={{action "customAttributeKeyContentFilter"}}
+      @keyValuePairs={{customAttribute}}
+      @addActionLabel="nodeDriver.vmwarevsphere.customAttributes.addActionLabel"
+    />
   {{/accordion-list-item}}
 
   {{#accordion-list-item


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The keys for custom attributes needed to be unique. To enforce the
unique constraint I created the FormContextualKeyValue component.
This component behaves similarly to the FormContextualSelectArray
but handles key value pairs.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

Linked Issues
======
rancher/rancher#23782
rancher/rancher#23845 this should could get fixed because this change removes the offending component all together. 

![Screen Shot 2019-11-01 at 3 11 20 PM](https://user-images.githubusercontent.com/55104481/68059483-e0ab9000-fcb9-11e9-8d8d-6b2b85a4273e.png)
