### PR TITLE
[2.3.4] delete the istio-system namespace when disabling istio

### DIFF
--- a/lib/istio/addon/components/modal-delete-istio/component.js
+++ b/lib/istio/addon/components/modal-delete-istio/component.js
@@ -33,11 +33,12 @@ export default Component.extend(ModalBase, {
       const {
         istioApp, onlyIstio, cluster
       } = this
+      const { systemProject } = cluster;
+      const istioSystemNamespace       = ( systemProject.namespaces || []).findBy('id', 'istio-system');
 
       set(this, 'saving', true)
 
-      const disableIstio = istioApp.delete()
-      const promises = [disableIstio]
+      const promises = [istioApp.delete(), istioSystemNamespace.delete()];
 
       if (!onlyIstio) {
         promises.pushObject(cluster.doAction('disableMonitoring'))

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -7244,8 +7244,8 @@ machineTemplatesPage:
 modalDeleteIstio:
   title: 'Are you sure you want to disable:'
   onlyIstio:
-    true: Istio Only
-    false: Both Istio and Monitoring
+    true: Istio and remove Istio system namespace
+    false: Istio, Monitoring and remove Istio system namespace
   disable: Disable
   disabling: Disabling
 


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
In order for Istio to be redeployed after being disabled we have to remove the istio-system namespace. This PR adds that functionality. I also update the labels to indicate this will happen. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#24850
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
