### PR TITLE
Fixed trimming blank lines in multiline values of secrets breaks RSA format 

### DIFF
--- a/app/components/cru-secret/template.hbs
+++ b/app/components/cru-secret/template.hbs
@@ -53,6 +53,7 @@
     base64Value=true
     concealValue=true
     editing=notView
+    trimWhenMultiLines=false
     changed=(action "updateData")
   }}
 </div>

--- a/lib/shared/addon/components/form-key-value/component.js
+++ b/lib/shared/addon/components/form-key-value/component.js
@@ -57,6 +57,12 @@ function removeEmptyEntries(ary, allowEmptyValue = false) {
   ary.removeObjects(toRemove);
 }
 
+function isMultiline(val){
+  let lines = val.split(/\r?\n/);
+
+  return lines.length > 1;
+}
+
 export default Component.extend(Upload, {
   layout,
   // Inputs
@@ -79,6 +85,7 @@ export default Component.extend(Upload, {
   showNoneLabel:        true,
   concealValue:         false,
   editing:              true,
+  trimWhenMultiLines:   true,
   kvSeparator:          '=',
   separators:           ['=', ': '],
   addActionLabel:       'formKeyValue.addAction',
@@ -210,7 +217,14 @@ export default Component.extend(Upload, {
       var v;
 
       if ( get(row, 'value') !== undefined && get(row, 'value') !== null ) {
-        v =  (`${ get(row, 'value')  }`).trim();
+        v =  (`${ get(row, 'value')  }`);
+        if ( isMultiline(v) ) {
+          if ( this.trimWhenMultiLines ) {
+            v = v.trim()
+          }
+        } else {
+          v = v.trim()
+        }
       }
 
       if ( get(this, 'base64Value') ) {


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->
**Problem:** 
When adding secrets of RSA private keys, blank lines at the end of the file are trimmed, which breaks its format.

**Solution:** 
Added condition for trimming multiline inputs, and set to false when adding secrets

Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

https://github.com/rancher/rancher/issues/24577

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
