### PR TITLE
Pipeline Setup Error

### DIFF
--- a/lib/pipeline/addon/components/settings-git/component.js
+++ b/lib/pipeline/addon/components/settings-git/component.js
@@ -71,22 +71,41 @@ export default Component.extend({
     },
 
     saveLimit(cb) {
-      const cpuRequest = get(this, 'settings').findBy('name', 'executor-cpu-request');
-      const cpuLimit = get(this, 'settings').findBy('name', 'executor-cpu-limit');
-      const memoryRequest = get(this, 'settings').findBy('name', 'executor-memory-request');
-      const memoryLimit = get(this, 'settings').findBy('name', 'executor-memory-limit');
+      const {
+        cpuRequest,
+        cpuLimit,
+        memoryRequest,
+        memoryLimit
+      } = this;
+      const cpuRequestSetting    = get(this, 'settings').findBy('name', 'executor-cpu-request');
+      const cpuLimitSetting      = get(this, 'settings').findBy('name', 'executor-cpu-limit');
+      const memoryRequestSetting = get(this, 'settings').findBy('name', 'executor-memory-request');
+      const memoryLimitSetting   = get(this, 'settings').findBy('name', 'executor-memory-limit');
+      const promises = [];
 
-      set(cpuRequest, 'value', `${ get(this, 'cpuRequest') }m`);
-      set(cpuLimit, 'value', `${ get(this, 'cpuLimit') }m`);
-      set(memoryRequest, 'value', `${ get(this, 'memoryRequest') }Mi`);
-      set(memoryLimit, 'value', `${ get(this, 'memoryLimit') }Mi`);
+      // there is a small possability that these values are NaN due to an issue where input-interger wouldn't set the Min value if the value inside was a NaN.
+      // this helps those that may have hit this bug before the fix and will resolve the issue the next time they open this page.
+      if (!Number.isNaN(cpuRequest)) {
+        set(cpuRequestSetting, 'value', `${ cpuRequest }m`);
+        promises.push(cpuRequestSetting.save());
+      }
 
-      return PromiseAll([
-        cpuRequest.save(),
-        cpuLimit.save(),
-        memoryRequest.save(),
-        memoryLimit.save(),
-      ]).then(() => {
+      if (!Number.isNaN(cpuLimit)) {
+        set(cpuLimitSetting, 'value', `${ cpuLimit }m`);
+        promises.push(cpuLimitSetting.save());
+      }
+
+      if (!Number.isNaN(memoryRequest)) {
+        set(memoryRequestSetting, 'value', `${ memoryRequest }Mi`);
+        promises.push(memoryRequestSetting.save());
+      }
+
+      if (!Number.isNaN(memoryLimit)) {
+        set(memoryLimitSetting, 'value', `${ memoryLimit }Mi`);
+        promises.push(memoryLimitSetting.save());
+      }
+
+      return PromiseAll(promises).then(() => {
         cb(true);
       }).catch((err) => {
         get(this, 'growl').fromError(get(this, 'intl').t('pipelinesSetting.error.limit'), err);

--- a/lib/shared/addon/components/input-integer/component.js
+++ b/lib/shared/addon/components/input-integer/component.js
@@ -31,9 +31,14 @@ export default TextField.extend({
 
     let num = parseInt(val, 10);
     let max = parseInt(this.get('max'), 10);
+    let min = parseInt(this.get('min'), 10);
 
     if ( !isNaN(num) && !isNaN(max) && num > max ) {
       val = `${ max }`;
+    }
+
+    if ( !isNaN(min) && (isNaN(num) || num < min ) ) {
+      val = `${ min }`;
     }
 
     if ( cur !== val ) {

--- a/lib/shared/addon/utils/parse-unit.js
+++ b/lib/shared/addon/utils/parse-unit.js
@@ -47,7 +47,8 @@ export function parseSi(inValue, increment = null, allowFractional = true) {
 
   inValue = inValue.replace(/,/g, '')
 
-  let [, valStr, unit, incStr] = inValue.match(/^([0-9.-]+)\s*([^0-9.-]?)([^0-9.-]?)/);
+  let [, valStr, unit, incStr] = inValue.match(/^([0-9.-]+)\s*([^0-9.-]?)([^0-9.-]?)/) || [];
+
   const val = parseFloat(valStr);
 
   if ( !unit ) {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
If the pipeline is setup with the configuration limits set to nothing an unhandled error would spawn from the parseSi method. I've added a check to this area so the method won't cause the page to explode.

The main crux of this issue though is that the input-integer component did not set the min value if the input was `NaN` which would prevent this from happening in the first place. 

As a back up measure for users who change the values via the API and then use the UI (unlikely) or hit this issue in <= 2.3 I've also added a check to the saveLimit method which only saves values that aren't NaN types. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#21608
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
The reason this validation doesn't happen at the schema level is the fields are strings and the best way to fix this would be fixing the schemas so the values are int's and let the backend deal with setting the notation if that has to be passed around. This would ensure the users can't send incorrect values from UI and API. 
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
