### PR TITLE
Make special case for the 'running' state color

### DIFF
--- a/app/models/clusterscan.js
+++ b/app/models/clusterscan.js
@@ -4,7 +4,7 @@ import moment from 'moment';
 import { downloadFile } from 'shared/utils/download-files';
 import ObjectsToCsv from 'objects-to-csv';
 
-export default Resource.extend({
+const ClusterScan = Resource.extend({
   type:          'clusterScan',
   report:        'null',
   reportPromise: null,
@@ -143,3 +143,7 @@ export default Resource.extend({
   },
 
 });
+
+ClusterScan.reopenClass({ stateMap: { 'running': { color: 'text-info' } } });
+
+export default ClusterScan;

--- a/lib/shared/addon/mixins/cattle-transitioning-resource.js
+++ b/lib/shared/addon/mixins/cattle-transitioning-resource.js
@@ -174,7 +174,7 @@ const defaultStateMap = {
   },
   'running':                  {
     icon:  'icon icon-circle-o',
-    color: 'text-info'
+    color: 'text-success'
   },
   'starting':                 {
     icon:  'icon icon-adjust',


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
I originally changed the color in transitioning which changed the
color elsewhere like the workload progress bars. We decided to
make the color of running an exceptional case in CIS scans since the
meaning of running differs here.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#24440
rancher/rancher#24639
