### PR TITLE
Use KDM to drive benchmark options and profile default

### DIFF
--- a/lib/shared/addon/cis-helpers/service.js
+++ b/lib/shared/addon/cis-helpers/service.js
@@ -2,12 +2,15 @@ import Service, { inject as service } from '@ember/service';
 import { toTitle } from 'shared/utils/util';
 import { get } from '@ember/object';
 import { computed } from '@ember/object';
+import StatefulPromise from 'shared/utils/stateful-promise';
 
 export default Service.extend({
   globalStore:     service(),
 
   createProfileKey(profile, benchmark) {
-    return `${ benchmark.toUpperCase() } ${ profile } `;
+    return profile && benchmark
+      ? `${ benchmark.toUpperCase() } ${ profile } `
+      : '';
   },
 
   clusterScanConfigToProfile(scanConfig) {
@@ -27,20 +30,28 @@ export default Service.extend({
     }
   },
 
-  defaultClusterScanConfig: computed(function() {
-    return this.profileToClusterScanConfig(this.defaultCisScanProfileOption);
-  }),
-
   cisScanConfigProfiles: computed(function() {
     return this.globalStore.getById('schema', 'cisscanconfig').optionsFor('profile');
   }),
 
-  cisScanBenchmarks: computed(() => {
-    return [
-      'rke-cis-1.4',
-      'rke-cis-1.5'
-    ]
+  cisConfigs: computed(function() {
+    return StatefulPromise.wrap(this.globalStore.findAll('cisConfig'), []);
   }),
+
+  benchmarkMapping: computed('cisConfigs.value', function() {
+    const configs = get(this, 'cisConfigs.value');
+
+    return configs.reduce((agg, config) => ({
+      ...agg,
+      [config.name]: config.params.benchmarkVersion
+    }), {})
+  }),
+
+  benchmarkMappingValues: computed('benchmarkMapping', function() {
+    return Object.values(get(this, 'benchmarkMapping'));
+  }),
+
+  cisScanBenchmarks: computed.uniq('benchmarkMappingValues'),
 
   cisScanProfiles: computed('cisScanConfigProfiles', 'cisScanBenchmarks', function() {
     const profiles = get(this, 'cisScanConfigProfiles');
@@ -55,8 +66,18 @@ export default Service.extend({
       }))
     });
 
-    return Object.assign.apply({}, asArray);
+    return asArray.length > 0 ? Object.assign.apply({}, asArray) : {};
   }),
+
+  getDefaultCisScanProfileOption(kubernetesVersion) {
+    const mapping = get(this, 'benchmarkMapping');
+    const version = kubernetesVersion.split('.').slice(0, 2).join('.');
+
+    const defaultBenchmark = mapping[version] ? mapping[version] : mapping['default'];
+    const defaultProfile = get(this, 'cisScanConfigProfiles')[0];
+
+    return this.createProfileKey(defaultProfile, defaultBenchmark);
+  },
 
   cisScanProfileOptions: computed('cisScanProfiles', function() {
     return Object.keys(get(this, 'cisScanProfiles')).map((key) => ({

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -473,6 +473,26 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     set(this, 'config.services', services);
   }),
 
+  initScheduledClusterScan: observer('cisHelpers.cisScanBenchmarks.[]', function() {
+    // We need to wait for benchmarks to be available before we can actually create the profiles
+    if (this.cisHelpers.cisScanBenchmarks.length === 0) {
+      return;
+    }
+
+    const kubernetesVersion = get(this, 'primaryResource.rancherKubernetesEngineConfig.kubernetesVersion');
+    const defaultProfileOption = this.cisHelpers.getDefaultCisScanProfileOption(kubernetesVersion);
+    const scheduledClusterScan = get(this, 'primaryResource.scheduledClusterScan') || get(this, 'scheduledClusterScan');
+    const scanConfig = get(this, 'primaryResource.scheduledClusterScan.scanConfig') || this.cisHelpers.profileToClusterScanConfig(defaultProfileOption);
+    const scheduleConfig = get(this, 'primaryResource.scheduledClusterScan.scheduleConfig') ||  get(this, 'scheduledClusterScan.scheduleConfig');
+    const cisProfile =  this.cisHelpers.clusterScanConfigToProfile(scanConfig);
+
+    set(this, 'scheduledClusterScan', scheduledClusterScan);
+    set(this, 'scheduledClusterScan.scanConfig', scanConfig);
+    set(this, 'scheduledClusterScan.scheduleConfig', scheduleConfig);
+    set(this, 'cisProfile', cisProfile);
+  }),
+
+
   enforcementChanged: on('init', observer('settings.clusterTemplateEnforcement', function() {
     let {
       access:   { me: { hasAdmin: globalAdmin = null } },
@@ -933,19 +953,6 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     set(this, 'upgradeStrategy.nodeDrainInput', drainInput ? drainInput : {});
     set(this, 'upgradeStrategy.drain', get(this, 'primaryResource.rancherKubernetesEngineConfig.upgradeStrategy.drain'));
   },
-
-  initScheduledClusterScan() {
-    const scheduledClusterScan = get(this, 'primaryResource.scheduledClusterScan') || get(this, 'scheduledClusterScan');
-    const scanConfig = get(this, 'primaryResource.scheduledClusterScan.scanConfig') || this.cisHelpers.defaultClusterScanConfig;
-    const scheduleConfig = get(this, 'primaryResource.scheduledClusterScan.scheduleConfig') ||  get(this, 'scheduledClusterScan.scheduleConfig');
-    const cisProfile =  this.cisHelpers.clusterScanConfigToProfile(scanConfig);
-
-    set(this, 'scheduledClusterScan', scheduledClusterScan);
-    set(this, 'scheduledClusterScan.scanConfig', scanConfig);
-    set(this, 'scheduledClusterScan.scheduleConfig', scheduleConfig);
-    set(this, 'cisProfile', cisProfile);
-  },
-
 
   getClusterFields(primaryResource) {
     let pojoPr = JSON.parse(JSON.stringify(removeEmpty(primaryResource, EXCLUDED_KEYS, EXCLUDED_CHILDREN_KEYS)));

--- a/lib/shared/addon/components/run-scan-modal/component.js
+++ b/lib/shared/addon/components/run-scan-modal/component.js
@@ -2,7 +2,7 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import ModalBase from 'shared/mixins/modal-base';
 import layout from './template';
-import { get, set } from '@ember/object';
+import { get, set, observer } from '@ember/object';
 
 export default Component.extend(ModalBase, {
   settings:     service(),
@@ -16,11 +16,6 @@ export default Component.extend(ModalBase, {
   profile: null,
 
   classNames: ['generic', 'about', 'medium-modal'],
-
-  init() {
-    this._super(...arguments);
-    set(this, 'profile', this.cisHelpers.cisScanProfileOptions[0].value);
-  },
 
   actions: {
     run() {
@@ -45,4 +40,11 @@ export default Component.extend(ModalBase, {
       (onRun || (() => {}))();
     }
   },
+
+  cisScanProfileOptionsChanged: observer('cisHelpers.cisScanProfileOptions.[]', function() {
+    const kubernetesVersion = get(this, 'modalOpts.cluster.rancherKubernetesEngineConfig.kubernetesVersion');
+    const defaultOption = this.cisHelpers.getDefaultCisScanProfileOption(kubernetesVersion);
+
+    set(this, 'profile', defaultOption);
+  }),
 });


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This will now allow KDM to drive what the benchmark options are and what
the default option is for profile selection given a kubernetes version.

The 'cisConfig' type is what we look up for this information.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#25888
