### PR TITLE
Resolve RKE Template issue caused by CIS

### DIFF
--- a/app/authenticated/cluster/cis/scan/detail/controller.js
+++ b/app/authenticated/cluster/cis/scan/detail/controller.js
@@ -43,10 +43,6 @@ export default Controller.extend({
 
   actions: {
     async runScan() {
-      await get(this, 'scope.currentCluster').doAction('runSecurityScan', {
-        failuresOnly: false,
-        skip:         null
-      });
       get(this, 'scope.currentCluster').send('runCISScan', { onRun: () => get(this, 'router').replaceWith('authenticated.cluster.cis/scan') });
     },
     download() {

--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -9,7 +9,6 @@ import { equal, alias } from '@ember/object/computed';
 import { resolve } from 'rsvp';
 import C from 'ui/utils/constants';
 import { isEmpty } from '@ember/utils';
-import { createProfileKey, toTitle } from 'shared/utils/util';
 import moment from 'moment';
 const TRUE = 'True';
 const CLUSTER_TEMPLATE_ID_PREFIX = 'cattle-global-data:';
@@ -411,45 +410,6 @@ export default Resource.extend(Grafana, ResourceUsage, {
     });
 
     return out;
-  }),
-
-
-  cisScanConfigProfiles: computed(function() {
-    return this.globalStore.getById('schema', 'cisscanconfig').optionsFor('profile');
-  }),
-
-  cisScanBenchmarks: computed(() => {
-    return [
-      'rke-cis-1.4',
-      'rke-cis-1.5'
-    ]
-  }),
-
-  cisScanProfiles: computed('cisScanConfigProfiles', 'cisScanBenchmarks', function() {
-    const profiles = get(this, 'cisScanConfigProfiles');
-    const benchmarks = get(this, 'cisScanBenchmarks');
-
-    const asArray = profiles.flatMap((profile) => {
-      return benchmarks.map((benchmark) => ({
-        [createProfileKey(profile, benchmark)]: {
-          benchmark,
-          profile
-        }
-      }))
-    });
-
-    return Object.assign.apply({}, asArray);
-  }),
-
-  cisScanProfileOptions: computed('cisScanProfiles', function() {
-    return Object.keys(get(this, 'cisScanProfiles')).map((key) => ({
-      label: toTitle(key),
-      value: key
-    }))
-  }),
-
-  defaultCisScanProfileOption: computed('cisScanProfileOptions', function() {
-    return get(this, 'cisScanProfileOptions')[0].value;
   }),
 
   actions: {

--- a/lib/shared/addon/cis-helpers/service.js
+++ b/lib/shared/addon/cis-helpers/service.js
@@ -1,0 +1,71 @@
+import Service, { inject as service } from '@ember/service';
+import { toTitle } from 'shared/utils/util';
+import { get } from '@ember/object';
+import { computed } from '@ember/object';
+
+export default Service.extend({
+  globalStore:     service(),
+
+  createProfileKey(profile, benchmark) {
+    return `${ benchmark.toUpperCase() } ${ profile } `;
+  },
+
+  clusterScanConfigToProfile(scanConfig) {
+    return this.createProfileKey(scanConfig.cisScanConfig.profile, scanConfig.cisScanConfig.overrideBenchmarkVersion);
+  },
+
+  profileToClusterScanConfig(profile) {
+    const profileBenchmark = this.cisScanProfiles[profile];
+
+    return {
+      cisScanConfig: {
+        failuresOnly:             false,
+        skip:                     null,
+        profile:                  profileBenchmark.profile,
+        overrideBenchmarkVersion: profileBenchmark.benchmark
+      }
+    }
+  },
+
+  defaultClusterScanConfig: computed(function() {
+    return this.profileToClusterScanConfig(this.defaultCisScanProfileOption);
+  }),
+
+  cisScanConfigProfiles: computed(function() {
+    return this.globalStore.getById('schema', 'cisscanconfig').optionsFor('profile');
+  }),
+
+  cisScanBenchmarks: computed(() => {
+    return [
+      'rke-cis-1.4',
+      'rke-cis-1.5'
+    ]
+  }),
+
+  cisScanProfiles: computed('cisScanConfigProfiles', 'cisScanBenchmarks', function() {
+    const profiles = get(this, 'cisScanConfigProfiles');
+    const benchmarks = get(this, 'cisScanBenchmarks');
+
+    const asArray = profiles.flatMap((profile) => {
+      return benchmarks.map((benchmark) => ({
+        [this.createProfileKey(profile, benchmark)]: {
+          benchmark,
+          profile
+        }
+      }))
+    });
+
+    return Object.assign.apply({}, asArray);
+  }),
+
+  cisScanProfileOptions: computed('cisScanProfiles', function() {
+    return Object.keys(get(this, 'cisScanProfiles')).map((key) => ({
+      label: toTitle(key),
+      value: key
+    }))
+  }),
+
+  defaultCisScanProfileOption: computed('cisScanProfileOptions', function() {
+    return get(this, 'cisScanProfileOptions')[0].value;
+  }),
+});

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -5,9 +5,7 @@ import {
 } from '@ember/object';
 import { maxSatisfying } from 'shared/utils/parse-version';
 import { inject as service } from '@ember/service';
-import {
-  clusterScanConfigToProfile, removeEmpty, keysToCamel, profileToClusterScanConfig, validateEndpoint, keysToDecamelize,
-} from 'shared/utils/util';
+import { removeEmpty, keysToCamel, validateEndpoint, keysToDecamelize } from 'shared/utils/util';
 import { validateHostname } from '@rancher/ember-api-store/utils/validate';
 import { validateCertWeakly } from 'shared/utils/util';
 import C from 'shared/utils/constants';
@@ -79,6 +77,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
   clusterTemplates:             service(),
   access:                       service(),
   router:                       service(),
+  cisHelpers:                   service(),
 
   layout,
   authChoices:                  AUTHCHOICES,
@@ -929,10 +928,9 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
   initScheduledClusterScan() {
     const scheduledClusterScan = get(this, 'primaryResource.scheduledClusterScan') || get(this, 'scheduledClusterScan');
-    const scanConfig = get(this, 'primaryResource.scheduledClusterScan.scanConfig') || profileToClusterScanConfig(get(this, 'model.cluster.defaultCisScanProfileOption'), get(this, 'model.cluster.cisScanProfiles'));
-    const scheduleConfig = get(this, 'primaryResource.scheduledClusterScan.scheduleConfig') || get(this, 'scheduledClusterScan.scheduleConfig');
-    const cisProfile = clusterScanConfigToProfile(scanConfig);
-
+    const scanConfig = get(this, 'primaryResource.scheduledClusterScan.scanConfig') || this.cisHelpers.defaultClusterScanConfig;
+    const scheduleConfig = get(this, 'primaryResource.scheduledClusterScan.scheduleConfig') ||  get(this, 'scheduledClusterScan.scheduleConfig');
+    const cisProfile =  this.cisHelpers.clusterScanConfigToProfile(scanConfig);
 
     set(this, 'scheduledClusterScan', scheduledClusterScan);
     set(this, 'scheduledClusterScan.scanConfig', scanConfig);
@@ -1049,7 +1047,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     const scheduledClusterScan = { ...get(this, 'scheduledClusterScan') };
 
     if (scheduledClusterScan.enabled) {
-      scheduledClusterScan.scanConfig = profileToClusterScanConfig(get(this, 'cisProfile'), get(this, 'model.cluster.cisScanProfiles'));
+      scheduledClusterScan.scanConfig = this.cisHelpers.profileToClusterScanConfig(get(this, 'cisProfile'));
     } else {
       scheduledClusterScan.scanConfig = null;
       scheduledClusterScan.scheduleConfig = null;

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -994,7 +994,7 @@
                   {{new-select
                     id="cis-scan-profile"
                     classNames="form-control"
-                    content=model.cluster.cisScanProfileOptions
+                    content=cisHelpers.cisScanProfileOptions
                     value=cisProfile
                     disabled=(not scheduledClusterScan.enabled)
                   }}

--- a/lib/shared/addon/components/run-scan-modal/component.js
+++ b/lib/shared/addon/components/run-scan-modal/component.js
@@ -9,6 +9,7 @@ export default Component.extend(ModalBase, {
   globalStore:  service(),
   growl:        service(),
   intl:         service(),
+  cisHelpers:   service(),
   modalService: service('modal'),
 
   layout,
@@ -18,8 +19,7 @@ export default Component.extend(ModalBase, {
 
   init() {
     this._super(...arguments);
-
-    set(this, 'profile', get(this, 'modalOpts.cluster.cisScanProfileOptions.first.value'));
+    set(this, 'profile', this.cisHelpers.cisScanProfileOptions[0].value);
   },
 
   actions: {
@@ -28,7 +28,9 @@ export default Component.extend(ModalBase, {
       const onRun = get(this, 'modalOpts.onRun');
       const intl = get(this, 'intl');
 
-      const profile = get(this, 'modalOpts.cluster.cisScanProfiles')[get(this, 'profile')];
+      const profile = this.cisHelpers.cisScanProfiles[get(this, 'profile')];
+      const clusterName = get(this, 'modalOpts.cluster.displayName');
+
 
       cluster.doAction('runSecurityScan', {
         failuresOnly:             false,
@@ -36,7 +38,7 @@ export default Component.extend(ModalBase, {
         profile:                  profile.profile,
         overrideBenchmarkVersion: profile.benchmark
       }).then(() => {
-        this.growl.success(intl.t('cis.scan.growl.success', { clusterName: get(this, 'name') }), '');
+        this.growl.success(intl.t('cis.scan.growl.success', { clusterName }), '');
       });
 
       this.get('modalService').toggleModal();

--- a/lib/shared/addon/components/run-scan-modal/template.hbs
+++ b/lib/shared/addon/components/run-scan-modal/template.hbs
@@ -8,7 +8,7 @@
 {{new-select
   id="cis-scan-profile"
   classNames="form-control"
-  content=modalOpts.cluster.cisScanProfileOptions
+  content=cisHelpers.cisScanProfileOptions
   value=profile
 }}
 

--- a/lib/shared/addon/utils/util.js
+++ b/lib/shared/addon/utils/util.js
@@ -582,29 +582,6 @@ export function extractUniqueStrings(strings) {
   return Object.keys(index);
 }
 
-export function createProfileKey(profile, benchmark) {
-  return `${ benchmark.toUpperCase() } ${ profile } `;
-}
-
-export function clusterScanConfigToProfile(scanConfig) {
-  console.log(scanConfig.cisScanConfig.profile, scanConfig.cisScanConfig.overrideBenchmarkVersion);
-
-  return createProfileKey(scanConfig.cisScanConfig.profile, scanConfig.cisScanConfig.overrideBenchmarkVersion);
-}
-
-export function profileToClusterScanConfig(profile, cisScanProfiles) {
-  const profileBenchmark = cisScanProfiles[profile];
-
-  return {
-    cisScanConfig: {
-      failuresOnly:             false,
-      skip:                     null,
-      profile:                  profileBenchmark.profile,
-      overrideBenchmarkVersion: profileBenchmark.benchmark
-    }
-  }
-}
-
 var Util = {
   absoluteUrl,
   addAuthorization,
@@ -614,10 +591,8 @@ var Util = {
   arrayIntersect,
   compareDisplayEndpoint,
   camelToTitle,
-  clusterScanConfigToProfile,
   convertToMillis,
   constructUrl,
-  createProfileKey,
   download,
   deepCopy,
   escapeHtml,
@@ -638,7 +613,6 @@ var Util = {
   parseUrl,
   pluralize,
   popupWindowOptions,
-  profileToClusterScanConfig,
   random32,
   randomStr,
   removeEmpty,

--- a/lib/shared/app/cis-helpers/service.js
+++ b/lib/shared/app/cis-helpers/service.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/cis-helpers/service';


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The profile helper methods were attached to the cluster model.
Unfortunately, the cluster isn't available when creating a new rke
template.

To resolve this I moved all of the cis helpers out of the cluster model
and utils and moved them into a cisHelpers service so they could be
used without access to the cluster itself.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)
