### PR TITLE
[backport] Broken promise 2.3

### DIFF
--- a/lib/shared/addon/utils/stateful-promise.js
+++ b/lib/shared/addon/utils/stateful-promise.js
@@ -18,11 +18,12 @@ export default class StatefulPromise {
         loaded:  true,
         value
       });
-    }, (value) => {
+    }, (errorValue) => {
       setProperties(promise, {
         loading: false,
         error:   true,
-        value
+        value:   defaultValue,
+        errorValue
       });
     });
 


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When the promise was rejected it took the error value and
set that as the value of the promise.

This lead to code expecting one shape to completely fail. This
now assigns the errorValue to an errorValue property on the
promise and the defaultValue to value when a promise is rejected.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#24620
