### PR TITLE
Provide empty configMap when it can't be retrieved

### DIFF
--- a/app/authenticated/cluster/cis/scan/controller.js
+++ b/app/authenticated/cluster/cis/scan/controller.js
@@ -49,9 +49,7 @@ export default Controller.extend({
 
   runningClusterScans: computed.filterBy('clusterScans', 'isRunning', true),
 
-  disableRunScanButton: computed.notEmpty('runningClusterScans'),
-
-  isRKE:   computed.alias('scope.currentCluster.isRKE'),
+  isRKE:                computed.alias('scope.currentCluster.isRKE'),
   actions: {
     runScan() {
       get(this, 'scope.currentCluster').doAction('runSecurityScan', {
@@ -60,6 +58,10 @@ export default Controller.extend({
       });
     }
   },
+  disableRunScanButton: computed('runningClusterScans', 'scope.currentCluster.systemProject', function() {
+    return get(this, 'runningClusterScans') || !get(this, 'scope.currentCluster.systemProject');
+  }),
+
   bulkActionHandler: computed(function() {
     return {
       download: async(scans) => {

--- a/app/authenticated/cluster/cis/scan/detail/controller.js
+++ b/app/authenticated/cluster/cis/scan/detail/controller.js
@@ -41,8 +41,6 @@ export default Controller.extend({
 
   runningClusterScans: computed.filterBy('clusterScans', 'isRunning', true),
 
-  disableRunScanButton: computed.notEmpty('runningClusterScans'),
-
   actions: {
     async runScan() {
       await get(this, 'scope.currentCluster').doAction('runSecurityScan', {
@@ -62,6 +60,10 @@ export default Controller.extend({
       });
     }
   },
+
+  disableRunScanButton: computed('runningClusterScans', 'scope.currentCluster.systemProject', function() {
+    return get(this, 'runningClusterScans') || !get(this, 'scope.currentCluster.systemProject');
+  }),
 
   tests: computed('model.scan.report', 'securityScanConfig.skipList', function() {
     const results = get(this, 'model.scan.report.results');

--- a/lib/shared/addon/security-scan-config/service.js
+++ b/lib/shared/addon/security-scan-config/service.js
@@ -23,7 +23,9 @@ export default Service.extend({
   },
 
   loadAsyncConfigMap() {
-    const asyncConfigMap = StatefulPromise.wrap(get(this, 'scope.currentCluster.systemProject').followLink('configMaps'));
+    const systemProject = get(this, 'scope.currentCluster.systemProject');
+    const configMaps = systemProject ? systemProject.followLink('configMaps') : []
+    const asyncConfigMap = StatefulPromise.wrap(configMaps);
 
     set(this, 'asyncConfigMap', asyncConfigMap);
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When the user doesn't have access to the systemProject we just
return an empty configMap so the page can proceed without error.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#24644