### PR TITLE
Add CIS scheduling to rke configuration

### DIFF
--- a/app/application/route.js
+++ b/app/application/route.js
@@ -33,10 +33,16 @@ export default Route.extend({
       return;
     }
 
-    // Find out if auth is enabled
-    return get(this, 'access').detect().finally(() => {
-      return get(this, 'language').initLanguage();
-    });
+    return (async() => {
+      if (!window.Prettycron) {
+        window.Prettycron = await import('prettycron');
+      }
+
+      // Find out if auth is enabled
+      return get(this, 'access').detect().finally(() => {
+        return get(this, 'language').initLanguage();
+      });
+    })();
   },
 
   model(params, transition) {

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -494,6 +494,19 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       : get(this, 'intl').t('clusterNew.rke.upgradeStrategy.maximumWorkersDown.view.count', value)
   }),
 
+  cisScanProfileOptions: computed(() => {
+    return [
+      {
+        label:   'RKE-CIS-1.4 Permissive',
+        value: 'rke-cis-1.4-permissive'
+      },
+      {
+        label:   'RKE-CIS-1.4 Hardened',
+        value: 'rke-cis-1.4-hardened'
+      }
+    ]
+  }),
+
   showUpgradeK8sWarning: computed(
     'selectedClusterTemplateId',
     'applyClusterTemplate',
@@ -1432,6 +1445,14 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
           podSecurityPolicy:     false,
           serviceNodePortRange: '30000-32767',
         }),
+        cisScan: {
+          scheduled: {
+            enabled:       true,
+            profile:       'cis-rke-1.4-permissive',
+            intervalCron:  '0 * * * *',
+            retention:     24
+          }
+        },
         etcd: globalStore.createRecord({
           type:         'etcdService',
           snapshot:     false,

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -926,6 +926,154 @@
           </div>
 
           <div class="row">
+            <div class="col span-3">
+              <label class="acc-label">
+                {{t "clusterNew.rke.cisScan.scheduled.enabled.label"}}
+                {{#if clusterTemplateCreate}}
+                  <ClusterTemplateOverrideToggle
+                    @path="rancherKubernetesEngineConfig.services.cisScan.scheduled.enabled"
+                    @configVariable={{config.services.etcd.backupConfig.enabled}}
+                    @addOverride={{action "addOverride"}}
+                    @questions={{model.clusterTemplateRevision.questions}}
+                  />
+                {{/if}}
+              </label>
+              <CheckOverrideAllowed
+                @paramName="rancherKubernetesEngineConfig.services.cisScan.scheduled.enabled"
+                @applyClusterTemplate={{applyClusterTemplate}}
+                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                @questions={{model.clusterTemplateRevision.questions}}
+              >
+                {{#input-or-display
+                   editable=notView
+                   value=config.services.cisScan.scheduled.enabled
+                }}
+                  <div class="text-muted">
+                    <label>
+                      {{radio-button
+                        selection=config.services.cisScan.scheduled.enabled
+                        value=true
+                      }}
+                      {{t "generic.yes"}}
+                    </label>
+                    <label>
+                      {{radio-button
+                        selection=config.services.cisScan.scheduled.enabled
+                        value=false
+                      }}
+                      {{t "generic.no"}}
+                    </label>
+                  </div>
+                {{/input-or-display}}
+              </CheckOverrideAllowed>
+            </div>
+
+            <div class="col span-3">
+              <label class="acc-label">
+                {{t "clusterNew.rke.cisScan.scheduled.profile.label"}}
+                {{#if clusterTemplateCreate}}
+                  <ClusterTemplateOverrideToggle
+                    @path="rancherKubernetesEngineConfig.services.cisScan.scheduled.profile"
+                    @configVariable={{config.services.etcd.backupConfig.retention}}
+                    @addOverride={{action "addOverride"}}
+                    @questions={{model.clusterTemplateRevision.questions}}
+                  />
+                {{/if}}
+              </label>
+              <CheckOverrideAllowed
+                @paramName="rancherKubernetesEngineConfig.services.cisScan.scheduled.profile"
+                @applyClusterTemplate={{applyClusterTemplate}}
+                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                @questions={{model.clusterTemplateRevision.questions}}
+              >
+                {{#input-or-display
+                   tagName="div"
+                   editable=notView
+                   value=config.services.cisScan.scheduled.profile
+                }}
+                  {{new-select
+                    id="cis-scan-profile"
+                    classNames="form-control"
+                    content=cisScanProfileOptions
+                    value=config.services.cisScan.scheduled.profile
+                    disabled=(not config.services.cisScan.scheduled.enabled)
+                  }}
+                {{/input-or-display}}
+              </CheckOverrideAllowed>
+            </div>
+
+            <div class="col span-3">
+              <label class="acc-label">
+                {{t "clusterNew.rke.cisScan.scheduled.interval.label"}}
+                {{#if clusterTemplateCreate}}
+                  <ClusterTemplateOverrideToggle
+                    @path="rancherKubernetesEngineConfig.services.cisScan.scheduled.intervalCron"
+                    @configVariable={{config.services.cisScan.scheduled.intervalHours}}
+                    @addOverride={{action "addOverride"}}
+                    @questions={{model.clusterTemplateRevision.questions}}
+                  />
+                {{/if}}
+              </label>
+              <CheckOverrideAllowed
+                @paramName="rancherKubernetesEngineConfig.services.cisScan.scheduled.intervalCron"
+                @applyClusterTemplate={{applyClusterTemplate}}
+                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                @questions={{model.clusterTemplateRevision.questions}}
+              >
+                {{#if notView}}
+                  {{input
+                    type="text"
+                    value=config.services.cisScan.scheduled.intervalCron
+                    classNames="form-control"
+                    placeholder=(t "clusterNew.rke.etcd.backupConfig.interval.placeholder")
+                    disabled=(if (not config.services.cisScan.scheduled.enabled) true)
+                  }}
+                {{else}}
+                  <div>{{config.services.cisScan.scheduled.intervalCron}}</div>
+                {{/if}}
+                <div class="text-small text-muted">{{pretty-cron config.services.cisScan.scheduled.intervalCron "toString"}}</div>
+
+              </CheckOverrideAllowed>
+            </div>
+
+            <div class="col span-3">
+              <label class="acc-label">
+                {{t "clusterNew.rke.cisScan.scheduled.retention.label"}}
+                {{#if clusterTemplateCreate}}
+                  <ClusterTemplateOverrideToggle
+                    @path="rancherKubernetesEngineConfig.services.cisScan.scheduled.retention"
+                    @configVariable={{config.services.cisScan.scheduled.retention}}
+                    @addOverride={{action "addOverride"}}
+                    @questions={{model.clusterTemplateRevision.questions}}
+                  />
+                {{/if}}
+              </label>
+              <CheckOverrideAllowed
+                @paramName="rancherKubernetesEngineConfig.services.cisScan.scheduled.retention"
+                @applyClusterTemplate={{applyClusterTemplate}}
+                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                @questions={{model.clusterTemplateRevision.questions}}
+              >
+                {{#input-or-display
+                   tagName="div"
+                   classNames="input-group"
+                   editable=notView
+                   value=config.services.cisScan.scheduled.retention
+                }}
+                  <span class="input-group-addon bg-default">{{t "clusterNew.rke.etcd.backupConfig.retention.prefix"}}</span>
+                  {{input-integer
+                    value=config.services.cisScan.scheduled.retention
+                    min=1
+                    classNames="form-control"
+                    placeholder=(t "clusterNew.rke.etcd.backupConfig.retention.placeholder")
+                    disabled=(if (not config.services.cisScan.scheduled.enabled) true)
+                  }}
+                {{/input-or-display}}
+              </CheckOverrideAllowed>
+            </div>
+          </div>
+
+          <div class="row">
             <div class="col">
               <label class="acc-label">
                 {{t "clusterNew.rke.upgradeStrategy.maximumWorkersDown.label"}}

--- a/lib/shared/addon/components/new-select/template.hbs
+++ b/lib/shared/addon/components/new-select/template.hbs
@@ -1,4 +1,4 @@
-<select disabled={{asyncContent.loading}}>
+<select disabled={{or asyncContent.loading disabled}}>
   {{#if prompt}}
     <option selected={{not selection}}>
       {{#if localizedPrompt}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3964,6 +3964,17 @@ clusterNew:
         prompt: Select a RKE Template revision
         default: '{name} - Default (Created {ago})'
         other: '{name} (Created {ago})'
+    cisScan:
+      scheduled:
+        enabled:
+          label: Recurring Security Scan Enabled
+        interval:
+          label: Recurring Security Scan Interval (cron)
+        retention:
+          label: Recurring Security Scan Report Retention
+        profile:
+          label: Recurring Security Scan Profile
+      
     etcd:
       enabled:
         label: Recurring etcd Snapshot Enabled


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
We wanted to make CIS scheduling configuration a part of
a cluster's RKE config.



Types of changes
======
- New feature (non-breaking change which adds functionality)

Linked Issues
======
rancher/rancher#25347

![Screen Shot 2020-02-11 at 3 38 06 PM](https://user-images.githubusercontent.com/55104481/74287072-55915b80-4ce6-11ea-8b6f-5683759e4a71.png)
