### PR TITLE
[UI] Fix the custom address surrounded by '*%' in registry credentials page

### DIFF
--- a/app/components/registry-row/template.hbs
+++ b/app/components/registry-row/template.hbs
@@ -20,7 +20,7 @@
   {{/if}}
 </td>
 <td data-title="{{dt.registry}}">
-  {{t model.displayAddress}}
+  {{model.displayAddress}}
 </td>
 <td data-title="{{dt.username}}">
   {{model.displayUsername}}

--- a/app/models/dockercredential.js
+++ b/app/models/dockercredential.js
@@ -64,7 +64,7 @@ var DockerCredential = Resource.extend({
     } else if (address === window.location.host) {
       return address;
     } else if ( PRESETS[address] ) {
-      return `cruRegistry.address.${  PRESETS[address] }`;
+      return get(this, 'intl').t(`cruRegistry.address.${  PRESETS[address] }`);
     } else {
       return address;
     }


### PR DESCRIPTION
Proposed changes
======
custom registry in registry credentials page will be translated currently.

Don't known why `t` doesn't fallback like `maybe-t` in this case. Tried to add `default`. It still doesn't work

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
https://github.com/rancher/rancher/issues/24659