### PR TITLE
[2.3] Help Text and Label Text Updates

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -476,6 +476,32 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     }
   })),
 
+  showUpgradeK8sWarning: computed(
+    'selectedClusterTemplateId',
+    'applyClusterTemplate',
+    'initialVersion',
+    'model.clusterTemplateRevision.clusterConfig.rancherKubernetesEngineConfig.kubernetesVersion',
+    function() {
+      const {
+        applyClusterTemplate,
+        initialVersion,
+        isEdit,
+      } = this;
+      const ctrK8sVersion = get(this, 'model.clusterTemplateRevision.clusterConfig.rancherKubernetesEngineConfig.kubernetesVersion');
+
+      try {
+        if (isEdit && applyClusterTemplate) {
+          if (initialVersion && ctrK8sVersion && Semver.lt(initialVersion, ctrK8sVersion)) {
+            return true;
+          }
+        }
+      } catch (err) {
+        return false;
+      }
+
+      return false;
+    }),
+
   filteredClusterTemplates: computed('model.clusterTemplates.@each.{id,state,name,members}', function() {
     let { model: { clusterTemplates } } = this;
 

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -169,6 +169,11 @@
                   @showNotAllowed=true
                 />
               </CheckOverrideAllowed>
+              {{#if showUpgradeK8sWarning}}
+                <p class="help-block">
+                  {{t "formVersions.helpBlock.label" htmlSafe=true}}
+                </p>
+              {{/if}}
             </div>
           </div>
 

--- a/lib/shared/addon/components/form-network-config/template.hbs
+++ b/lib/shared/addon/components/form-network-config/template.hbs
@@ -201,6 +201,9 @@
           placeholder=(t "clusterNew.rke.networkMTU.detail")
         }}
       {{/input-or-display}}
+      <p class="help-block">
+        {{t "clusterNew.rke.networkMTU.help"}}
+      </p>
     </CheckOverrideAllowed>
 
   </div>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4029,7 +4029,8 @@ clusterNew:
     networkPolicy:
       label: Project Network Isolation
     networkMTU:
-      label: Network MTU
+      label: CNI Plugin MTU Override
+      help: "Only applied if the value is non-zero. When applied, the MTU value is explicitly configured for the chosen network provider (disabling auto-discovery). The override must be calculated from the host's MTU minus the CNI plugin's required overhead."
       detail: e.g. 1500
     version:
       label: Kubernetes Version


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This PR addresses two issues regarding helper text and labels.

Change label and add help block for the CNI Plugin MTU config on RKE based clusters.
Fixes a bug where the k8s version upgrade helper text was not showing up on a cluster launched with a template which was subsequently upgraded to a new template with a new k8s version. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#24829
rancher/rancher#24929
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
