### PR TITLE
Improve the Restore Snapshot modal

### DIFF
--- a/app/components/modal-restore-backup/component.js
+++ b/app/components/modal-restore-backup/component.js
@@ -1,5 +1,7 @@
 import { inject as service } from '@ember/service';
-import { get, set, setProperties, computed } from '@ember/object';
+import {
+  get, set, setProperties, computed, observer
+} from '@ember/object';
 import Component from '@ember/component';
 import ModalBase from 'shared/mixins/modal-base';
 import layout from './template';
@@ -12,6 +14,7 @@ export default Component.extend(ModalBase, {
   layout,
   classNames:       ['large-modal'],
   backupId:         null,
+  restoreRkeConfig: null,
   loadingBackups:   false,
 
   init() {
@@ -23,11 +26,14 @@ export default Component.extend(ModalBase, {
 
   actions: {
     restore() {
-      const { backupId } = this;
+      const { backupId, restoreRkeConfig } = this;
       const out          = {};
 
       if (backupId) {
         set(out, 'etcdBackupId', backupId);
+        if (restoreRkeConfig !== 'etcd') {
+          set(out, 'restoreRkeConfig', restoreRkeConfig);
+        }
 
         this.modalOpts.cluster.doAction('restoreFromEtcdBackup', out).then(() => {
           this.send('cancel');
@@ -38,17 +44,48 @@ export default Component.extend(ModalBase, {
     }
   },
 
+  updateRestoreRkeConfig: observer('backupId', function() {
+    const value = get(this, 'backupId') ? 'etcd' : '';
+
+    set(this, 'restoreRkeConfig', value);
+  }),
+
   availableBackups: computed('modalOpts.cluster.etcdbackups.[]', function() {
     return get(this, 'modalOpts.cluster.etcdbackups').map((backup) => {
       let time = moment(get(backup, 'created'));
+      const hyphenatedVersion = backup.status.kubernetesVersion
+        ? ` - ${ backup.status.kubernetesVersion }`
+        : '';
 
       return {
         id:      backup.id,
-        label:   `${ backup.displayName } ( ${ time.format('MMMM Do YYYY, H:mm:ss') })`,
+        label:   `( ${ time.format('MMMM Do YYYY, H:mm:ss') })${ hyphenatedVersion }`,
         created: backup.created,
         state:   backup.state,
       }
-    }).sortBy('created');
+    }).sortBy('created').reverse();
+  }),
+
+  selectedBackup: computed('modalOpts.cluster.etcdbackups.[]', 'backupId', function() {
+    const backupId = get(this, 'backupId');
+
+    return !backupId ? null : get(this, 'modalOpts.cluster.etcdbackups').findBy('id', backupId);
+  }),
+
+  selectedVersion: computed('selectedBackup.status.kubernetesVersion', function() {
+    return get(this, 'selectedBackup.status.kubernetesVersion') || this.intl.t('modalRestoreBackup.type.versionUnknown');
+  }),
+
+  k8sVersionDisabled: computed('selectedVersion', 'restorationTypeDisabled', function() {
+    return !get(this, 'restorationTypeDisabled') && get(this, 'selectedVersion') === this.intl.t('modalRestoreBackup.type.versionUnknown');
+  }),
+
+  k8sVersionRadioDisabled: computed('k8sVersionDisabled', 'restorationTypeDisabled', function() {
+    return get(this, 'k8sVersionDisabled') || get(this, 'restorationTypeDisabled');
+  }),
+
+  restorationTypeDisabled: computed('selectedBackup', function() {
+    return !get(this, 'selectedBackup');
   }),
 
   initOwnProperties() {

--- a/app/components/modal-restore-backup/template.hbs
+++ b/app/components/modal-restore-backup/template.hbs
@@ -41,10 +41,40 @@
         </select>
       {{/if}}
     </div>
+    {{#if (not loadingBackups)}}
+      <div class="col span-6">
+        <label
+          class="acc-label"
+          for="available-backups"
+        >
+          {{t "modalRestoreBackup.type.label"}}
+        </label>
+        <div class="radio {{if restorationTypeDisabled "text-muted"}}">
+          {{radio-button selection=restoreRkeConfig value="etcd" disabled=restorationTypeDisabled}} 
+          {{t "modalRestoreBackup.type.etcd"}}
+        </div>
+        <div class="radio {{if k8sVersionRadioDisabled "text-muted"}}">
+          {{radio-button selection=restoreRkeConfig value="kubernetesVersion" disabled=k8sVersionRadioDisabled}} 
+          {{t "modalRestoreBackup.type.k8sVersion" version=selectedVersion}}
+        </div>
+        <div class="radio {{if k8sVersionRadioDisabled "text-muted"}}">
+          {{radio-button selection=restoreRkeConfig value="all" disabled=k8sVersionRadioDisabled}} 
+          {{t "modalRestoreBackup.type.etcdAndK8sVersion" version=selectedVersion}}
+        </div>
+        {{#if k8sVersionDisabled}}
+          {{banner-message
+            color="bg-secondary mb-0 mt-10"
+            message=(t "modalRestoreBackup.type.k8sVersionUnknown")
+          }}
+        {{/if}}
+      </div>
+    {{/if}}
   </div>
 </section>
 
 {{save-cancel
+  editLabel="modalRestoreBackup.restoreButton"
+  savingLabel="modalRestoreBackup.restoreButton"
   editing=true
   save=(action "restore")
   saveDisabled=(not backupId)

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -7706,8 +7706,16 @@ modalRestoreBackup:
   backups: Available Snapshots
   error: A snapshot is required
   fetching: Fetching new snapshots
+  restoreButton: Restore
   select:
     all: Select an available snapshot
+  type:
+    label: Restoration Type
+    etcd: Restore ETCD
+    k8sVersion: "Kubernetes Version - {version}"
+    versionUnknown: 'Unknown'
+    etcdAndK8sVersion: "ETCD and Kubernetes Version - {version}"
+    k8sVersionUnknown: We cannot restore the kubernetes version for this snapshot because the version is unknown.
 
 modalRotateCertificates:
   title: Rotate Cluster Certificates


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
- Update the Available Snapshots labels
- Reverse the order of Available Snapshots
- Change 'Save' button to 'Restore' button
- Add restoration type section 'etcd', 'kubernetes version', 'etcd and
   kuberneters version'

Types of changes
======
- New feature (non-breaking change which adds functionality)

Linked Issues
======
rancher/rancher#25525

*New Labels and Order*
![Screen Shot 2020-02-26 at 1 37 02 PM](https://user-images.githubusercontent.com/55104481/75389273-7ee3e700-58a3-11ea-938f-d8e2d2e70d57.png)

*Selected snapshot without a recorded kubernetes version*
![Screen Shot 2020-02-26 at 1 36 56 PM](https://user-images.githubusercontent.com/55104481/75389277-80151400-58a3-11ea-8771-4e82d5732e2e.png)

*Selected snapshot with a recorded kubernetes version**New Labels and Order*
![Screen Shot 2020-02-26 at 1 36 45 PM](https://user-images.githubusercontent.com/55104481/75389278-80151400-58a3-11ea-8ec7-b85bfbe3240b.png)

*No selected snapshot*
![Screen Shot 2020-02-26 at 1 36 40 PM](https://user-images.githubusercontent.com/55104481/75389279-80adaa80-58a3-11ea-9d6a-caeb64b1011c.png)


