### PR TITLE
Fix wrap lines feature

### DIFF
--- a/app/styles/pages/_container.scss
+++ b/app/styles/pages/_container.scss
@@ -13,7 +13,6 @@
     white-space: -pre-wrap;
     white-space: -o-pre-wrap;
     word-wrap: break-word;
-    width: auto;
   }
 }
 


### PR DESCRIPTION
Proposed changes
======
When looking at a container's logs, there is a checkbox called "Wrap lines". Activating this overrides the width of the page showing the logs, causing vertical scrolling instead of actual line wrapping. This change fixes the issue.

Types of changes
======
Bugfix

Linked Issues
======
https://github.com/rancher/rancher/issues/23993

Further comments
======
I have tested and confirmed this fix works.