### PR TITLE
Remove config map validation from run scan

### DIFF
--- a/app/authenticated/cluster/cis/scan/controller.js
+++ b/app/authenticated/cluster/cis/scan/controller.js
@@ -54,7 +54,6 @@ export default Controller.extend({
   isRKE:   computed.alias('scope.currentCluster.isRKE'),
   actions: {
     runScan() {
-      this.securityScanConfig.validateSecurityScanConfig();
       get(this, 'scope.currentCluster').doAction('runSecurityScan', {
         failuresOnly: false,
         skip:         null

--- a/app/authenticated/cluster/cis/scan/detail/controller.js
+++ b/app/authenticated/cluster/cis/scan/detail/controller.js
@@ -45,7 +45,6 @@ export default Controller.extend({
 
   actions: {
     async runScan() {
-      this.securityScanConfig.validateSecurityScanConfig();
       await get(this, 'scope.currentCluster').doAction('runSecurityScan', {
         failuresOnly: false,
         skip:         null


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Because the scan will ignore an invalid config map I'm removing
the validation from run scan so the UI can run the scan without issue.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#24496

