### PR TITLE
Refactor how cis scans are disabled.

### DIFF
--- a/app/authenticated/cluster/cis/scan/controller.js
+++ b/app/authenticated/cluster/cis/scan/controller.js
@@ -60,10 +60,6 @@ export default Controller.extend({
       });
     }
   },
-  disableRunScanButton: computed('runningClusterScans', 'scope.currentCluster.systemProject', function() {
-    return get(this, 'runningClusterScans.length') > 0 || !get(this, 'scope.currentCluster.systemProject');
-  }),
-
   bulkActionHandler: computed(function() {
     return {
       download: async(scans) => {

--- a/app/authenticated/cluster/cis/scan/detail/controller.js
+++ b/app/authenticated/cluster/cis/scan/detail/controller.js
@@ -64,10 +64,6 @@ export default Controller.extend({
     }
   },
 
-  disableRunScanButton: computed('runningClusterScans', 'scope.currentCluster.systemProject', function() {
-    return get(this, 'runningClusterScans.length') > 0 || !get(this, 'scope.currentCluster.systemProject');
-  }),
-
   tests: computed('model.scan.report', 'securityScanConfig.skipList', function() {
     const results = get(this, 'model.scan.report.results');
 

--- a/app/authenticated/cluster/cis/scan/detail/template.hbs
+++ b/app/authenticated/cluster/cis/scan/detail/template.hbs
@@ -32,7 +32,7 @@
           {{/if}}
         </div>
       </div>  
-      <button class="btn btn-sm bg-primary pl-40 pr-40 ml-20" {{action "runScan"}} disabled={{disableRunScanButton}}>
+      <button class="btn btn-sm bg-primary pl-40 pr-40 ml-20" {{action "runScan"}} disabled={{scope.currentCluster.isClusterScanDisabled}}>
         {{t 'cis.scan.actions.runScan'}}
       </button>      
   </div>

--- a/app/authenticated/cluster/cis/scan/template.hbs
+++ b/app/authenticated/cluster/cis/scan/template.hbs
@@ -23,7 +23,7 @@
           <td colspan="{{sortable.fullColspan}}" class="text-center text-muted pt-20 pb-20">{{t 'cis.scan.table.empty'}}</td>
         </tr>
       {{else if (eq kind "right-actions")}}
-        <button style="margin-left: -5px;" class="btn btn-sm bg-primary pl-40 pr-40" {{action "runScan"}} disabled={{disableRunScanButton}}>
+        <button style="margin-left: -5px;" class="btn btn-sm bg-primary pl-40 pr-40" {{action "runScan"}} disabled={{scope.currentCluster.isClusterScanDisabled}}>
           {{t 'cis.scan.actions.runScan'}}
         </button>
       {{/if}}

--- a/app/authenticated/cluster/route.js
+++ b/app/authenticated/cluster/route.js
@@ -23,6 +23,7 @@ export default Route.extend(Preload, {
         .then(() => {
           if ( get(cluster, 'isReady') ) {
             return this.loadSchemas('clusterStore').then(() => PromiseAll([
+              this.preload('clusterScan', 'globalStore'),
               this.preload('namespace', 'clusterStore'),
               this.preload('storageClass', 'clusterStore'),
               this.preload('persistentVolume', 'clusterStore'),

--- a/app/authenticated/route.js
+++ b/app/authenticated/route.js
@@ -117,6 +117,7 @@ export default Route.extend(Preload, {
             this.preload('globalRoleBinding', 'globalStore', { url: 'globalRoleBinding' }),
             this.preload('user', 'globalStore', { url: 'user' }),
             this.preload('features', 'globalStore', { url: 'features' }),
+            this.preload('clusterScan', 'globalStore'),
 
             globalStore.findAll('principal').then((principals) => {
               const me = principals.filter((p) => p.me === true);

--- a/app/models/clusterscan.js
+++ b/app/models/clusterscan.js
@@ -14,7 +14,7 @@ const ClusterScan = Resource.extend({
   skipped:       computed.alias('summary.skipped'),
   failed:        computed.alias('summary.failed'),
 
-  isRunning: computed.equal('state', 'activating'),
+  isRunning: computed.equal('state', 'running'),
 
   loader: observer('store', 'state', function() {
     this.loadReport();

--- a/lib/shared/addon/security-scan-config/service.js
+++ b/lib/shared/addon/security-scan-config/service.js
@@ -24,7 +24,7 @@ export default Service.extend({
 
   loadAsyncConfigMap() {
     const systemProject = get(this, 'scope.currentCluster.systemProject');
-    const configMaps = systemProject ? systemProject.followLink('configMaps') : []
+    const configMaps = systemProject && systemProject.hasLink('configMaps') && get(this, 'scope.currentCluster.state') === 'active' ? systemProject.followLink('configMaps') : []
     const asyncConfigMap = StatefulPromise.wrap(configMaps);
 
     set(this, 'asyncConfigMap', asyncConfigMap);


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This refactoring removed code duplication and
provides a more cohesive experience across all
of the pages that you can run a scan.

This will also now check and ensure the following
- there aren't running ClusterScans
- this isn't a windows cluster
- systemProject is available
- the cluster is active
- the action link is available

When the above isn't the case Run CIS Scan will not be present in
the cluster action drop downs and the Run CIS Scan but
 will be disabled on the CIS Scans and CIS Scan Detail
pages.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#24759
rancher/rancher#25298
