### PR TITLE
Make the security-scan-config load for each route

### DIFF
--- a/app/authenticated/cluster/cis/scan/detail/route.js
+++ b/app/authenticated/cluster/cis/scan/detail/route.js
@@ -15,7 +15,7 @@ export default Route.extend({
     const configMaps = (async() => {
       this.securityScanConfig.setReport(await report);
 
-      return get(this, 'securityScanConfig.asyncConfigMap');
+      return this.securityScanConfig.loadAsyncConfigMap();
     })();
 
     return hash({

--- a/app/authenticated/cluster/cis/scan/route.js
+++ b/app/authenticated/cluster/cis/scan/route.js
@@ -18,7 +18,7 @@ export default Route.extend({
 
         return await Promise.all(reportPromises);
       })(),
-      configMaps: get(this, 'securityScanConfig.asyncConfigMap')
+      configMaps: this.securityScanConfig.loadAsyncConfigMap()
     });
   },
 });

--- a/lib/shared/addon/security-scan-config/service.js
+++ b/lib/shared/addon/security-scan-config/service.js
@@ -15,18 +15,23 @@ export default Service.extend({
 
   FILE_KEY: CONFIG_MAP_FILE_KEY,
 
-  report: null,
+  report:         null,
+  asyncConfigMap: null,
 
   setReport(report) {
     set(this, 'report', report);
   },
 
-  asyncConfigMap: computed(function() {
-    return StatefulPromise.wrap(get(this, 'scope.currentCluster.systemProject').followLink('configMaps'));
-  }),
+  loadAsyncConfigMap() {
+    const asyncConfigMap = StatefulPromise.wrap(get(this, 'scope.currentCluster.systemProject').followLink('configMaps'));
+
+    set(this, 'asyncConfigMap', asyncConfigMap);
+
+    return asyncConfigMap;
+  },
 
   configMaps: computed('asyncConfigMap.value', function() {
-    return get(this, 'asyncConfigMap.value');
+    return get(this, 'asyncConfigMap.value') || [];
   }),
 
   defaultValue: computed('report.version', function() {


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The security-scan-config wasn't being reloaded when
navigating between clusters because the config map
was getting cached. This forces it to be reloaded.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#24623

