### PR TITLE
Ensure upgrade strategy defaults are used on an upgraded rancher

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -942,16 +942,24 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
 
   initUpgradeStrategy() {
-    const maxUnavailableControlplane = get(this, 'primaryResource.rancherKubernetesEngineConfig.upgradeStrategy.maxUnavailableControlplane');
-    const maxUnavailableWorker = get(this, 'primaryResource.rancherKubernetesEngineConfig.upgradeStrategy.maxUnavailableWorker') || '';
+    const upgradeStrategy = get(this, 'primaryResource.rancherKubernetesEngineConfig.upgradeStrategy')
+    const source = upgradeStrategy
+      ? upgradeStrategy
+      : this.globalStore.createRecord({
+        type:           'nodeUpgradeStrategy',
+        nodeDrainInput: this.globalStore.createRecord({ type: 'nodeDrainInput' })
+      });
+
+    const maxUnavailableControlplane = get(source, 'maxUnavailableControlplane');
+    const maxUnavailableWorker = get(source, 'maxUnavailableWorker') || '';
     const maxUnavailableUnit = maxUnavailableWorker.includes('%') ? 'percentage' : 'count';
-    const drainInput = get(this, 'primaryResource.rancherKubernetesEngineConfig.upgradeStrategy.nodeDrainInput');
+    const drainInput = get(source, 'nodeDrainInput');
 
     set(this, 'upgradeStrategy.maxUnavailableControlplane', maxUnavailableControlplane);
     set(this, 'upgradeStrategy.maxUnavailableWorker', maxUnavailableWorker.replace('%', ''));
     set(this, 'upgradeStrategy.maxUnavailableUnit', maxUnavailableUnit);
     set(this, 'upgradeStrategy.nodeDrainInput', drainInput ? drainInput : {});
-    set(this, 'upgradeStrategy.drain', get(this, 'primaryResource.rancherKubernetesEngineConfig.upgradeStrategy.drain'));
+    set(this, 'upgradeStrategy.drain', get(source, 'drain'));
   },
 
   getClusterFields(primaryResource) {


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The default rancherKubernetesEngineConfig is only created for new
clusters. This now creates a default upgradeStraegy object when one
doesn't exist in rancherKubernetesEngineConfig.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#25951

