### PR TITLE
A number of small fixes for CIS Scans

### DIFF
--- a/app/authenticated/cluster/cis/scan/detail/controller.js
+++ b/app/authenticated/cluster/cis/scan/detail/controller.js
@@ -126,9 +126,11 @@ export default Controller.extend({
 
     return splitId
       .map((column) => {
-        const columnPaddingWidth = Math.max(columnWidth - column.length, 0)
+        const suffix = column.match(/[a-z]$/i) ? '' : 'a';
+        const columnWithSuffix = column + suffix;
+        const columnPaddingWidth = Math.max(columnWidth - columnWithSuffix.length, 0)
 
-        return '0'.repeat(columnPaddingWidth) + column;
+        return '0'.repeat(columnPaddingWidth) + columnWithSuffix;
       })
       .join('');
   },

--- a/app/authenticated/cluster/cis/scan/detail/controller.js
+++ b/app/authenticated/cluster/cis/scan/detail/controller.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { computed, get } from '@ember/object';
+import { computed, get, set } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default Controller.extend({
@@ -58,6 +58,9 @@ export default Controller.extend({
         resources:        [get(this, 'model.scan')],
         onDeleteFinished: () => get(this, 'router').replaceWith('authenticated.cluster.cis/scan')
       });
+    },
+    clearSearchText() {
+      set(this, 'searchText', '');
     }
   },
 

--- a/app/authenticated/cluster/cis/scan/detail/template.hbs
+++ b/app/authenticated/cluster/cis/scan/detail/template.hbs
@@ -25,6 +25,11 @@
             class="input-sm pull-right ember-text-field ember-view" 
             type="search" 
           />
+          {{#if searchText}}
+            <span class="input-group-btn">
+              <button class="btn bg-transparent text-info pl-10 pr-10" {{action "clearSearchText"}}><i class="icon icon-close"></i></button>
+            </span>
+          {{/if}}
         </div>
       </div>  
       <button class="btn btn-sm bg-primary pl-40 pr-40 ml-20" {{action "runScan"}} disabled={{disableRunScanButton}}>

--- a/app/models/clusterscan.js
+++ b/app/models/clusterscan.js
@@ -121,15 +121,15 @@ const ClusterScan = Resource.extend({
   },
 
   getNodesAndStateForTestResult(testResult) {
+    const nodeNames = this.getNodeNamesFromNodeType(testResult.node_type);
+
     if (testResult.state === 'skip') {
       return {
-        nodes:       [],
+        nodes:       nodeNames,
         passedNodes: [],
         failedNodes: []
       }
     }
-
-    const nodeNames = this.getNodeNamesFromNodeType(testResult.node_type);
 
     if (testResult.state === 'pass') {
       return {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
- Adding the clear button to the detail page search input
- Add nodes to skipped test in the csv download
   - We want to display the nodes the test would run on even if it was skipped.
- Add support for lettered suffixes when sorting
   - When sorting CIS scan tests by number the lettered suffixes weren't sorting properly. This adds support for sorting numbers such as 1.1.37b.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#24750
rancher/rancher#24725
rancher/rancher#24715

