### PR TITLE
Fix MC App Answer Validation

### DIFF
--- a/app/models/templateversion.js
+++ b/app/models/templateversion.js
@@ -57,7 +57,7 @@ export default Resource.extend({
     return out;
   }),
 
-  validationErrors() {
+  validationErrors(answersMap) {
     const {
       intl, allQuestions, valuesYaml
     } = this;
@@ -96,7 +96,7 @@ export default Resource.extend({
     } else {
       if ( filteredQuestions ) {
         filteredQuestions.forEach((item) => {
-          if ( item.required && item.type !== 'boolean' && !item.answer ) {
+          if ( item.required && item.type !== 'boolean' && isEmpty(answersMap[item.variable]) ) {
             errors.push(intl.t('validation.required', { key: item.label }));
           }
 

--- a/lib/global-admin/addon/components/new-multi-cluster-app/component.js
+++ b/lib/global-admin/addon/components/new-multi-cluster-app/component.js
@@ -84,6 +84,7 @@ export default Component.extend(NewOrEdit, CatalogApp, {
   isClone:                   false,
   projectsToAddOnUpgrade:    null,
   projectsToRemoveOnUpgrade: null,
+  mcAppIsSaving:             false,
 
   overridesHeaders:          OVERRIDE_HEADERS,
 
@@ -267,6 +268,10 @@ export default Component.extend(NewOrEdit, CatalogApp, {
   },
 
   updateAnswerOverrides: observer('selectedTemplateModel', 'multiClusterApp.answers.@each.{values}', function() {
+    if (this.mcAppSaving) {
+      return;
+    }
+
     let { selectedTemplateModel = {} } = this;
 
     const questions       = get(selectedTemplateModel, 'questions')
@@ -353,7 +358,7 @@ export default Component.extend(NewOrEdit, CatalogApp, {
     }
   }),
 
-  templateOrHelmChartQuestions: computed('selectedTemplateModel', function() {
+  templateOrHelmChartQuestions: computed('selectedTemplateModel', 'selectedTemplateModel.allQuestions.@each.{answer,variable}', function() {
     let { selectedTemplateModel, multiClusterApp } = this;
     let nueQuestions = [];
 
@@ -577,7 +582,7 @@ export default Component.extend(NewOrEdit, CatalogApp, {
     this._super(...arguments);
     const errors = get(this, 'errors') || [];
 
-    errors.pushObjects(get(this, 'selectedTemplateModel').validationErrors() || []);
+    errors.pushObjects(get(this, 'selectedTemplateModel').validationErrors(this.answers) || []);
     errors.pushObjects(this.validateTargetsProjectIds());
 
     set(this, 'errors', errors.uniq());

--- a/lib/global-admin/addon/components/new-multi-cluster-app/template.hbs
+++ b/lib/global-admin/addon/components/new-multi-cluster-app/template.hbs
@@ -368,6 +368,7 @@
     {{save-cancel
       createLabel=(if editing saveUpgrade saveNew)
       save=(action "save")
+      saving=mcAppSaving
       cancel=(action "cancel")
     }}
   </div>


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
There was a bug in multi cluster apps that did not validate the answers to the catalog apps questions correctly. Answers that were empty strings would be validated as okay because of the `!` check. Switched it over to use the `isEmpty` method. 

This revealed a bug where after an error and upon save we did not fetch the latest answers to validate against because we were not watching the correct keys on the computed property.

Additionally I saw a place where upon successful save of an upgrade, the selected template model would recompute and causing any old answer values to briefly flash on the screen before transitioning back to the correct route. I've added a check to this property that recomputes to prevent this. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#22733

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
