### PR TITLE
Make unhandled exceptions display the fail whale

### DIFF
--- a/app/fail-whale/route.js
+++ b/app/fail-whale/route.js
@@ -1,5 +1,6 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
+import { run } from '@ember/runloop';
 
 export default Route.extend({
   storeReset: service(),
@@ -12,6 +13,13 @@ export default Route.extend({
   afterModel(model) {
     if ( model ) {
       this.get('storeReset').reset();
+
+      // This ensures the loading over/underlays are hidden even if a failure
+      // happens in the middle of loading.
+      run.scheduleOnce('afterRender', function() { // eslint-disable-line
+        $('#loading-underlay').hide(); // eslint-disable-line
+        $('#loading-overlay').hide(); // eslint-disable-line
+      });
     } else {
       this.transitionTo('authenticated');
     }

--- a/app/initializers/uncaught-exceptions.js
+++ b/app/initializers/uncaught-exceptions.js
@@ -1,0 +1,20 @@
+export function initialize(application) {
+  const errorHandler = (message, file, line, column, error) => {
+    const router = application.__container__.lookup('router:main');
+    const controller = application.__container__.lookup('controller:application');
+
+    controller.setProperties({ error });
+    router.transitionTo('failWhale');
+  }
+
+  window.onerror = errorHandler;
+
+  window.addEventListener('unhandledrejection', () => {
+    errorHandler(null, null, null, null, 'Promise was rejected.');
+  });
+}
+
+export default {
+  name:       'uncaught-exceptions',
+  initialize
+};


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Anytime we have an unhandled exception we will now navigate to the
fail whale page.

Types of changes
======
- New feature (non-breaking change which adds functionality)

Linked Issues
======
rancher/rancher#25198
