### PR TITLE
Remove CIS skip button and total number

### DIFF
--- a/app/authenticated/cluster/cis/scan/controller.js
+++ b/app/authenticated/cluster/cis/scan/controller.js
@@ -20,7 +20,7 @@ export default Controller.extend({
       name:           'name',
       sort:           ['id'],
       translationKey: 'cis.scan.table.name',
-      width:          200,
+      width:          220,
     },
     {
       name:           'profile',
@@ -31,19 +31,19 @@ export default Controller.extend({
       name:           'passed',
       sort:           ['passed', 'id'],
       translationKey: 'cis.scan.table.passed',
-      width:          150,
+      width:          120,
     },
     {
       name:           'skipped',
       sort:           ['skipped', 'id'],
       translationKey: 'cis.scan.table.skipped',
-      width:          150,
+      width:          120,
     },
     {
       name:           'failed',
       sort:           ['failed', 'id'],
       translationKey: 'cis.scan.table.failed',
-      width:          150,
+      width:          120,
     },
     {
       name:           'notapplicable',

--- a/app/authenticated/cluster/cis/scan/detail/controller.js
+++ b/app/authenticated/cluster/cis/scan/detail/controller.js
@@ -31,10 +31,6 @@ export default Controller.extend({
       name:           'description',
       sort:           ['description', 'sortableId'],
       translationKey: 'cis.scan.detail.table.description',
-    },
-    {
-      name:           'buttons',
-      width:          120,
     }
   ],
   sortBy: 'state',

--- a/app/components/cluster/cis/scan/detail/table-row/template.hbs
+++ b/app/components/cluster/cis/scan/detail/table-row/template.hbs
@@ -12,18 +12,6 @@
             <div class="text-small text-error mt-5">{{t "cis.scan.detail.table.nodesTable.row.remediation" remediation=model.remediation}}</div>
         {{/if}}
     </td>
-    <td class="pl-15 pr-15">
-        {{#if showSkipButton}}
-            <button class="btn btn-sm bg-primary more-actions full-width bg-transparent" {{action "toggleSkip"}}>
-                {{t "cis.scan.detail.table.skip"}}
-            </button>
-        {{/if}}
-        {{#if showUnskipButton}}
-            <button class="btn btn-sm bg-primary more-actions full-width bg-transparent" {{action "toggleSkip"}}>
-                {{t "cis.scan.detail.table.unskip"}}
-            </button>
-        {{/if}}
-    </td>
     <td></td>
 </tr>
 {{#if (and expanded hasExpandableContent)}}

--- a/app/components/cluster/cis/scan/table-row/template.hbs
+++ b/app/components/cluster/cis/scan/table-row/template.hbs
@@ -3,10 +3,10 @@
     <td class="state"><BadgeState @model={{model}} /></td>
     <td><a href="{{href-to "authenticated.cluster.cis/scan/detail" model.clusterId model.id }}">{{model.name}}</a></td>
     <td>{{model.profile}}</td>
-    <td>{{#if model.total}}{{t "generic.completedOf" completed=model.passed total=model.total}}{{/if}}</td>
-    <td>{{#if model.total}}{{t "generic.completedOf" completed=model.skipped total=model.total}}{{/if}}</td>
-    <td>{{#if model.total}}{{t "generic.completedOf" completed=model.failed total=model.total}}{{/if}}</td>
-    <td>{{#if model.total}}{{t "generic.completedOf" completed=model.notApplicable total=model.total}}{{/if}}</td>
+    <td>{{#if model.total}}{{model.passed}}{{/if}}</td>
+    <td>{{#if model.total}}{{model.skipped}}{{/if}}</td>
+    <td>{{#if model.total}}{{model.failed}}{{/if}}</td>
+    <td>{{#if model.total}}{{model.notApplicable}}{{/if}}</td>
     <td>{{model.createdDate}}</td>
     <td class="actions">
         {{action-menu model=model}}


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
We're removing the CIS skip button because we decided the current UX
is poort and we don't want to spend a tremendous amount of effort
making a marginally better UX in the short time we have left.

We also removed the 19 of 59 from the main CIS page as the total was
misleading and wasn't actionable.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#25863
