### PR TITLE
[2.3.5] Missing Remove Button Cluster Members

### DIFF
--- a/lib/shared/addon/components/form-members/template.hbs
+++ b/lib/shared/addon/components/form-members/template.hbs
@@ -16,6 +16,7 @@
             @roleTemplate={{defRole}}
             @pageType={{primaryResource.type}}
             @noUpdate={{true}}
+            @isCreatorMember={{true}}
           />
         {{/each}}
       {{/if}}

--- a/lib/shared/addon/components/project-member-row/component.js
+++ b/lib/shared/addon/components/project-member-row/component.js
@@ -51,6 +51,7 @@ export default Component.extend({
   principal:            null,
   external:             null,
   noUpdate:             false,
+  isCreatorMember:      false,
   principalId:          null,
   principalGravatarSrc: null,
 

--- a/lib/shared/addon/components/project-member-row/template.hbs
+++ b/lib/shared/addon/components/project-member-row/template.hbs
@@ -47,9 +47,7 @@
 </td>
 <td>&nbsp;</td>
 <div class="input-group-btn">
-  {{#unless noUpdate}}
-    <button class="btn bg-primary btn-sm" {{action "remove"}}>
-      <i class="icon icon-minus" />
-    </button>
-  {{/unless}}
+  <button class="btn bg-primary btn-sm" {{action "remove"}}>
+    <i class="icon icon-minus" />
+  </button>
 </div>

--- a/lib/shared/addon/components/project-member-row/template.hbs
+++ b/lib/shared/addon/components/project-member-row/template.hbs
@@ -47,7 +47,9 @@
 </td>
 <td>&nbsp;</td>
 <div class="input-group-btn">
-  <button class="btn bg-primary btn-sm" {{action "remove"}}>
-    <i class="icon icon-minus" />
-  </button>
+  {{#unless isCreatorMember}}
+    <button class="btn bg-primary btn-sm" {{action "remove"}}>
+      <i class="icon icon-minus" />
+    </button>
+  {{/unless}}
 </div>


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Changed the remove button logic as noUpdate doesn't mean the user can't remove the member. The remove button should only be disabled for the dummy row that is displayed when creating a cluster or project. The dummy row is displayed so the creator knows they will be added as a member, the backend does this automatically on create so we dont have to do it our selves.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#24934
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
