### PR TITLE
Switch to new implementation of creationType

### DIFF
--- a/lib/nodes/addon/components/driver-vmwarevsphere/component.js
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/component.js
@@ -11,10 +11,16 @@ const CONFIG = 'vmwarevsphereConfig';
 const VAPP_MODE_DISABLED = 'disabled';
 const VAPP_MODE_AUTO = 'auto';
 const VAPP_MODE_MANUAL = 'manual';
-const CREATION_METHOD_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY = 'deployFromTemplateContentLibrary';
-const CREATION_METHOD_DEPLOY_FROM_TEMPLATE_DATA_CENTER = 'deployFromTemplateDataCenter';
-const CREATION_METHOD_CLONE_AN_EXISTING_VIRTUAL_MACHINE = 'cloneAnExistingVirtualMachine';
-const CREATION_METHOD_RANCHER_OS_ISO = 'rancherOsIso';
+const CREATION_TYPE_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY = 'library';
+const CREATION_TYPE_DEPLOY_FROM_TEMPLATE_DATA_CENTER = 'template';
+const CREATION_TYPE_CLONE_AN_EXISTING_VIRTUAL_MACHINE = 'vm';
+const CREATION_TYPE_RANCHER_OS_ISO = 'legacy';
+const CREATION_TYPES = [
+  CREATION_TYPE_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY,
+  CREATION_TYPE_DEPLOY_FROM_TEMPLATE_DATA_CENTER,
+  CREATION_TYPE_CLONE_AN_EXISTING_VIRTUAL_MACHINE,
+  CREATION_TYPE_RANCHER_OS_ISO
+];
 
 const stringsToParams = (params, str) => {
   const index = str.indexOf('=');
@@ -125,7 +131,7 @@ export default Component.extend(NodeDriver, {
     this.initKeyValueParams('config.cfgparam', 'initParamArray');
     this.initKeyValueParams('config.vappProperty', 'initVappArray');
     this.initVappMode();
-    this.initCreationMethods();
+    this.initCreationTypes();
     this.initCustomAttributes();
     this.initTag();
     this.initNetwork();
@@ -163,21 +169,15 @@ export default Component.extend(NodeDriver, {
     }
   },
 
-  creationMethodObserver: observer('creationMethod', function() {
-    const creationType = get(this, 'creationMethod') === CREATION_METHOD_RANCHER_OS_ISO
-      ? 'manual'
-      : 'clone';
-
-    set(this, 'config.creationType', creationType);
-
-    const isContentLibraryField = get(this, 'creationMethod') === CREATION_METHOD_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY;
+  creationTypeObserver: observer('config.creationType', function() {
+    const isContentLibraryField = get(this, 'config.creationType') === CREATION_TYPE_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY;
 
     if (!isContentLibraryField && get(this, 'config.contentLibrary')) {
       set(this, 'config.contentLibrary', undefined);
     }
 
-    const isCloneFromMethod = get(this, 'creationMethod') === CREATION_METHOD_CLONE_AN_EXISTING_VIRTUAL_MACHINE
-      || get(this, 'creationMethod') === CREATION_METHOD_DEPLOY_FROM_TEMPLATE_DATA_CENTER;
+    const isCloneFromMethod = get(this, 'config.creationType') === CREATION_TYPE_CLONE_AN_EXISTING_VIRTUAL_MACHINE
+      || get(this, 'config.creationType') === CREATION_TYPE_DEPLOY_FROM_TEMPLATE_DATA_CENTER;
 
     if (!isCloneFromMethod && get(this, 'config.cloneFrom')) {
       set(this, 'config.cloneFrom', undefined);
@@ -267,11 +267,17 @@ export default Component.extend(NodeDriver, {
   }),
 
   libraryTemplateContent: computed('config.contentLibrary', async function() {
+    const contentLibrary = get(this, 'config.contentLibrary');
+
+    if (!contentLibrary) {
+      return [];
+    }
+
     const options = await this.requestOptions(
       'library-templates',
       get(this, 'model.cloudCredentialId'),
       undefined,
-      get(this, 'config.contentLibrary')
+      contentLibrary
     );
 
     return this.mapPathOptionsToContent(options);
@@ -297,20 +303,20 @@ export default Component.extend(NodeDriver, {
     return this.mapPathOptionsToContent(options);
   }),
 
-  showRancherOsIso: computed('creationMethod', function() {
-    return get(this, 'creationMethod') === CREATION_METHOD_RANCHER_OS_ISO;
+  showRancherOsIso: computed('config.creationType', function() {
+    return get(this, 'config.creationType') === CREATION_TYPE_RANCHER_OS_ISO;
   }),
 
-  showContentLibrary: computed('creationMethod', function() {
-    return get(this, 'creationMethod') === CREATION_METHOD_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY;
+  showContentLibrary: computed('config.creationType', function() {
+    return get(this, 'config.creationType') === CREATION_TYPE_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY;
   }),
 
-  showVirtualMachine: computed('creationMethod', function() {
-    return get(this, 'creationMethod') === CREATION_METHOD_CLONE_AN_EXISTING_VIRTUAL_MACHINE;
+  showVirtualMachine: computed('config.creationType', function() {
+    return get(this, 'config.creationType') === CREATION_TYPE_CLONE_AN_EXISTING_VIRTUAL_MACHINE;
   }),
 
-  showTemplate: computed('creationMethod', function() {
-    return get(this, 'creationMethod') === CREATION_METHOD_DEPLOY_FROM_TEMPLATE_DATA_CENTER;
+  showTemplate: computed('config.creationType', function() {
+    return get(this, 'config.creationType') === CREATION_TYPE_DEPLOY_FROM_TEMPLATE_DATA_CENTER;
   }),
 
   bootstrap() {
@@ -337,31 +343,30 @@ export default Component.extend(NodeDriver, {
     set(this, `model.${ CONFIG }`, config);
   },
 
-  initCreationMethods() {
-    set(this, 'creationMethodContent', [
+  initCreationTypes() {
+    set(this, 'creationTypeContent', [
       {
-        label: this.intl.t(`nodeDriver.vmwarevsphere.creationMethod.${ CREATION_METHOD_DEPLOY_FROM_TEMPLATE_DATA_CENTER }`),
-        value: CREATION_METHOD_DEPLOY_FROM_TEMPLATE_DATA_CENTER
+        label: this.intl.t(`nodeDriver.vmwarevsphere.creationType.${ CREATION_TYPE_DEPLOY_FROM_TEMPLATE_DATA_CENTER }`),
+        value: CREATION_TYPE_DEPLOY_FROM_TEMPLATE_DATA_CENTER
       },
       {
-        label: this.intl.t(`nodeDriver.vmwarevsphere.creationMethod.${ CREATION_METHOD_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY }`),
-        value: CREATION_METHOD_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY
+        label: this.intl.t(`nodeDriver.vmwarevsphere.creationType.${ CREATION_TYPE_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY }`),
+        value: CREATION_TYPE_DEPLOY_FROM_TEMPLATE_CONTENT_LIBRARY
       },
       {
-        label: this.intl.t(`nodeDriver.vmwarevsphere.creationMethod.${ CREATION_METHOD_CLONE_AN_EXISTING_VIRTUAL_MACHINE }`),
-        value: CREATION_METHOD_CLONE_AN_EXISTING_VIRTUAL_MACHINE
+        label: this.intl.t(`nodeDriver.vmwarevsphere.creationType.${ CREATION_TYPE_CLONE_AN_EXISTING_VIRTUAL_MACHINE }`),
+        value: CREATION_TYPE_CLONE_AN_EXISTING_VIRTUAL_MACHINE
       },
       {
-        label: this.intl.t(`nodeDriver.vmwarevsphere.creationMethod.${ CREATION_METHOD_RANCHER_OS_ISO }`),
-        value: CREATION_METHOD_RANCHER_OS_ISO
+        label: this.intl.t(`nodeDriver.vmwarevsphere.creationType.${ CREATION_TYPE_RANCHER_OS_ISO }`),
+        value: CREATION_TYPE_RANCHER_OS_ISO
       },
     ]);
+    const creationType = get(this, 'config.creationType');
 
-    if (get(this, 'config.creationType') === 'manual') {
-      return set(this, 'creationMethod', CREATION_METHOD_RANCHER_OS_ISO);
+    if (!creationType || CREATION_TYPES.indexOf(creationType) === -1) {
+      set(this, 'config.creationType', get(this, 'creationTypeOptions.firstObject.value'));
     }
-
-    set(this, 'creationMethod', get(this, 'creationMethodOptions.firstObject.value'));
   },
 
   initKeyValueParams(pairsKey, paramsKey) {

--- a/lib/nodes/addon/components/driver-vmwarevsphere/template.hbs
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/template.hbs
@@ -179,13 +179,13 @@
     <div class="row">
       <div class="col {{if showContentLibrary "span-4" "span-6"}}">
         <label class="acc-label">
-          {{t "nodeDriver.vmwarevsphere.creationMethod.label"}}
+          {{t "nodeDriver.vmwarevsphere.creationType.label"}}
         </label>
         <NewSelect
             @class="form-control"
             @useContentForDefaultValue={{true}}
-            @content={{creationMethodContent}}
-            @value={{creationMethod}}
+            @content={{creationTypeContent}}
+            @value={{config.creationType}}
         />
       </div>
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -8234,12 +8234,12 @@ nodeDriver:
     hostOptions:
       any:
         label: 'Any'
-    creationMethod:
+    creationType:
       label: Creation method
-      deployFromTemplateContentLibrary: "Deploy from template: Content Library"
-      deployFromTemplateDataCenter: "Deploy from template: Data Center"
-      cloneAnExistingVirtualMachine: "Clone an existing virtual machine"
-      rancherOsIso: RancherOS ISO (Deprecated)
+      library: "Deploy from template: Content Library"
+      template: "Deploy from template: Data Center"
+      vm: "Clone an existing virtual machine"
+      legacy: RancherOS ISO (Deprecated)
     access:
       title: 1. Account Access
       detail: Configure where to find the VCenter or ESXi server


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The backend has made a new implementation of creationType which allowed
me to remove the creationMethod concept and just use creationType.

This change allows us to properly populate the creation type form fields
when a user edits a vsphere nodetemplate.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#23812

Backend Changes
======
rancher/machine#45
https://github.com/rancher/rancher/pull/23910