### PR TITLE
Ensure skipping works for multiple cis versions

### DIFF
--- a/app/authenticated/cluster/cis/scan/controller.js
+++ b/app/authenticated/cluster/cis/scan/controller.js
@@ -49,7 +49,7 @@ export default Controller.extend({
 
   runningClusterScans: computed.filterBy('clusterScans', 'isRunning', true),
 
-  isRKE:                computed.alias('scope.currentCluster.isRKE'),
+  isRKE:   computed.alias('scope.currentCluster.isRKE'),
   actions: {
     runScan() {
       get(this, 'scope.currentCluster').doAction('runSecurityScan', {
@@ -59,7 +59,7 @@ export default Controller.extend({
     }
   },
   disableRunScanButton: computed('runningClusterScans', 'scope.currentCluster.systemProject', function() {
-    return get(this, 'runningClusterScans') || !get(this, 'scope.currentCluster.systemProject');
+    return get(this, 'runningClusterScans.length') > 0 || !get(this, 'scope.currentCluster.systemProject');
   }),
 
   bulkActionHandler: computed(function() {

--- a/app/authenticated/cluster/cis/scan/detail/controller.js
+++ b/app/authenticated/cluster/cis/scan/detail/controller.js
@@ -62,7 +62,7 @@ export default Controller.extend({
   },
 
   disableRunScanButton: computed('runningClusterScans', 'scope.currentCluster.systemProject', function() {
-    return get(this, 'runningClusterScans') || !get(this, 'scope.currentCluster.systemProject');
+    return get(this, 'runningClusterScans.length') > 0 || !get(this, 'scope.currentCluster.systemProject');
   }),
 
   tests: computed('model.scan.report', 'securityScanConfig.skipList', function() {

--- a/lib/shared/addon/security-scan-config/service.js
+++ b/lib/shared/addon/security-scan-config/service.js
@@ -77,7 +77,7 @@ export default Service.extend({
         return;
       }
 
-      if (!Array.isArray(parsed.skip[version])) {
+      if (parsed.skip[version] && !Array.isArray(parsed.skip[version])) {
         throw new Error("Security Scan Config didin't contain the 'skip' array.");
       }
     } catch (error) {
@@ -145,7 +145,14 @@ export default Service.extend({
 
   editSkipList(newValue) {
     const version = get(this, 'report.version');
-    const newSkipListObject = { skip: { [version]: newValue } };
+
+    const existingSkip = get(this, 'parsedSecurityScanConfig.skip') || {};
+    const newSkipListObject = {
+      skip: {
+        ...existingSkip,
+        [version]: newValue
+      }
+    };
     const newConfig = { [get(this, 'FILE_KEY')]: JSON.stringify(newSkipListObject) };
 
     this.editSecurityScanConfig(newConfig);


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
We validating the security scan config appropriately when
a version was already present in the skip list. This now
ensures a version exists before verifying that it contains an array.

We were also replacing the existing skip object in the
security-scan-config which prevented us from storing
multiple versions at a time. We now extend the object
instead using the spread operator.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#24733
rancher/rancher#24742