### PR TITLE
Adding id as a column to the roles page

### DIFF
--- a/lib/global-admin/addon/security/roles/index/controller.js
+++ b/lib/global-admin/addon/security/roles/index/controller.js
@@ -19,6 +19,11 @@ const HEADERS = [
     translationKey: 'rolesPage.index.table.name',
   },
   {
+    name:           'id',
+    sort:           ['id', 'name'],
+    translationKey: 'rolesPage.index.table.id',
+  },
+  {
     name:           'builtin',
     sort:           ['builtin'],
     translationKey: 'rolesPage.index.table.builtin',

--- a/lib/global-admin/addon/security/roles/index/template.hbs
+++ b/lib/global-admin/addon/security/roles/index/template.hbs
@@ -58,6 +58,9 @@
             {{row.name}}
           {{/link-to}}
         </td>
+        <td data-title="{{t "rolesPage.index.table.id"}}:" class="clip">
+            {{row.id}}
+        </td>
         <td data-title="{{t "rolesPage.index.table.builtin"}}:" >
           {{#if row.builtin}}
             <i class="icon icon-check"/>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -461,6 +461,7 @@ rolesPage:
       created: Created Time
       enabled: Enabled
       name: Name
+      id: Id
       noData: There are no roles defined.
       noMatch: No roles match the current search
       subjectKind: Kind


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Since we allow users to create roles with duplicate
names we're adding the id as a column to allow them
to differentiate between the two.



Types of changes
======
- New feature (non-breaking change which adds functionality)


Linked Issues
======
rancher/rancher#24409

![Screen Shot 2020-03-03 at 4 17 13 PM](https://user-images.githubusercontent.com/55104481/75829629-f7e3b280-5d6b-11ea-8352-25dd5ee434c0.png)

