### PR TITLE
Improving the UX of the run scan modal

### DIFF
--- a/app/authenticated/cluster/cis/scan/detail/controller.js
+++ b/app/authenticated/cluster/cis/scan/detail/controller.js
@@ -9,6 +9,7 @@ export default Controller.extend({
   growl:              service(),
   intl:               service(),
   securityScanConfig: service(),
+  cisHelpers:         service(),
 
   tableHeaders: [
     {
@@ -84,7 +85,7 @@ export default Controller.extend({
         state,
         sortableState:     this.getSortableState(state),
         id:                test.id,
-        sortableId:        this.createSortableId(test.id),
+        sortableId:        this.cisHelpers.createSortableId(test.id),
         description:       test.description,
         remediation:       state === 'Fail' ? test.remediation : null,
         nodes,
@@ -102,27 +103,6 @@ export default Controller.extend({
   clusterScans: computed('model.clusterScans.@each', function() {
     return get(this, 'model.clusterScans').filterBy('clusterId', get(this, 'scope.currentCluster.id'));
   }),
-
-  /**
-   * Converts an id that looks like 1.1.9 into 000010000100009. This
-   * allows us to appropriately compare the ids as if they are versions
-   * instead of just doing a naive string comparison.
-   * @param {*} id
-   */
-  createSortableId(id) {
-    const columnWidth = 5;
-    const splitId = id.split('.');
-
-    return splitId
-      .map((column) => {
-        const suffix = column.match(/[a-z]$/i) ? '' : 'a';
-        const columnWithSuffix = column + suffix;
-        const columnPaddingWidth = Math.max(columnWidth - columnWithSuffix.length, 0)
-
-        return '0'.repeat(columnPaddingWidth) + columnWithSuffix;
-      })
-      .join('');
-  },
 
   toggleSkip(testId) {
     this.securityScanConfig.validateSecurityScanConfig();

--- a/app/styles/base/_color.scss
+++ b/app/styles/base/_color.scss
@@ -18,7 +18,7 @@
   color: $link-color;
 }
 
-.text-disabled, .text-muted, .text-muted A {
+.text-disabled, .text-muted {
   // color: mix($mid-grey, $light-grey);
   color: $mid-grey;
 }

--- a/lib/shared/addon/cis-helpers/service.js
+++ b/lib/shared/addon/cis-helpers/service.js
@@ -5,7 +5,9 @@ import { computed } from '@ember/object';
 import StatefulPromise from 'shared/utils/stateful-promise';
 
 export default Service.extend({
-  globalStore:     service(),
+  globalStore:        service(),
+  intl:               service(),
+  securityScanConfig: service(),
 
   createProfileKey(profile, benchmark) {
     return profile && benchmark
@@ -29,6 +31,31 @@ export default Service.extend({
       }
     }
   },
+
+  /**
+   * Converts an id that looks like 1.1.9 into 000010000100009. This
+   * allows us to appropriately compare the ids as if they are versions
+   * instead of just doing a naive string comparison.
+   * @param {*} id
+   */
+  createSortableId(id) {
+    const columnWidth = 5;
+    const splitId = id.trim().split('.');
+
+    return splitId
+      .map((column) => {
+        const suffix = column.match(/[a-z]$/i) ? '' : 'a';
+        const columnWithSuffix = column + suffix;
+        const columnPaddingWidth = Math.max(columnWidth - columnWithSuffix.length, 0)
+
+        return '0'.repeat(columnPaddingWidth) + columnWithSuffix;
+      })
+      .join('');
+  },
+
+  defaultClusterScanConfig: computed(function() {
+    return this.profileToClusterScanConfig(this.defaultCisScanProfileOption);
+  }),
 
   cisScanConfigProfiles: computed(function() {
     return this.globalStore.getById('schema', 'cisscanconfig').optionsFor('profile');
@@ -88,5 +115,50 @@ export default Service.extend({
 
   defaultCisScanProfileOption: computed('cisScanProfileOptions', function() {
     return get(this, 'cisScanProfileOptions')[0].value;
+  }),
+
+  benchmarkVersions: computed(function() {
+    return StatefulPromise.wrap(this.globalStore.findAll('cisBenchmarkVersion'), []);
+  }),
+
+  benchmarkLookup: computed('benchmarkVersions.value', 'securityScanConfig.parsedSecurityScanConfig', function() {
+    const getUserSkip = (benchmark) => {
+      try {
+        const userSkipLookup = get(this, 'securityScanConfig.parsedSecurityScanConfig.skip');
+        const userSkip = userSkipLookup[benchmark];
+
+        const skips = (Array.isArray(userSkip) && userSkip.every((s) => typeof s === 'string'))
+          ? userSkip
+          : [];
+
+        return skips.reduce((agg, skip) => ({
+          ...agg,
+          [`${ skip } `]: this.intl.t('cis.scan.modal.skippedByUserExplanation')
+        }), {});
+      } catch (ex) {
+        return {};
+      }
+    };
+
+    return get(this, 'benchmarkVersions.value')
+      .filter((bv) => bv.info.notApplicableChecks && bv.info.skippedChecks)
+      .reduce((agg, bv) => ({
+        ...agg,
+        [bv.name]: {
+          notApplicableChecks: Object.entries(bv.info.notApplicableChecks).map((e) => ({
+            sortableId: this.createSortableId(e[0]),
+            id:         e[0],
+            why:        e[1]
+          })).sortBy('sortableId'),
+          skippedChecks:       Object.entries({
+            ...bv.info.skippedChecks,
+            ...getUserSkip(bv.name)
+          }).map((e) => ({
+            sortableId: this.createSortableId(e[0]),
+            id:         e[0],
+            why:        e[1]
+          })).sortBy('sortableId'),
+        }
+      }), {});
   }),
 });

--- a/lib/shared/addon/components/run-scan-modal/component.js
+++ b/lib/shared/addon/components/run-scan-modal/component.js
@@ -2,20 +2,25 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import ModalBase from 'shared/mixins/modal-base';
 import layout from './template';
-import { get, set, observer } from '@ember/object';
+import { get, set, observer, computed } from '@ember/object';
 
 export default Component.extend(ModalBase, {
-  settings:     service(),
-  globalStore:  service(),
-  growl:        service(),
-  intl:         service(),
-  cisHelpers:   service(),
-  modalService: service('modal'),
+  settings:           service(),
+  globalStore:        service(),
+  growl:              service(),
+  intl:               service(),
+  cisHelpers:         service(),
+  modalService:       service('modal'),
 
   layout,
   profile: null,
 
   classNames: ['generic', 'about', 'medium-modal'],
+
+  init() {
+    this._super(...arguments);
+    this.updateProfile();
+  },
 
   actions: {
     run() {
@@ -23,7 +28,7 @@ export default Component.extend(ModalBase, {
       const onRun = get(this, 'modalOpts.onRun');
       const intl = get(this, 'intl');
 
-      const profile = this.cisHelpers.cisScanProfiles[get(this, 'profile')];
+      const profile = get(this, 'profileObject');
       const clusterName = get(this, 'modalOpts.cluster.displayName');
 
 
@@ -42,9 +47,46 @@ export default Component.extend(ModalBase, {
   },
 
   cisScanProfileOptionsChanged: observer('cisHelpers.cisScanProfileOptions.[]', function() {
-    const kubernetesVersion = get(this, 'modalOpts.cluster.rancherKubernetesEngineConfig.kubernetesVersion');
-    const defaultOption = this.cisHelpers.getDefaultCisScanProfileOption(kubernetesVersion);
-
-    set(this, 'profile', defaultOption);
+    this.updateProfile();
   }),
+
+  profileObject: computed('profile', function() {
+    return this.cisHelpers.cisScanProfiles[get(this, 'profile')];
+  }),
+
+  testsNotRunning: computed('cisHelpers.benchmarkLookup', 'profileObject', function() {
+    const benchmarkLookup = get(this, 'cisHelpers.benchmarkLookup');
+    const profile = get(this, 'profileObject');
+
+    if (!benchmarkLookup || !profile) {
+      return {};
+    }
+    const mapping = benchmarkLookup[profile.benchmark];
+
+    if (!mapping) {
+      return {};
+    }
+
+    const skippedChecks = mapping.skippedChecks;
+
+    return {
+      skippedChecks,
+      notApplicableChecks: mapping.notApplicableChecks
+    } ;
+  }),
+  profileDocsHtml: computed(function() {
+    return this.intl.t('cis.scan.modal.profileDocs');
+  }),
+  testDocsHtml: computed(function() {
+    return this.intl.t('cis.scan.modal.testDocs');
+  }),
+  updateProfile() {
+    if (this.cisHelpers.cisScanProfileOptions.length > 0) {
+      const kubernetesVersion = get(this, 'modalOpts.cluster.rancherKubernetesEngineConfig.kubernetesVersion');
+      const defaultOption = this.cisHelpers.getDefaultCisScanProfileOption(kubernetesVersion);
+
+      set(this, 'profile', defaultOption);
+    }
+  },
+
 });

--- a/lib/shared/addon/components/run-scan-modal/template.hbs
+++ b/lib/shared/addon/components/run-scan-modal/template.hbs
@@ -7,10 +7,72 @@
 <label>{{t "cis.scan.modal.chooseAProfile"}}</label>
 {{new-select
   id="cis-scan-profile"
-  classNames="form-control"
+  classNames="form-control mb-10"
   content=cisHelpers.cisScanProfileOptions
   value=profile
 }}
+<div class="text-small text-muted">{{{profileDocsHtml}}}</div>
+
+<div class="mt-20">
+  {{#if testsNotRunning}}
+    <h3 class="mb-0">{{t "cis.scan.modal.testsWontRun"}}</h3>
+    {{#accordion-list showExpandAll=false as |al expandFn|}}
+      {{#accordion-list-item
+          title=(t "cis.scan.modal.notApplicableTests" count=testsNotRunning.notApplicableChecks.length)
+          expand=(action expandFn)
+          expandOnInit=false
+      }}
+        <table>
+          <thead>
+            <tr>
+              <td width="70">
+                {{t "cis.scan.modal.tableHeaders.id"}}
+              </td>
+              <td>
+                {{t "cis.scan.modal.tableHeaders.explanation"}}
+              </td>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each testsNotRunning.notApplicableChecks as |test|}}
+              <tr>
+                <td>{{ test.id }}</td>
+                <td class="text-small text-muted">{{ test.why }}</td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      {{/accordion-list-item}}
+      {{#accordion-list-item
+          title=(t "cis.scan.modal.skippedTests" count=testsNotRunning.skippedChecks.length)
+          expand=(action expandFn)
+          expandOnInit=false
+      }}
+        <table>
+          <thead>
+          <tr>
+            <td width="70">
+              {{t "cis.scan.modal.tableHeaders.id"}}
+            </td>
+            <td>
+              {{t "cis.scan.modal.tableHeaders.explanation"}}
+            </td>
+          </tr>
+        </thead>
+          <tbody>
+            {{#each testsNotRunning.skippedChecks as |test|}}
+              <tr>
+                <td>{{ test.id }}</td>
+                <td class="text-small text-muted">{{ test.why }}</td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      {{/accordion-list-item}}
+    {{/accordion-list}}
+    <div class="text-small text-muted">{{{testDocsHtml}}}</div>
+  {{/if}}
+</div>
 
 <div class="footer-actions pull-right">
   <button {{action "cancel"}} class="btn bg-secondary">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1042,6 +1042,15 @@ cis:
     modal:
       chooseAProfile: Choose a profile
       title: Run CIS Scan
+      testsWontRun: These tests won't run
+      notApplicableTests: Not Applicable Tests ({count})
+      skippedByUserExplanation: Skipped by user 
+      skippedTests: Skipped Tests ({count})
+      profileDocs: To find out more about profiles visit our docs <a href="https://rancher.com/docs/" target="_blank" rel="nofollow noopener noreferrer">here</a>.
+      testDocs: To find out why these tests won't run visit our docs <a href="https://rancher.com/docs/" target="_blank" rel="nofollow noopener noreferrer">here</a>.
+      tableHeaders:
+        id: Test Id
+        explanation: Explanation
     growl:
       success: Running CIS scan on '{clusterName}'
     header: CIS Scans


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
We are going to add a section beneath the profile selector of the run
scan modal. This section is responsible for informing the user of which
tests will not be run and why.

There will be two subsections Not Applicable and Skipped tests.
Skipped tests will only be shown for permissive profiles since
hardened tests shouldn't skip anything.


Types of changes
======
- New feature (non-breaking change which adds functionality)


Linked Issues
======
rancher/rancher#25961

![Screen Shot 2020-03-11 at 12 44 37 PM](https://user-images.githubusercontent.com/55104481/76460454-4233e780-639b-11ea-9c35-2e13b7a1d60f.png)

![Screen Shot 2020-03-11 at 12 44 47 PM](https://user-images.githubusercontent.com/55104481/76460450-419b5100-639b-11ea-95ae-24fe26157346.png)

![Screen Shot 2020-03-11 at 12 45 01 PM](https://user-images.githubusercontent.com/55104481/76460444-406a2400-639b-11ea-81a0-8e92a7fdc455.png)

