### PR TITLE
Additional checks around default/existing openLdapConfig Shibboleth

### DIFF
--- a/lib/global-admin/addon/components/saml-config/component.js
+++ b/lib/global-admin/addon/components/saml-config/component.js
@@ -5,6 +5,7 @@ import Saml from 'global-admin/mixins/saml-auth';
 import { alias, equal } from '@ember/object/computed';
 import { computed, get, set } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { isEmpty } from '@ember/utils';
 
 export default Component.extend(AuthMixin, Saml, {
   globalStore: service(),
@@ -24,12 +25,10 @@ export default Component.extend(AuthMixin, Saml, {
 
   actions: {
     openLdapExpanded(expandFn, item) {
-      const { openLdapIsExpanded } = this;
+      const { openLdapIsExpanded, authConfig } = this;
 
-      if (openLdapIsExpanded) {
-        set(this, 'openLdapIsExpanded', false);
-        delete this.authConfig.openLdapConfig;
-      } else {
+      // Intentionally not reset, only needs to indicate it was opened once
+      if (!openLdapIsExpanded && isEmpty(authConfig.openLdapConfig)) {
         set(this, 'openLdapIsExpanded', true);
         set(this, 'authConfig.openLdapConfig', this.globalStore.createRecord({ type: 'ldapFields' }));
       }

--- a/lib/global-admin/addon/mixins/saml-auth.js
+++ b/lib/global-admin/addon/mixins/saml-auth.js
@@ -8,6 +8,8 @@ import C from 'ui/utils/constants';
 import { isEmpty } from '@ember/utils';
 
 export default Mixin.create({
+  intl:             service(),
+  globalStore:      service(),
   settings:         service(),
   saml:             service(),
   errors:           null,
@@ -44,10 +46,14 @@ export default Mixin.create({
     authTest(cb) {
       this.send('clearError');
 
-      const model = get(this, 'authConfig');
-      const am    = get(model, 'accessMode') || 'unrestricted';
+      let model = get(this, 'authConfig');
+      const am  = get(model, 'accessMode') || 'unrestricted';
 
       setProperties(model, { accessMode: am });
+
+      if (model.id === 'shibboleth' && !isEmpty(model.openLdapConfig)) {
+        ( model = this.removeOpenLdapConfigIfDefault(model) );
+      }
 
       const errors = model.validationErrors();
 
@@ -145,5 +151,17 @@ export default Mixin.create({
 
     return (this.get('authConfig.allowedIdentities') || []).filterBy('externalIdType', type).get('length');
   }),
+
+  removeOpenLdapConfigIfDefault(authConfig) {
+    let openLdapConfig     = authConfig.openLdapConfig;
+    let defaultLdapFields  = JSON.stringify(this.globalStore.createRecord({ type: 'ldapFields' }));
+    let stringedAuthConfig = JSON.stringify(openLdapConfig);
+
+    if (defaultLdapFields === stringedAuthConfig) {
+      delete authConfig.openLdapConfig;
+    }
+
+    return authConfig;
+  },
 
 });


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Adds some additional logic around sending the openLdapConfig when enabling shibboleth. The previous implementation was not robust enough to handle preexisting configs, nor smart enough to drop the config if it was the default config. The error checking for openLdapConfig will only happen if the user has made some change to the open ldap search area so we don't spam users with missing required fields if they only _opened_ that area and didn't make changes. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#25459

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
