### PR TITLE
Ensure clusterScanRule gets default for all alert sections

### DIFF
--- a/lib/alert/addon/components/alert/form-alert-rules/component.js
+++ b/lib/alert/addon/components/alert/form-alert-rules/component.js
@@ -77,7 +77,10 @@ export default Component.extend({
     const clusterId = get(this, 'scope.currentCluster.id')
     const nodeRule = gs.createRecord({ type: 'nodeRule' });
     const systemServiceRule = gs.createRecord({ type: 'systemServiceRule' });
-    const clusterScanRule = gs.createRecord({ type: 'clusterScanRule' });
+    const clusterScanRule = gs.createRecord({
+      type:        'clusterScanRule',
+      scanRunType: 'manual'
+    });
     const eventRule = gs.createRecord({ type: 'eventRule' });
     const metricRule = gs.createRecord({
       type:           'metricRule',

--- a/lib/alert/addon/edit/route.js
+++ b/lib/alert/addon/edit/route.js
@@ -50,6 +50,10 @@ export default Route.extend({
 
     const nodeRule = gs.createRecord({ type: 'nodeRule' });
     const systemServiceRule = gs.createRecord({ type: 'systemServiceRule' });
+    const clusterScanRule = gs.createRecord({
+      type:        'clusterScanRule',
+      scanRunType: 'manual'
+    });
     const eventRule = gs.createRecord({ type: 'eventRule' });
     const metricRule = gs.createRecord({
       type:           'metricRule',
@@ -77,6 +81,7 @@ export default Route.extend({
         nodeRule,
         systemServiceRule,
         metricRule,
+        clusterScanRule,
       });
       break;
     case 'node':
@@ -85,6 +90,7 @@ export default Route.extend({
         eventRule,
         systemServiceRule,
         metricRule,
+        clusterScanRule,
       });
       break;
     case 'systemService':
@@ -92,6 +98,7 @@ export default Route.extend({
         nodeRule,
         eventRule,
         metricRule,
+        clusterScanRule,
       });
       break;
     case 'metric':
@@ -99,6 +106,15 @@ export default Route.extend({
         nodeRule,
         systemServiceRule,
         eventRule,
+        clusterScanRule,
+      })
+      break;
+    case 'cisScan':
+      setProperties(alert, {
+        nodeRule,
+        systemServiceRule,
+        eventRule,
+        metricRule,
       })
       break;
     }

--- a/lib/alert/addon/mixins/edit-or-clone.js
+++ b/lib/alert/addon/mixins/edit-or-clone.js
@@ -13,6 +13,10 @@ export default Mixin.create({
 
     const nodeRule = gs.createRecord({ type: 'nodeRule' });
     const systemServiceRule = gs.createRecord({ type: 'systemServiceRule' });
+    const clusterScanRule = gs.createRecord({
+      type:        'clusterScanRule',
+      scanRunType: 'manual'
+    });
     const eventRule = gs.createRecord({ type: 'eventRule' });
     const metricRule = gs.createRecord({
       type:           'metricRule',
@@ -29,6 +33,7 @@ export default Mixin.create({
         nodeRule,
         systemServiceRule,
         metricRule,
+        clusterScanRule,
         _targetType: `${ et.toLowerCase() }Event`,
       });
       break;
@@ -38,6 +43,7 @@ export default Mixin.create({
         eventRule,
         systemServiceRule,
         metricRule,
+        clusterScanRule,
       });
       break;
     case 'systemService':
@@ -45,6 +51,7 @@ export default Mixin.create({
         nodeRule,
         eventRule,
         metricRule,
+        clusterScanRule,
       });
       break;
     case 'metric':
@@ -52,7 +59,16 @@ export default Mixin.create({
         nodeRule,
         systemServiceRule,
         eventRule,
-      })
+        clusterScanRule,
+      });
+      break;
+    case 'cisScan':
+      setProperties(model, {
+        nodeRule,
+        systemServiceRule,
+        eventRule,
+        metricRule,
+      });
       break;
     }
 

--- a/lib/alert/addon/new-rule/route.js
+++ b/lib/alert/addon/new-rule/route.js
@@ -52,6 +52,10 @@ export default Route.extend(EditOrClone, {
       duration:       '5m',
       thresholdValue: 0,
     })
+    const clusterScanRule = gs.createRecord({
+      type:        'clusterScanRule',
+      scanRunType: 'manual'
+    });
 
     const opt = {
       type:        'clusterAlertRule',
@@ -60,6 +64,7 @@ export default Route.extend(EditOrClone, {
       nodeRule,
       eventRule,
       systemServiceRule,
+      clusterScanRule,
       metricRule,
       severity:    'critical',
     };


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The security scan option was only working when creating an alert in
a new group. This was occuring because the default value was not
being created in all the sections expected.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#25904