### PR TITLE
Fixing Run CIS Scan on the cluster list page

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -466,12 +466,15 @@ export default Resource.extend(Grafana, ResourceUsage, {
       this.modalService.toggleModal('modal-save-rke-template', { cluster: this });
     },
 
-    async runCISScan() {
-      await get(this, 'scope.currentCluster').doAction('runSecurityScan', {
+    runCISScan() {
+      const intl = get(this, 'intl');
+
+      this.doAction('runSecurityScan', {
         failuresOnly: false,
         skip:         null
+      }).then(() => {
+        this.growl.success(intl.t('cis.scan.growl.success', { clusterName: get(this, 'name') }), '');
       });
-      get(this, 'router').replaceWith('authenticated.cluster.cis/scan');
     },
 
     rotateCertificates() {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1040,6 +1040,8 @@ catalogPage:
 
 cis:
   scan:
+    growl:
+      success: Running CIS scan on '{clusterName}'
     header: CIS Scans
     rkeOnly: CIS Scans are only available to RKE Clusters
     actions:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Run CIS Scan was broken on the cluster list page because
currentCluster was being used instead of just using the current cluster.

I also removed the redirect and just use a growl notification to
indicate the scan is running.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

Linked Issues
======
rancher/rancher#25241
rancher/rancher#25159

![Screen Shot 2020-02-04 at 11 06 18 AM](https://user-images.githubusercontent.com/55104481/73775473-2ce7ef80-4743-11ea-9d86-84dbb88a0bce.png)

