### PR TITLE
Adding cisScan to displayCondition

### DIFF
--- a/app/models/clusteralertrule.js
+++ b/app/models/clusteralertrule.js
@@ -46,7 +46,8 @@ const clusterAlertRule = Resource.extend(Alert, {
     const c = get(this, 'nodeRule.condition')
     const cpuThreshold = get(this, 'nodeRule.cpuThreshold');
     const memThreshold = get(this, 'nodeRule.memThreshold');
-    const metricRule = get(this, 'metricRule')
+    const metricRule = get(this, 'metricRule');
+    const clusterScanRule = get(this, 'clusterScanRule');
 
     switch (t) {
     case 'systemService':
@@ -71,6 +72,11 @@ const clusterAlertRule = Resource.extend(Alert, {
       break;
     case 'metric':
       out = metricRule.comparison === C.ALERTING_COMPARISON.HAS_VALUE ? intl.t(`alertPage.comparison.${ metricRule.comparison }`) : `${ intl.t(`alertPage.comparison.${ metricRule.comparison }`) } ${ metricRule.thresholdValue }`
+      break;
+    case 'cisScan':
+      out = clusterScanRule.failuresOnly
+        ? intl.t('alertPage.index.table.displayCondition.failure')
+        : intl.t('alertPage.index.table.displayCondition.happens');
       break;
     }
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -402,6 +402,7 @@ alertPage:
       target: Target
       recipients: Notifiers
       displayCondition:
+        failure: Failure
         notScheduled: Not Scheduled
         notRunning: Not Running
         available: '{percent}% available'


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
We were displaying the Condition as Not Configured for
security scan alerts on the alerts page. We needed to define
the displayCondition for cis scans so it would display
appropriately.

It will display as either Failure or Happens depending on the value of
failuresOnly.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#25853
