### PR TITLE
[forwardport] Ensure awsCloudProvider presense for custom clusterawsCloudProvider w…

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -24,7 +24,7 @@ import { on } from '@ember/object/evented';
 import deepSet from 'ember-deep-set';
 import { coerceVersion } from 'shared/utils/parse-version';
 
-const EXCLUDED_KEYS = ['extra_args'];
+const EXCLUDED_KEYS = ['extra_args', 'awsCloudProvider'];
 
 function camelToUnderline(str, split = true) {
   str = (str || '');
@@ -836,7 +836,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     let pojoPr = JSON.parse(JSON.stringify(removeEmpty(primaryResource, EXCLUDED_KEYS)));
     let decamelizedObj = {};
 
-    decamelizedObj = keysToDecamelize(pojoPr, void (0), ['type', 'azureCloudProvider']);
+    decamelizedObj = keysToDecamelize(pojoPr, ['awsCloudProvider'], ['type', 'azureCloudProvider']);
 
     return decamelizedObj;
   },

--- a/lib/shared/addon/utils/util.js
+++ b/lib/shared/addon/utils/util.js
@@ -436,8 +436,8 @@ function keyNotType(k) {
 
 export function removeEmpty(obj, excludedKeys = []){
   return Object.keys(obj)
-    .filter((k) => !isEmpty(obj[k]) && (typeof obj[k] !== 'object' || keyNotType(obj[k])))
-    .reduce((newObj, k) => !isArray(obj[k]) && typeof obj[k] === 'object' && excludedKeys.indexOf(k) === -1 ?
+    .filter((k) => excludedKeys.includes(k) || (!isEmpty(obj[k]) && (typeof obj[k] !== 'object' || keyNotType(obj[k]))))
+    .reduce((newObj, k) => !isArray(obj[k]) && typeof obj[k] === 'object' && !excludedKeys.includes(k) ?
       Object.assign(newObj, { [k]: removeEmpty(obj[k], excludedKeys) }) :
       Object.assign(newObj, { [k]: obj[k] }),
     {});


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
awsCloudProvider was being removed from custom clusters when editing
the YAML. This change ensures that the field is still present. It also
required modifying the removeEmpty method as it was removing fields that
were in the excludedKeys argument.


Types of changes
======

- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#24569
