### PR TITLE
Give the skipList a default value if malformed

### DIFF
--- a/lib/shared/addon/security-scan-config/service.js
+++ b/lib/shared/addon/security-scan-config/service.js
@@ -80,16 +80,22 @@ export default Service.extend({
   },
 
   skipList: computed('securityScanConfig.data.@each', function() {
-    const securityScanConfig = get(this, 'securityScanConfig');
+    const defaultValue = [];
 
-    if (!securityScanConfig) {
-      return [];
+    try {
+      const securityScanConfig = get(this, 'securityScanConfig');
+
+      if (!securityScanConfig) {
+        return [];
+      }
+
+      const version = get(this, 'report.version');
+      const skip = get(this, `parsedSecurityScanConfig.skip`)[version];
+
+      return Array.isArray(skip) ? skip : defaultValue;
+    } catch {
+      return defaultValue;
     }
-
-    const version = get(this, 'report.version');
-    const skip = get(this, `parsedSecurityScanConfig.skip`)[version];
-
-    return Array.isArray(skip) ? skip : [];
   }),
 
   async editSecurityScanConfig(newValue) {


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
I don't want to validate the configMap in the skipList
because a malformed configMap is the equivelant of
an empty skipList for the purposes of running a scan
and displaying what is currently being skipped.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#24627