### PR TITLE
Global Roles Bugs

### DIFF
--- a/lib/global-admin/addon/components/new-edit-role/component.js
+++ b/lib/global-admin/addon/components/new-edit-role/component.js
@@ -69,11 +69,12 @@ export default Component.extend(ViewNewEdit, {
 
     addRule() {
       get(this, 'ruleArray').pushObject({
-        apiGroups: ['*'],
-        type:      'policyRule',
-        resource:  null,
-        resources: [],
-        verbs:     [],
+        apiGroups:       ['*'],
+        type:            'policyRule',
+        resource:        null,
+        resources:       [],
+        nonResourceURLs: null,
+        verbs:           [],
       });
     },
 
@@ -220,19 +221,32 @@ export default Component.extend(ViewNewEdit, {
 
     for (let i = rules.length - 1; i >= 0; i--) {
       obj = rules[i];
-      if (obj.resources && obj.resources.length && obj.verbs.length) {
+      if (( !isEmpty(obj.resources) || !isEmpty(obj.nonResourceURLs) ) && obj.verbs.length) {
         const resources = [];
-
-        obj.resources.forEach((r) => {
-          resources.pushObjects((r || '').split(',').filter((r) => r));
-        });
-
-        actualRules.push({
+        const out = {
           type:      obj.type,
-          apiGroups: obj.apiGroups.slice(),
           verbs:     obj.verbs.slice(),
-          resources,
-        });
+        };
+
+        if (!isEmpty(obj.apiGroups)) {
+          out['apiGroups'] = obj.apiGroups.slice();
+        }
+
+        if (!isEmpty(obj.resources)) {
+          obj.resources.forEach((r) => {
+            resources.pushObjects((r || '').split(',').filter((r) => r));
+          });
+
+          out['resources'] = resources;
+        } else if (!isEmpty(obj.nonResourceURLs)) {
+          obj.nonResourceURLs.forEach((r) => {
+            resources.pushObjects((r || '').split(',').filter((r) => r));
+          });
+
+          out['nonResourceURLs'] = resources;
+        }
+
+        actualRules.push(out);
       } else {
         rules.removeObject(obj);
       }

--- a/lib/global-admin/addon/components/new-edit-role/component.js
+++ b/lib/global-admin/addon/components/new-edit-role/component.js
@@ -69,12 +69,11 @@ export default Component.extend(ViewNewEdit, {
 
     addRule() {
       get(this, 'ruleArray').pushObject({
-        apiGroups:       ['*'],
-        type:            'policyRule',
-        resource:        null,
-        resources:       [],
-        nonResourceURLs: null,
-        verbs:           [],
+        apiGroups: ['*'],
+        type:      'policyRule',
+        resource:  null,
+        resources: [],
+        verbs:     [],
       });
     },
 

--- a/lib/global-admin/addon/components/new-edit-role/template.hbs
+++ b/lib/global-admin/addon/components/new-edit-role/template.hbs
@@ -133,6 +133,8 @@
             {{/each}}
             <th>{{t "rolesPage.new.form.allow.resource"}}</th>
             <th width="10">&nbsp;</th>
+            <th>{{t "rolesPage.new.form.allow.nonResourceUrl"}}</th>
+            <th width="10">&nbsp;</th>
             <th>{{t "rolesPage.new.form.allow.apiGroups"}}</th>
             <th width="10">&nbsp;</th>
             <th width="40"></th>

--- a/lib/global-admin/addon/components/role-rule-row/component.js
+++ b/lib/global-admin/addon/components/role-rule-row/component.js
@@ -8,12 +8,14 @@ const verbs = C.RULE_VERBS;
 
 export default Component.extend({
   layout,
-  rule:     null,
-  rules:    null,
-  resource: null,
-  apiGroup: null,
-  readOnly: null,
-  editing:  true,
+
+  rule:           null,
+  rules:          null,
+  resource:       null,
+  nonResourceURL: null,
+  apiGroup:       null,
+  readOnly:       null,
+  editing:        true,
 
   tagName:    'TR',
   classNames: 'main-row',
@@ -22,31 +24,36 @@ export default Component.extend({
     this._super(...arguments);
     const { rule }     = this;
     let { rules }      = this;
+    const {
+      resources       = [],
+      nonResourceURLs = [],
+      apiGroups       = [],
+    } = rule;
     const currentVerbs = get(rule, 'verbs');
 
-    set(this, 'verbs', verbs.map((verb) => {
-      return {
-        key:   verb,
-        value: currentVerbs.indexOf('*') > -1 || currentVerbs.indexOf(verb) > -1,
-      };
-    }));
+    set(this, 'verbs', verbs.map((verb) => ({
+      key:   verb,
+      value: currentVerbs.indexOf('*') > -1 || currentVerbs.indexOf(verb) > -1,
+    })));
 
     if (isEmpty(rules)) {
       rules = C.ROLE_RULES.sort();
 
-      set(this, 'rules', rules.map((rule) => {
-        return {
-          label: rule,
-          value: rule.toLowerCase(),
-        };
-      }));
+      set(this, 'rules', rules.map((rule) => ({
+        label: rule,
+        value: rule.toLowerCase(),
+      })));
     }
 
-    if ((get(rule, 'resources') || []).get('length') > 0) {
-      set(this, 'resource', get(rule, 'resources').join(','));
+    if (resources.get('length') > 0) {
+      this.initResourceLikeParams(resources, 'resource');
     }
 
-    set(this, 'apiGroup', (get(rule, 'apiGroups') || []).join(','));
+    if (nonResourceURLs.get('length') > 0) {
+      this.initResourceLikeParams(nonResourceURLs, 'nonResourceURL');
+    }
+
+    this.initResourceLikeParams(apiGroups, 'apiGroup');
   },
 
   actions: {
@@ -70,11 +77,21 @@ export default Component.extend({
     set(rule, 'resources', [get(this, 'resource')])
   }),
 
+  selectedNonResourceUrlChanged: observer('nonResourceURL', function() {
+    const rule = get(this, 'rule');
+
+    set(rule, 'nonResourceURLs', [get(this, 'nonResourceURL')])
+  }),
+
   apiGroupsChanged: observer('apiGroup', function() {
     const rule = get(this, 'rule');
 
     set(rule, 'apiGroups', (get(this, 'apiGroup') || '').split(','))
   }),
+
+  initResourceLikeParams(rules, resourceName) {
+    set(this, resourceName, rules.join(','));
+  },
 
   remove() {
     throw new Error('remove action is required!');

--- a/lib/global-admin/addon/components/role-rule-row/template.hbs
+++ b/lib/global-admin/addon/components/role-rule-row/template.hbs
@@ -16,23 +16,31 @@
   </td>
 {{/each}}
 <td class="pt-5 pb-5">
-  {{#if (and readOnly rule.nonResourceURLs)}}
-    <span class="text-muted">
-      Non-Resource URL: {{join-array rule.nonResourceURLs}}
-    </span>
-  {{else}}
-    <InputOrDisplay
-      @editable={{editing}}
+  <InputOrDisplay
+    @editable={{editing}}
+    @value={{resource}}
+  >
+    <SearchableSelect
+      @allowCustom={{true}}
+      @content={{rules}}
       @value={{resource}}
-    >
-      <SearchableSelect
-        @allowCustom={{true}}
-        @content={{rules}}
-        @value={{resource}}
-        @readOnly={{readOnly}}
-      />
-    </InputOrDisplay>
-  {{/if}}
+      @readOnly={{or readOnly (and nonResourceURL nonResourceURL.length)}}
+    />
+  </InputOrDisplay>
+</td>
+<td class="pt-5 pb-5">&nbsp;</td>
+<td class="pt-5 pb-5">
+  <InputOrDisplay
+    @editable={{editing}}
+    @value={{nonResourceURL}}
+  >
+    <Input
+      @type="text"
+      @value={{nonResourceURL}}
+      @disabled={{or readOnly (and resource resource.length)}}
+      @classNames="form-control"
+    />
+  </InputOrDisplay>
 </td>
 <td class="pt-5 pb-5">&nbsp;</td>
 <td class="pt-5 pb-5">

--- a/lib/global-admin/addon/security/roles/index/template.hbs
+++ b/lib/global-admin/addon/security/roles/index/template.hbs
@@ -13,7 +13,7 @@
   <div class="right-buttons">
     {{#link-to
        "security.roles.new"
-       (query-params context=context)
+       (query-params context=context id=null)
        classNames="btn btn-sm bg-primary right-divider-btn"
        disabled=(rbac-prevents resource="globalrole" scope="global" permission="create")
     }}

--- a/lib/shared/addon/components/searchable-select/component.js
+++ b/lib/shared/addon/components/searchable-select/component.js
@@ -166,7 +166,11 @@ export default Component.extend({
   },
 
   observeContent: observer('asyncContent.value.[]', 'value', 'displayLabel', function(){
-    set(this, 'interContent', get(this, 'asyncContent.value').slice(0));
+    let asyncContentValue = get(this, 'asyncContent.value');
+
+    if (asyncContentValue) {
+      set(this, 'interContent', asyncContentValue.slice(0));
+    }
 
     if (get(this, 'allowCustom')) {
       set(this, 'searchLabel', 'generic.searchOrCustomInput');

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -513,6 +513,7 @@ rolesPage:
         watch: Watch
         labelText: Allow
         resource: Resource
+        nonResourceUrl: Non-Resource URLs (path only)
         addAction: Add Resource
         apiGroups: API Groups
       otherRole:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Some roles (e.g. global admin) use the `nonResourceURLs` param on a policy rule model. The UI never exposed entering a `nonResourceURLs` param but did make a special case on detail view. When roles were update to be cloned this was not taken into consideration and when cloning a role that had `nonResourceURLs` in the rules we could get into a state where you could not clone that rule. 
This PR exposes the `nonResourceURLs` param. The new param is mutually exclusive with `resources` so if you are using one you may not use the other. This is all the error checking that occurs with the new param. Technically the param on the Kubernetes side can only take a path or `*` (all) indicator. We could validate this but that doesn't stop someone creating/editing from the API. If this needs to be validated the back-end should validate. 
Additionally this PR fixes an issue where the `query-params` helper seems to be caching query parms on the route so when clicking the new button you got the old id. I've added a null id to the add button query params because we should never have to pass and id when creating a new role not from a clone. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#25085
rancher/rancher#25086
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
