### PR TITLE
Remove cloud_provider if it's not intended

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -768,6 +768,11 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       // get rid of undefined
       config = JSON.parse(JSON.stringify(config));
 
+      // We are assuming that the presentce of name indicates that
+      // cloud_provider should be present otherwise we remove it.
+      if (!cpConfig.name) {
+        delete config.rancher_kubernetes_engine_config.cloud_provider;
+      }
 
       if ( cpConfig ) {
         cpConfig = removeEmpty(cpConfig, EXCLUDED_KEYS);


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
We were erroneously adding cloud_provider.awsCloudProvider on
digital ocean etc due to rancher/rancher#24515.

This change assumes that the presence of
onfig.rancher_kubernetes_engine_config.cloud_provider.name
implies that the cloud_provider should be present. If that
nested field isn't present we remove cloud_provider.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#24745
