### PR TITLE
[2.3] remove display of 'edit yaml' button on step > 1 for custom cluster

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -14,7 +14,7 @@
     </h2>
   </div>
   <div class="right-buttons">
-    {{#if (or (not applyClusterTemplate) (and (eq step 1) (not applyClusterTemplate)))}}
+    {{#if (or (and isEdit (not applyClusterTemplate)) (and (lte step 1) (not applyClusterTemplate)))}}
       {{#if pasteOrUpload}}
         <button {{action "cancel"}} type="button" class="btn btn-sm bg-primary" disabled={{not canEditForm}}>
           {{#if notView}}


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
There is no need to show the `edit yaml` button when launching a custom cluster and you're past step 1 because. Non of the changes applied on the second step of launching a cluster apply to the cluster config and only change the command the user is running. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#24749
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
