### PR TITLE
Fix broken jquery dom targeting

### DIFF
--- a/app/components/input-files/component.js
+++ b/app/components/input-files/component.js
@@ -43,7 +43,7 @@ export default Component.extend({
     },
 
     upload() {
-      $('.input-files')[0].click();
+      $(this.element).find('.input-files').click();
     },
 
     remove(file) {

--- a/lib/logging/addon/components/logging/input-logging-config/component.js
+++ b/lib/logging/addon/components/logging/input-logging-config/component.js
@@ -47,7 +47,7 @@ export default Component.extend(ThrottledResize, {
 
   actions: {
     click() {
-      $('INPUT[type=file]')[0].click();
+      $(this.element).find('INPUT[type=file]').click();
     },
 
     updateValue(value) {

--- a/lib/shared/addon/components/input-text-file/component.js
+++ b/lib/shared/addon/components/input-text-file/component.js
@@ -34,7 +34,7 @@ export default Component.extend({
 
   actions: {
     click() {
-      $('INPUT[type=file]')[0].click();
+      $(this.element).find('INPUT[type=file]').click();
     },
 
     wantsChange() {
@@ -49,6 +49,7 @@ export default Component.extend({
       return get(this, 'accept');
     }
   }),
+
   change(event) {
     var input = event.target;
 

--- a/lib/shared/addon/components/input-yaml/component.js
+++ b/lib/shared/addon/components/input-yaml/component.js
@@ -62,7 +62,7 @@ export default Component.extend(ThrottledResize, {
 
   actions: {
     click() {
-      $('INPUT[type=file]')[0].click();
+      $(this.element).find('INPUT[type=file]').click()
     },
 
     wantsChange() {

--- a/lib/shared/addon/mixins/input-answers.js
+++ b/lib/shared/addon/mixins/input-answers.js
@@ -9,7 +9,7 @@ export default Mixin.create({
 
   actions: {
     upload() {
-      $('INPUT[type=file]')[0].click();
+      $(this.element).find('INPUT[type=file]').click();
     },
     showPaste() {
       set(this, 'pasteOrUpload', true);

--- a/lib/shared/addon/mixins/upload.js
+++ b/lib/shared/addon/mixins/upload.js
@@ -8,7 +8,7 @@ export default Mixin.create({
 
   actions: {
     upload() {
-      $('INPUT[type=file]')[0].click();
+      $(this.element).find('INPUT[type=file]').click();
     },
   },
 


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Fixes broken jquery element targeting in upload-*ish* components. We were not targeting the elements inside the component. In the case of auth setup where we display 3 file inputs on SAML providers this would cause the click to open a file to only target the first component. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#24960
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
