### PR TITLE
[Forwardport] RKE Cluster - network plugin not editable

### DIFF
--- a/lib/shared/addon/components/check-override-allowed/template.hbs
+++ b/lib/shared/addon/components/check-override-allowed/template.hbs
@@ -1,6 +1,8 @@
 {{#if applyClusterTemplate}}
   {{#if (has-override questions=questions paramName=paramName)}}
-    {{yield}}
+    {{yield (hash
+      hasOverride=true
+      )}}
   {{else}}
     <div>
       {{#if value}}

--- a/lib/shared/addon/components/form-network-config/template.hbs
+++ b/lib/shared/addon/components/form-network-config/template.hbs
@@ -16,9 +16,10 @@
     @paramName="rancherKubernetesEngineConfig.network.plugin"
     @clusterTemplateRevision={{clusterTemplateRevision.clusterConfig}}
     @applyClusterTemplate={{applyClusterTemplate}}
+    as |override|
   >
     {{#input-or-display
-       editable=(eq mode "new")
+       editable=(or (and (eq mode "new") (or (not applyClusterTemplate) override.hasOverride)) clusterTemplateCreate)
        value=config.network.plugin
     }}
       {{new-select


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Fix network plugin being editable on rke clusters. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#23999

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
