### PR TITLE
Hide mtu input for custom cluster on flannel network provider

### DIFF
--- a/lib/shared/addon/components/form-network-config/template.hbs
+++ b/lib/shared/addon/components/form-network-config/template.hbs
@@ -171,40 +171,41 @@
     </div>
   {{/if}}
 
-  <div class="col span-4">
-    <label class="acc-label">
-      {{t "clusterNew.rke.networkMTU.label"}}
-      {{#if clusterTemplateCreate}}
-        <ClusterTemplateOverrideToggle
-          @path="rancherKubernetesEngineConfig.network.mtu"
-          @configVariable={{config.network.mtu}}
-          @addOverride={{addOverride}}
-          @questions={{clusterTemplateRevision.questions}}
-        />
-      {{/if}}
-    </label>
+  {{#if (not-eq config.network.plugin "flannel")}}
+    <div class="col span-4">
+      <label class="acc-label">
+        {{t "clusterNew.rke.networkMTU.label"}}
+        {{#if clusterTemplateCreate}}
+          <ClusterTemplateOverrideToggle
+            @path="rancherKubernetesEngineConfig.network.mtu"
+            @configVariable={{config.network.mtu}}
+            @addOverride={{addOverride}}
+            @questions={{clusterTemplateRevision.questions}}
+          />
+        {{/if}}
+      </label>
 
-    <CheckOverrideAllowed
-      @questions={{clusterTemplateRevision.questions}}
-      @paramName="rancherKubernetesEngineConfig.network.mtu"
-      @clusterTemplateRevision={{clusterTemplateRevision.clusterConfig}}
-      @applyClusterTemplate={{applyClusterTemplate}}
-    >
-      {{#input-or-display
-         editable=(not-eq mode "view")
-         value=config.network.mtu
-      }}
-        {{input-integer
-          value=config.network.mtu
-          min=1
-          classNames="form-control"
-          placeholder=(t "clusterNew.rke.networkMTU.detail")
+      <CheckOverrideAllowed
+        @questions={{clusterTemplateRevision.questions}}
+        @paramName="rancherKubernetesEngineConfig.network.mtu"
+        @clusterTemplateRevision={{clusterTemplateRevision.clusterConfig}}
+        @applyClusterTemplate={{applyClusterTemplate}}
+      >
+        {{#input-or-display
+           editable=(not-eq mode "view")
+           value=config.network.mtu
         }}
-      {{/input-or-display}}
-      <p class="help-block">
-        {{t "clusterNew.rke.networkMTU.help"}}
-      </p>
-    </CheckOverrideAllowed>
-
-  </div>
+          {{input-integer
+            value=config.network.mtu
+            min=1
+            classNames="form-control"
+            placeholder=(t "clusterNew.rke.networkMTU.detail")
+          }}
+        {{/input-or-display}}
+        <p class="help-block">
+          {{t "clusterNew.rke.networkMTU.help"}}
+        </p>
+      </CheckOverrideAllowed>
+    </div>
+  {{/if}}
 </div>


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Flannel Network provider does not support overriding network MTU. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#25267
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
