### PR TITLE
Change the messaging and default creationtype

### DIFF
--- a/lib/nodes/addon/components/driver-vmwarevsphere/component.js
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/component.js
@@ -381,8 +381,10 @@ export default Component.extend(NodeDriver, {
       },
     ]);
     const creationType = get(this, 'config.creationType');
+    const creationTypeNotFound = CREATION_TYPES.indexOf(creationType) === -1;
+    const isNew = !get(this, 'editing');
 
-    if (!creationType || CREATION_TYPES.indexOf(creationType) === -1) {
+    if (!creationType || creationTypeNotFound || isNew) {
       set(this, 'config.creationType', get(this, 'creationTypeOptions.firstObject.value'));
     }
   },

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -8239,7 +8239,7 @@ nodeDriver:
       library: "Deploy from template: Content Library"
       template: "Deploy from template: Data Center"
       vm: "Clone an existing virtual machine"
-      legacy: RancherOS ISO (Deprecated)
+      legacy: Install from boot2docker ISO (Legacy)
     access:
       title: 1. Account Access
       detail: Configure where to find the VCenter or ESXi server


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The backend was setting the default to legacy so that the legacy
template would still work when users migrate to the latest
version of the driver. This was causing the default value to
be legacy when creating a new vsphere template. Forcing
the backend to change the default will likely lead to problems
with the migration so we're making the change on the front end.

Ultimately we use the existing set default logic if a vsphere template
is being created (as opposed to edited) instead of just when the
creation type doesn't exist or is invalid.

We also changed the text for the legacy value to be friendlier.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#24060
