### PR TITLE
Notify user of value missing from options

### DIFF
--- a/app/styles/base/_helpers.scss
+++ b/app/styles/base/_helpers.scss
@@ -205,6 +205,11 @@
   white-space: normal;
 }
 
+.list-small {
+  line-height: 14px;
+  padding: 0 0 0 22px;
+  margin: 0;
+}
 .list-unstyled { @include list-unstyled }
 .no-select { @include no-select }
 .no-resize { @include no-resize }

--- a/lib/nodes/addon/components/driver-vmwarevsphere/component.js
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/component.js
@@ -135,6 +135,7 @@ export default Component.extend(NodeDriver, {
     this.initCustomAttributes();
     this.initTag();
     this.initNetwork();
+    set(this, 'floof', 'floof');
   },
 
   actions: {

--- a/lib/nodes/addon/components/driver-vmwarevsphere/template.hbs
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/template.hbs
@@ -49,6 +49,7 @@
         <p class="help-block">
           {{t "nodeDriver.vmwarevsphere.dataCenter.help"}}
         </p>
+        <SelectValueCheck @values={{config.datacenter}} @options={{datacenterContent}} />
       </div>
 
       <div class="col span-6">
@@ -64,6 +65,7 @@
         <p class="help-block">
           {{t "nodeDriver.vmwarevsphere.pool.help"}}
         </p>
+        <SelectValueCheck @values={{config.pool}} @options={{resourcePoolContent}} />
       </div>
     </div>
 
@@ -81,6 +83,7 @@
         <p class="help-block">
           {{t "nodeDriver.vmwarevsphere.dataStore.help"}}
         </p>
+        <SelectValueCheck @values={{config.datastore}} @options={{dataStoreContent}} />
       </div>
       <div class="col span-6">
         <label class="acc-label">
@@ -95,6 +98,7 @@
         <p class="help-block">
           {{t "nodeDriver.vmwarevsphere.folder.help"}}
         </p>
+        <SelectValueCheck @values={{floof}} @options={{folderContent}} />
       </div>
     </div>
 
@@ -112,6 +116,7 @@
         <p class="help-block">
           {{t "nodeDriver.vmwarevsphere.host.help"}}
         </p>
+        <SelectValueCheck @values={{config.hostsystem}} @options={{hostContent}} />
       </div>
     </div>
   {{/accordion-list-item}}
@@ -274,6 +279,7 @@
           @valueLabel="nodeDriver.vmwarevsphere.network.valueLabel"
           @valuePlaceholder="nodeDriver.vmwarevsphere.network.valuePlaceholder"
         />
+        <SelectValueCheck @values={{config.network}} @options={{networkContent}} />
       </div>
     </div>
 

--- a/lib/shared/addon/components/select-value-check/component.js
+++ b/lib/shared/addon/components/select-value-check/component.js
@@ -1,0 +1,34 @@
+import Component from '@ember/component';
+import layout from './template';
+import { computed, get } from '@ember/object';
+import StatefulPromise from 'shared/utils/stateful-promise';
+
+export default Component.extend({
+  layout,
+
+  optionValues:  computed.mapBy('asyncOptions.value', 'value'),
+  asyncOptions: computed('content', function() {
+    return StatefulPromise.wrap(get(this, 'options'), []);
+  }),
+  valueArray: computed('values', function() {
+    const values = get(this, 'values');
+
+    return Array.isArray(values)
+      ? values
+      : [values];
+  }),
+  missingValues: computed('valueArray', 'optionValues', function() {
+    const optionValues = get(this, 'optionValues');
+
+    if (optionValues.length === 0) {
+      return [];
+    }
+
+    return get(this, 'valueArray').filter((value) => {
+      return optionValues.indexOf(value) === -1
+    });
+  }),
+  showMessaging: computed('values', 'missingValues.length', function() {
+    return get(this, 'values') && get(this, 'missingValues.length') > 0;
+  })
+});

--- a/lib/shared/addon/components/select-value-check/template.hbs
+++ b/lib/shared/addon/components/select-value-check/template.hbs
@@ -1,0 +1,10 @@
+{{#if showMessaging}}
+    <div class="select-value-check text-small text-warning">
+        {{t "selectValueCheck.message" values=missingValues.length}}
+        <ul class="list-small">
+            {{#each missingValues as |missingValue|}}
+                <li>"{{missingValue}}"</li>
+            {{/each}}
+        </ul>
+    </div>
+{{/if}}

--- a/lib/shared/app/components/select-value-check/component.js
+++ b/lib/shared/app/components/select-value-check/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/select-value-check/component';

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -9823,3 +9823,10 @@ pipelineNotification:
   recipients:
     required: Recipient is required
   asMessage: Send a message to
+
+selectValueCheck:
+  message: |
+    {values, plural,
+      =1 {Please select a new value. The following is no longer valid:}
+      other {Please select new values. The following are no longer valid:}
+    }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When using an older vsphere node template in the latest version it was
possible that a user entered value would not be a valid option. When
the value isn't a valid option the dropdown has nothing selected. To
improve the UX we now notify the user that the current value is no
longer valid and sask them to select a new value.


Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#23920

![Screen Shot 2019-11-07 at 4 20 55 PM](https://user-images.githubusercontent.com/55104481/68437880-932e9780-017f-11ea-9aff-ac0f7ce39ec3.png)

