### PR TITLE
[forwardport] Too many annotations are read-only

### DIFF
--- a/lib/shared/addon/components/form-labels-annotations/component.js
+++ b/lib/shared/addon/components/form-labels-annotations/component.js
@@ -96,10 +96,11 @@ export default Component.extend(ManageLabels, {
     })
 
     Object.keys((get(this, 'model.annotations') || {})).forEach((key) => {
-      if ( C.ANNOTATIONS_TO_IGNORE.find((L) => key.indexOf(L) > -1)) {
+      if ( C.ANNOTATIONS_TO_IGNORE_PREFIX.find((L) => key.startsWith(L)) || C.ANNOTATIONS_TO_IGNORE_CONTAINS.find((L) => key.indexOf(L) > -1)) {
         readonlyAnnotations.push(key);
       }
     })
+
     set(this, 'readonlyAnnotations', readonlyAnnotations);
 
     this.initLabels(this.get('initialLabels'), 'user', null, readonlyLabels);

--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -584,10 +584,16 @@ C.LABEL_PREFIX_TO_IGNORE = [
   'workload.user.cattle.io/',
 ];
 
-C.ANNOTATIONS_TO_IGNORE = [
+C.ANNOTATIONS_TO_IGNORE_CONTAINS = [
   'coreos.com/',
-  'kubernetes.io/',
   'cattle.io/',
+]
+
+C.ANNOTATIONS_TO_IGNORE_PREFIX = [
+  'kubernetes.io/',
+  'beta.kubernetes.io/',
+  'node.alpha.kubernetes.io/',
+  'volumes.kubernetes.io/',
 ]
 
 C.GRAY_OUT_SCHEDULER_STATUS_PROVIDERS = [


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Now some annotations which should be user-editable are read-only.

The primary offender is that Annotations looks for "contains kubernetes.io" instead of "starts with kubernetes.io/ like the Labels section. So that blocks nginx-ingress.kubernetes.io/* and similar.

We should use startsWith for kubernetes.io.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/23945
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
