### PR TITLE
Mc.app.display.issues

### DIFF
--- a/lib/global-admin/addon/components/new-multi-cluster-app/component.js
+++ b/lib/global-admin/addon/components/new-multi-cluster-app/component.js
@@ -85,10 +85,7 @@ export default Component.extend(NewOrEdit, CatalogApp, {
   isClone:                   false,
   projectsToAddOnUpgrade:    null,
   projectsToRemoveOnUpgrade: null,
-  editable:                  {
-    selectedTemplateUrl:     null,
-    multiClusterApp:     { targets: [], },
-  },
+  editable:                  null,
   mcAppIsSaving:             false,
 
   overridesHeaders:          OVERRIDE_HEADERS,
@@ -101,6 +98,11 @@ export default Component.extend(NewOrEdit, CatalogApp, {
   init() {
     this._super(...arguments);
 
+    set(this, 'editable', {
+      selectedTemplateUrl: null,
+      multiClusterApp:     { targets: [], },
+    });
+
     this.initAttrs();
     this.initUpgradeStrategy();
 
@@ -110,6 +112,7 @@ export default Component.extend(NewOrEdit, CatalogApp, {
       } else {
         this.initSelectedTemplateModel();
       }
+
       set(this, 'editable.selectedTemplateUrl', get(this, 'selectedTemplateUrl'));
     });
     if (get(this, 'multiClusterApp.targets')) {

--- a/lib/shared/addon/components/schema/input-password/component.js
+++ b/lib/shared/addon/components/schema/input-password/component.js
@@ -22,7 +22,7 @@ export default Component.extend({
 
       set(this, 'value', randomStr);
 
-      var $field = $('INPUT');
+      var $field = $(this.element).find('INPUT');
 
       $field.attr('type', 'text');
       setTimeout(() => {

--- a/lib/shared/addon/mixins/catalog-app.js
+++ b/lib/shared/addon/mixins/catalog-app.js
@@ -7,6 +7,7 @@ import { compare as compareVersion } from 'ui/utils/parse-version';
 import { stringifyAnswer } from 'shared/utils/evaluate';
 import C from 'ui/utils/constants';
 import { evaluate } from 'shared/utils/evaluate';
+import { isEmpty } from '@ember/utils';
 
 export default Mixin.create({
   previewTabDidChange: observer('previewTab', 'previewOpen', function() {
@@ -35,7 +36,11 @@ export default Mixin.create({
   }),
 
   templateChanged: observer('editable.selectedTemplateUrl', 'templateResource.defaultVersion', function() {
-    return this.getTemplate.perform();
+    const { editable : { selectedTemplateUrl = '' } } = this;
+
+    if (!isEmpty(selectedTemplateUrl)) {
+      this.getTemplate.perform();
+    }
   }),
 
   filenames: computed('selectedTemplateModel', 'selectedTemplateModel.filesAsArray.[]', function(){


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
`templateChanged` which loads the content of what we need for a MC app was
updated to watch a new property, `editable: { selectedTemplateUrl } `. The new
property was declared on the component as an object. Observers watching a static
object that have never been fetched do not recompute. If we set the property
on init to the object it would have been declared with then additional sets on
the watched property cause the observer to recompute.

Also fixes an issue where selecting the `generate password` button causes all input to change to text. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#24057
rancher/rancher#24122
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
This may have been accomplished another way by always calling `templateChanged` from the init but it's best practice to set root properties of an ember object to primitive types or built in ember helpers (alias, computed, observer, etc); Non-primitive types should be set during the init phase. 
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
