### PR TITLE
Fix dashbaord link for prod build

### DIFF
--- a/app/components/page-header/component.js
+++ b/app/components/page-header/component.js
@@ -102,6 +102,14 @@ export default Component.extend({
     });
   },
 
+  actions: {
+    clickDashboard() {
+      // Regular click on the link will have Ember try to resolve /dashboard/c/<id>
+      // to an Ember route and show the error page.  That's bad.
+      window.location.href = get(this, 'dashboardLink');
+    },
+  },
+
   shouldUpdateNavTree: observer(
     'pageScope',
     'clusterId',

--- a/app/components/page-header/template.hbs
+++ b/app/components/page-header/template.hbs
@@ -107,7 +107,7 @@
   {{#if dashboardLink}}
     <ul>
       <li class="bg-warning">
-        <a href="{{dashboardLink}}">{{t "nav.dashboard.try"}}</a>
+        <a href="{{dashboardLink}}" {{action "clickDashboard"}}>{{t "nav.dashboard.try"}}</a>
       </li>
     </ul>
   {{/if}}


### PR DESCRIPTION
Proposed changes
======
Fix the dashboard link on production builds so that it goes to dashboard instead of trying to load /dashboard within Ember/without really loading the page.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#25168