### PR TITLE
Handle Deprecated Transition Params 

### DIFF
--- a/app/authenticated/cluster/edit/route.js
+++ b/app/authenticated/cluster/edit/route.js
@@ -46,10 +46,13 @@ export default Route.extend({
 
     if (clusterTemplateRevisionId) {
       if (clusterTemplateRevisions) {
-        let ctr  = null;
+        let ctr               = null;
+        const { queryParams } = transition.to;
 
-        if (transition.queryParams && transition.queryParams.clusterTemplateRevision) {
-          clusterTemplateRevisionId = transition.queryParams.clusterTemplateRevision;
+        if (queryParams && queryParams.clusterTemplateRevision) {
+          clusterTemplateRevisionId = queryParams.clusterTemplateRevision;
+
+          set(cluster, 'clusterTemplateRevisionId', clusterTemplateRevisionId);
         }
 
         ctr  = clusterTemplateRevisions.findBy('id', clusterTemplateRevisionId);

--- a/lib/global-admin/addon/clusters/new/launch/route.js
+++ b/lib/global-admin/addon/clusters/new/launch/route.js
@@ -28,7 +28,7 @@ export default Route.extend({
       }
 
       if (clusterTemplateEnforcement) {
-        if (clusterTemplates.length === 1 && isEmpty(transition.queryParams.clusterTemplateRevision)) {
+        if (clusterTemplates.length === 1 && isEmpty(transition.to.params.clusterTemplateRevision)) {
           return this.replaceWith(this.routeName, transition.to.params.provider, { queryParams: { clusterTemplateRevision: clusterTemplates.firstObject.defaultRevisionId } });
         }
       }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Ember deprecated `transition.queryParams` private API in favor of using the public api's either on the router service, or from a transitions to/from properties. Without these params the version switching wasn't working correctly for RKE templates when editing a cluster. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#23682
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
This does not affect the 2.3 branch because 2.3 is on ember 3.9 where master is on 3.12+
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
