### PR TITLE
[2.3] Azure aks get the latest satisfying version from versions

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-azureaks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-azureaks/component.js
@@ -3,12 +3,15 @@ import Component from '@ember/component'
 import {
   computed, get, set, setProperties, observer
 } from '@ember/object';
+import { alias } from '@ember/object/computed';
 import layout from './template';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { on } from '@ember/object/evented';
 import ipaddr from 'ipaddr.js';
 import { equal } from '@ember/object/computed'
+import C from 'shared/utils/constants';
+import Semver  from 'semver';
 
 import {
   sizes,
@@ -32,6 +35,7 @@ const NETWORK_PLUGINS = [
 export default Component.extend(ClusterDriver, {
   globalStore:  service(),
   intl:         service(),
+  settings:     service(),
   layout,
   configField:  'azureKubernetesServiceConfig',
 
@@ -42,6 +46,7 @@ export default Component.extend(ClusterDriver, {
   netMode:                'default',
   monitoringRegionConent: [],
   networkPlugins:         NETWORK_PLUGINS,
+  defaultK8sVersionRange: alias(`settings.${ C.SETTING.VERSION_SYSTEM_K8S_DEFAULT_RANGE }`),
 
   editing:       equal('mode', 'edit'),
   isNew:         equal('mode', 'new'),
@@ -115,6 +120,12 @@ export default Component.extend(ClusterDriver, {
 
       return hash(aksRequest).then((resp) => {
         const { versions, virtualNetworks } = resp;
+        const versionz                      = (get(versions, 'body') || []);
+        const initialVersion                = Semver.maxSatisfying(versionz, this.defaultK8sVersionRange);
+
+        if (initialVersion) {
+          set(this, 'cluster.azureKubernetesServiceConfig.kubernetesVersion', initialVersion);
+        }
 
         setProperties(this, {
           step:            2,


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Azure config has a default K8s version that is back in the 1.11 era. We should grab the latest satisfying version from the returned versions call. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/25100
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
