### PR TITLE
Change the way extra_args are excluded

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -25,7 +25,8 @@ import deepSet from 'ember-deep-set';
 import { coerceVersion } from 'shared/utils/parse-version';
 import { prepareForBackend as drainNodeWillSave } from 'shared/components/drain-node/component';
 
-const EXCLUDED_KEYS = ['extra_args', 'name'];
+const EXCLUDED_KEYS = ['name'];
+const EXCLUDED_CHILDREN_KEYS = ['extra_args'];
 
 function camelToUnderline(str, split = true) {
   str = (str || '');
@@ -826,13 +827,13 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       let cpConfig = get(config, 'rancher_kubernetes_engine_config.cloud_provider');
 
       // some kind of recursion bug
-      config = removeEmpty(config, EXCLUDED_KEYS);
+      config = removeEmpty(config, EXCLUDED_KEYS, EXCLUDED_CHILDREN_KEYS);
       // get rid of undefined
       config = JSON.parse(JSON.stringify(config));
 
 
       if ( cpConfig ) {
-        cpConfig = removeEmpty(cpConfig, EXCLUDED_KEYS);
+        cpConfig = removeEmpty(cpConfig, EXCLUDED_KEYS, EXCLUDED_CHILDREN_KEYS);
         if (cpConfig.name === 'aws' && !cpConfig.awsCloudProvider) {
           config.rancher_kubernetes_engine_config.cloud_provider = {
             ...config.rancher_kubernetes_engine_config.cloud_provider,
@@ -905,7 +906,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
 
   getClusterFields(primaryResource) {
-    let pojoPr = JSON.parse(JSON.stringify(removeEmpty(primaryResource, EXCLUDED_KEYS)));
+    let pojoPr = JSON.parse(JSON.stringify(removeEmpty(primaryResource, EXCLUDED_KEYS, EXCLUDED_CHILDREN_KEYS)));
     let decamelizedObj = {};
 
     decamelizedObj = keysToDecamelize(pojoPr, void (0), ['type', 'azureCloudProvider']);

--- a/lib/shared/addon/utils/util.js
+++ b/lib/shared/addon/utils/util.js
@@ -434,7 +434,12 @@ function keyNotType(k) {
   return Object.keys(k).filter((key) => key !== 'type').length > 0;
 }
 
-export function removeEmpty(obj, excludedKeys = []){
+/**
+ * Removes properties from obj that are empty.
+ * If a property is a part of excludedKeys it will be inluded regardless of whether or not it's empty.
+ * If a property is a part of excludedChildrenKeys it will exclude the property if it's empty but won't do the empty check on any of it's children.
+ */
+export function removeEmpty(obj, excludedKeys = [], excludedChildrenKeys = []){
   return Object.keys(obj)
     .filter((k) => {
       if (excludedKeys.indexOf(k) >= 0 || !isEmpty(obj[k]) && (typeof obj[k] !== 'object' || keyNotType(obj[k]))) {
@@ -442,7 +447,7 @@ export function removeEmpty(obj, excludedKeys = []){
       }
     })
     .reduce((newObj, k) => !isArray(obj[k]) && typeof obj[k] === 'object' && excludedKeys.indexOf(k) === -1 ?
-      Object.assign(newObj, { [k]: removeEmpty(obj[k], excludedKeys) }) :
+      Object.assign(newObj, { [k]: excludedChildrenKeys.includes(k) ? obj[k] : removeEmpty(obj[k], excludedKeys, excludedChildrenKeys) }) :
       Object.assign(newObj, { [k]: obj[k] }),
     {});
 }


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The original intent of ecluding extra_args was actually
to exclude the children of extra_args from being
removed when empty according to https://github.com/rancher/rancher/issues/24794#issuecomment-570043854.

This will now properly handle that intent while also
removing empty extra_args properties.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#25612
