### PR TITLE
Provide notification for CIS Scan is RKE only

### DIFF
--- a/app/authenticated/cluster/cis/scan/controller.js
+++ b/app/authenticated/cluster/cis/scan/controller.js
@@ -49,6 +49,7 @@ export default Controller.extend({
 
   disableRunScanButton: computed.notEmpty('runningClusterScans'),
 
+  isRKE:   computed.alias('scope.currentCluster.isRKE'),
   actions: {
     runScan() {
       get(this, 'scope.currentCluster').doAction('runSecurityScan', {
@@ -78,5 +79,4 @@ export default Controller.extend({
   clusterScans: computed('model.clusterScans.@each', function() {
     return get(this, 'model.clusterScans').filterBy('clusterId', get(this, 'scope.currentCluster.id'));
   }),
-
 });

--- a/app/authenticated/cluster/cis/scan/template.hbs
+++ b/app/authenticated/cluster/cis/scan/template.hbs
@@ -1,31 +1,39 @@
 <section class="header clearfix">
   <h1>{{t 'cis.scan.header'}}</h1>
 </section>
-
-<section>
-  {{#sortable-table
-      tableClassNames="bordered"
-      bulkActions=true
-      bulkActionHandler=bulkActionHandler
-      descending=descending
-      paging=false
-      search=true
-      sortBy=sortBy
-      headers=tableHeaders
-      body=clusterScans
-      rightActions=true
-      as |sortable kind scan dt|
-  }}
-    {{#if (eq kind "row")}}
-      <Cluster::Cis::Scan::TableRow @model={{scan}} />
-    {{else if (eq kind "norows")}}
-      <tr>
-        <td colspan="{{sortable.fullColspan}}" class="text-center text-muted pt-20 pb-20">{{t 'cis.scan.table.empty'}}</td>
-      </tr>
-    {{else if (eq kind "right-actions")}}
-      <button style="margin-left: -5px;" class="btn btn-sm bg-primary pl-40 pr-40" {{action "runScan"}} disabled={{disableRunScanButton}}>
-        {{t 'cis.scan.actions.runScan'}}
-      </button>
-    {{/if}}
-  {{/sortable-table}}
-</section>
+{{#if isRKE}}
+  <section>
+    {{#sortable-table
+        tableClassNames="bordered"
+        bulkActions=true
+        bulkActionHandler=bulkActionHandler
+        descending=descending
+        paging=false
+        search=true
+        sortBy=sortBy
+        headers=tableHeaders
+        body=clusterScans
+        rightActions=true
+        as |sortable kind scan dt|
+    }}
+      {{#if (eq kind "row")}}
+        <Cluster::Cis::Scan::TableRow @model={{scan}} />
+      {{else if (eq kind "norows")}}
+        <tr>
+          <td colspan="{{sortable.fullColspan}}" class="text-center text-muted pt-20 pb-20">{{t 'cis.scan.table.empty'}}</td>
+        </tr>
+      {{else if (eq kind "right-actions")}}
+        <button style="margin-left: -5px;" class="btn btn-sm bg-primary pl-40 pr-40" {{action "runScan"}} disabled={{disableRunScanButton}}>
+          {{t 'cis.scan.actions.runScan'}}
+        </button>
+      {{/if}}
+    {{/sortable-table}}
+  </section>
+{{else}}
+  <div class="row">
+    <div class="banner bg-info">
+      <div class="banner-icon"><i class="icon icon-info"></i></div>
+      <div class="banner-message pt-10 pb-10">{{t 'cis.scan.rkeOnly'}}</div>
+    </div>
+  </div>
+{{/if}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1040,6 +1040,7 @@ catalogPage:
 cis:
   scan:
     header: CIS Scans
+    rkeOnly: CIS Scans are only available to RKE Clusters
     actions:
       delete: Delete
       download: Download


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
On the CIS Scans page we now show a notification which informs the user
that CIS scans are only available on RKE clusters. The notification is all that is
shown on the page since the user cannot actually run a scan or view any
scans.


Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#24433
![Screen Shot 2019-12-06 at 1 31 17 PM](https://user-images.githubusercontent.com/55104481/70355942-85c50580-1830-11ea-8e07-2aeb703fe0c7.png)

