### PR TITLE
Ensure bulk actions buttons are always on same line

### DIFF
--- a/app/styles/components/_tables.scss
+++ b/app/styles/components/_tables.scss
@@ -76,10 +76,11 @@ TABLE {
   }
 
   .fixed-header-actions {
+    background: $body-bg;
     min-height: 40px;
+    white-space: nowrap;
     width: 100%;
     z-index: 1;
-    background: $body-bg;
 
     input[type='search'] {
       width: auto;
@@ -103,7 +104,7 @@ TABLE {
           position: relative;
           left: -15px;
         }
-        
+
         .icon-stack .icon-stack-1x {
           width: initial;
         }


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Sometimes when bulk actions are rendered the JavaScript that sets the width runs before the elements are visible. Rather than add a bunch of logic tracking the visibility to deal with the race condition that is occurring I've just set the overflow of the bulk actions to not break. This is only an issue on init, once the user scrolls or clicks any where on the screen the resize handlers fire and set the width correctly so we should not see any issues on mobile vs desktop widths.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#23784
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
