### PR TITLE
Provide more feedback when a security config is malformed

### DIFF
--- a/app/authenticated/cluster/cis/scan/controller.js
+++ b/app/authenticated/cluster/cis/scan/controller.js
@@ -4,8 +4,10 @@ import { get, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default Controller.extend({
-  scope:        service(),
-  modalService: service('modal'),
+  scope:              service(),
+  modalService:       service('modal'),
+  securityScanConfig: service(),
+
   tableHeaders: [
     {
       name:           'state',
@@ -52,6 +54,7 @@ export default Controller.extend({
   isRKE:   computed.alias('scope.currentCluster.isRKE'),
   actions: {
     runScan() {
+      this.securityScanConfig.validateSecurityScanConfig();
       get(this, 'scope.currentCluster').doAction('runSecurityScan', {
         failuresOnly: false,
         skip:         []

--- a/app/authenticated/cluster/cis/scan/detail/controller.js
+++ b/app/authenticated/cluster/cis/scan/detail/controller.js
@@ -1,20 +1,14 @@
 import Controller from '@ember/controller';
-import { computed, get, set } from '@ember/object';
+import { computed, get } from '@ember/object';
 import { inject as service } from '@ember/service';
 
-const CONFIG_MAP_FILE_KEY = 'config.json';
-const CONFIG_MAP_NAMESPACE_ID = 'security-scan';
-const CONFIG_MAP_NAME = 'security-scan-cfg';
-const CONFIG_MAP_ID = `${ CONFIG_MAP_NAMESPACE_ID }:${ CONFIG_MAP_NAME }`;
-const CONFIG_MAP_DEFAULT_DATA = { [CONFIG_MAP_FILE_KEY]: JSON.stringify({ skip: [] }) };
-
 export default Controller.extend({
-  modalService: service('modal'),
-  router:       service(),
-  scope:        service(),
-  growl:        service(),
-  intl:         service(),
-  projectStore: service('store'),
+  modalService:       service('modal'),
+  router:             service(),
+  scope:              service(),
+  growl:              service(),
+  intl:               service(),
+  securityScanConfig: service(),
 
   tableHeaders: [
     {
@@ -43,6 +37,7 @@ export default Controller.extend({
       width:          120,
     }
   ],
+  sortBy: 'id',
 
   runningClusterScans: computed.filterBy('clusterScans', 'isRunning', true),
 
@@ -50,6 +45,7 @@ export default Controller.extend({
 
   actions: {
     async runScan() {
+      this.securityScanConfig.validateSecurityScanConfig();
       await get(this, 'scope.currentCluster').doAction('runSecurityScan', {
         failuresOnly: false,
         skip:         []
@@ -68,7 +64,7 @@ export default Controller.extend({
     }
   },
 
-  tests: computed('model.scan.report', 'skipList', function() {
+  tests: computed('model.scan.report', 'securityScanConfig.skipList', function() {
     const results = get(this, 'model.scan.report.results');
 
     if (!results) {
@@ -102,69 +98,17 @@ export default Controller.extend({
         toggleSkip:        () => {
           this.toggleSkip(test.id)
         },
-        skipList:          get(this, 'skipList'),
+        skipList:          get(this, 'securityScanConfig.skipList'),
         _availableActions: []
       };
     });
   }),
 
-  securityScanConfig: computed('model.configMaps.@each', function() {
-    const configMaps = get(this, 'model.configMaps');
-    const config = configMaps.findBy('id', CONFIG_MAP_ID);
 
-    return config
-      ? config
-      : this.createAndSaveDefaultConfigMap();
-  }),
-
-  parsedSecurityScanConfig: computed('securityScanConfig.data.@each', function() {
-    try {
-      return JSON.parse(get(this, 'securityScanConfig.data')[CONFIG_MAP_FILE_KEY]);
-    } catch (error) {
-      this.growl.fromError(this.intl.t('cis.scan.detail.error.parseConfig'), error.message);
-    }
-  }).volatile(),
-
-  skipList: computed('securityScanConfig.data.@each', function() {
-    const skip = get(this, 'parsedSecurityScanConfig.skip');
-
-    return skip ? skip : [];
-  }),
 
   clusterScans: computed('model.clusterScans.@each', function() {
     return get(this, 'model.clusterScans').filterBy('clusterId', get(this, 'scope.currentCluster.id'));
   }),
-
-  createAndSaveDefaultConfigMap() {
-    try {
-      const configMaps = get(this, 'model.configMaps');
-      const systemProjectLink = get(this, 'scope.currentCluster.systemProject.links.self');
-      const creationUrl =  `${ systemProjectLink }/configmap`;
-      const recordLink =  `${ systemProjectLink }/configMaps/${ CONFIG_MAP_ID }`;
-      const configRecord = get(this, 'projectStore').createRecord({
-        type:        'configMap',
-        id:          CONFIG_MAP_ID,
-        namespaceId: CONFIG_MAP_NAMESPACE_ID,
-        name:        CONFIG_MAP_NAME,
-        data:        CONFIG_MAP_DEFAULT_DATA,
-        links:       {}
-      });
-
-      configMaps.pushObject(configRecord);
-      configRecord.save({
-        url:    creationUrl,
-        method: 'POST'
-      });
-
-      // We have to set this link after .save instead of before because .save will attempt to
-      // use the self link to save the record and saving the record isn't setting the self link.
-      set(configRecord, 'links.self', recordLink);
-
-      return configRecord;
-    } catch (error) {
-      this.growl.fromError(this.intl.t('cis.scan.detail.error.createDefault'), error.message);
-    }
-  },
 
   /**
    * Converts an id that looks like 1.1.9 into 000010000100009. This
@@ -186,43 +130,23 @@ export default Controller.extend({
   },
 
   toggleSkip(testId) {
-    const isSkipped = get(this, 'skipList').indexOf(testId) !== -1;
+    this.securityScanConfig.validateSecurityScanConfig();
+    const isSkipped = get(this, 'securityScanConfig.skipList').indexOf(testId) !== -1;
     const fn = isSkipped ? this.unskip : this.skip;
 
     fn.call(this, testId);
   },
 
   skip(testId) {
-    this.editSecurityScanConfig((value) => {
-      value.skip.push(testId);
+    const newSkipList = [...get(this, 'securityScanConfig.skipList'), testId];
 
-      return value;
-    });
+    this.securityScanConfig.editSkipList(newSkipList);
   },
 
   unskip(testId) {
-    this.editSecurityScanConfig((value) => {
-      value.skip = value.skip.filter((skippedTestId) => skippedTestId !== testId);
+    const newSkipList = get(this, 'securityScanConfig.skipList').filter((skippedTestId) => skippedTestId !== testId);
 
-      return value;
-    });
-  },
-
-  editSecurityScanConfig(editorFn) {
-    const securityScanConfig = get(this, 'securityScanConfig');
-
-    const value = get(this, 'parsedSecurityScanConfig');
-
-    if (!value) {
-      return;
-    }
-    const newValue = editorFn(value);
-
-    set(securityScanConfig, 'data', {
-      ...securityScanConfig.data,
-      [CONFIG_MAP_FILE_KEY]: JSON.stringify(newValue)
-    });
-    securityScanConfig.save();
+    this.securityScanConfig.editSkipList(newSkipList);
   },
 
   getCheckState(check) {

--- a/app/authenticated/cluster/cis/scan/detail/route.js
+++ b/app/authenticated/cluster/cis/scan/detail/route.js
@@ -4,8 +4,9 @@ import { get } from '@ember/object';
 import { hash } from 'rsvp';
 
 export default Route.extend({
-  globalStore: service(),
-  scope:       service(),
+  globalStore:        service(),
+  scope:              service(),
+  securityScanConfig: service(),
   model(params) {
     const scan = get(this, 'globalStore').find('clusterScan', params.scan_id);
 
@@ -16,7 +17,7 @@ export default Route.extend({
         return (await scan).loadReport('report');
       })(),
       nodes:      get(this, 'scope.currentCluster.nodes'),
-      configMaps: get(this, 'scope.currentCluster.systemProject').followLink('configMaps')
+      configMaps: get(this, 'securityScanConfig.asyncConfigMap')
     });
   }
 });

--- a/app/authenticated/cluster/cis/scan/route.js
+++ b/app/authenticated/cluster/cis/scan/route.js
@@ -1,10 +1,11 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import { get } from '@ember/object';
+import { get, } from '@ember/object';
 import { hash } from 'rsvp';
 
 export default Route.extend({
-  globalStore: service(),
+  globalStore:        service(),
+  securityScanConfig: service(),
 
   model() {
     const clusterScans = get(this, 'globalStore').findAll('clusterScan');
@@ -16,7 +17,8 @@ export default Route.extend({
         const reportPromises = scans.map((scan) => scan.loadReport('report'));
 
         return await Promise.all(reportPromises);
-      })()
+      })(),
+      configMaps: get(this, 'securityScanConfig.asyncConfigMap')
     });
   },
 });

--- a/lib/shared/addon/security-scan-config/service.js
+++ b/lib/shared/addon/security-scan-config/service.js
@@ -1,0 +1,120 @@
+import Service, { inject as service } from '@ember/service';
+import { computed, get, set } from '@ember/object';
+import StatefulPromise from 'shared/utils/stateful-promise';
+
+const CONFIG_MAP_FILE_KEY = 'config.json'
+const CONFIG_MAP_NAMESPACE_ID = 'security-scan';
+const CONFIG_MAP_NAME = 'security-scan-cfg';
+const CONFIG_MAP_ID = `${ CONFIG_MAP_NAMESPACE_ID }:${ CONFIG_MAP_NAME }`;
+const CONFIG_MAP_DEFAULT_VALUE = { skip: [] };
+const CONFIG_MAP_DEFAULT_DATA = { [CONFIG_MAP_FILE_KEY]: JSON.stringify(CONFIG_MAP_DEFAULT_VALUE) };
+
+export default Service.extend({
+  scope:        service(),
+  growl:        service(),
+  intl:         service(),
+  projectStore: service('store'),
+
+  FILE_KEY: CONFIG_MAP_FILE_KEY,
+
+  asyncConfigMap: computed(function() {
+    return StatefulPromise.wrap(get(this, 'scope.currentCluster.systemProject').followLink('configMaps'));
+  }),
+
+  configMaps: computed('asyncConfigMap.value', function() {
+    return get(this, 'asyncConfigMap.value');
+  }),
+
+  securityScanConfig: computed('configMaps.@each', function() {
+    return get(this, 'configMaps').findBy('id', 'security-scan:security-scan-cfg');
+  }),
+
+  parsedSecurityScanConfig: computed('securityScanConfig.data.@each', function() {
+    try {
+      return JSON.parse(get(this, 'securityScanConfig.data')[CONFIG_MAP_FILE_KEY]);
+    } catch (error) {
+      return CONFIG_MAP_DEFAULT_VALUE;
+    }
+  }).volatile(),
+
+  validateSecurityScanConfig() {
+    try {
+      const data = get(this, `securityScanConfig.data`);
+
+      if (!data) {
+        return;
+      }
+
+      const configFile = data[CONFIG_MAP_FILE_KEY];
+
+      if (!configFile) {
+        return;
+      }
+      const parsed = JSON.parse(configFile);
+
+      if (!Array.isArray(parsed.skip)) {
+        throw new Error("Security Scan Config didin't contain the 'skip' array.");
+      }
+    } catch (error) {
+      this.growl.fromError(this.intl.t('cis.scan.detail.error.parseConfig'), error.message);
+      throw error;
+    }
+  },
+
+  skipList: computed('securityScanConfig.data.@each', function() {
+    const securityScanConfig = get(this, 'securityScanConfig');
+
+    if (!securityScanConfig) {
+      return [];
+    }
+
+    const skip = get(this, 'parsedSecurityScanConfig.skip');
+
+    return Array.isArray(skip) ? skip : [];
+  }),
+
+  async editSecurityScanConfig(newValue) {
+    const securityScanConfig = await Promise.resolve(get(this, 'securityScanConfig') || this.createAndSaveDefaultConfigMap());
+
+    set(securityScanConfig, 'data', newValue);
+    securityScanConfig.save();
+  },
+
+  async createAndSaveDefaultConfigMap() {
+    try {
+      const configMaps = get(this, 'configMaps');
+      const systemProjectLink = get(this, 'scope.currentCluster.systemProject.links.self');
+      const creationUrl =  `${ systemProjectLink }/configmap`;
+      const recordLink =  `${ systemProjectLink }/configMaps/${ CONFIG_MAP_ID }`;
+      const configRecord = get(this, 'projectStore').createRecord({
+        type:        'configMap',
+        id:          CONFIG_MAP_ID,
+        namespaceId: CONFIG_MAP_NAMESPACE_ID,
+        name:        CONFIG_MAP_NAME,
+        data:        CONFIG_MAP_DEFAULT_DATA,
+        links:       {}
+      });
+
+      configMaps.pushObject(configRecord);
+      await configRecord.save({
+        url:    creationUrl,
+        method: 'POST'
+      });
+
+      // We have to set this link after .save instead of before because .save will attempt to
+      // use the self link to save the record and saving the record isn't setting the self link.
+      set(configRecord, 'links.self', recordLink);
+
+      return configRecord;
+    } catch (error) {
+      this.growl.fromError(this.intl.t('cis.scan.detail.error.createDefault'), error.message);
+    }
+  },
+
+  editSkipList(newValue) {
+    const newSkipListObject = { skip: newValue };
+    const newConfig = { [get(this, 'FILE_KEY')]: JSON.stringify(newSkipListObject) };
+
+    this.editSecurityScanConfig(newConfig);
+  }
+});

--- a/lib/shared/app/security-scan-config/service.js
+++ b/lib/shared/app/security-scan-config/service.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/security-scan-config/service';


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
We provide an error notification when the security config is malformed and
the user attempts to run a scan. We also prevent the scan from running.

We also added a default sort by 'id' on the scan detail table.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#24495
rancher/rancher#24496

