### PR TITLE
Fixed edit as yaml in cluster options stuck on "saving"

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -881,6 +881,10 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     let { yamlValue } = this;
     let decamledYaml = this.parseOptsFromYaml(yamlValue);
 
+    if (!decamledYaml){
+      return;
+    }
+
     if (decamledYaml && isEmpty(decamledYaml.rancherKubernetesEngineConfig)) {
       set(this, 'clusterOptErrors', [`Cluster Options Parse Error: Missing rancher_kubernetes_engine_config key`]);
 
@@ -932,6 +936,8 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
         if (this.updateFromYaml) {
           this.updateFromYaml(newOpts);
         }
+      } else {
+        return false;
       }
     }
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->
Fixed when adding rke templates, edit as YAML in cluster options is not returning, which causes the button stays "saving".

Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 
https://github.com/rancher/rancher/issues/24767

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
