### PR TITLE
Make CIS schedule and alert buttons disabled more in line with run scan button

### DIFF
--- a/app/authenticated/cluster/cis/scan/template.hbs
+++ b/app/authenticated/cluster/cis/scan/template.hbs
@@ -23,10 +23,10 @@
           <td colspan="{{sortable.fullColspan}}" class="text-center text-muted pt-20 pb-20">{{t 'cis.scan.table.empty'}}</td>
         </tr>
       {{else if (eq kind "right-actions")}}
-        <button style="margin-left: -5px;" class="btn btn-sm bg-secondary pl-40 pr-40 mr-5" {{action "setSchedule"}} disabled={{scope.currentCluster.isWindows}}>
+        <button style="margin-left: -5px;" class="btn btn-sm bg-secondary pl-40 pr-40 mr-5" {{action "setSchedule"}} disabled={{scope.currentCluster.isClusterScanDown}}>
           {{t 'cis.scan.actions.addSchedule'}}
         </button>
-        <button style="margin-left: -5px;" class="btn btn-sm bg-secondary pl-40 pr-40 mr-5" {{action "setAlert"}} disabled={{scope.currentCluster.isWindows}}>
+        <button style="margin-left: -5px;" class="btn btn-sm bg-secondary pl-40 pr-40 mr-5" {{action "setAlert"}} disabled={{scope.currentCluster.isClusterScanDown}}>
           {{t 'cis.scan.actions.addAlert'}}
         </button>
         <button style="margin-left: -5px;" class="btn btn-sm bg-primary pl-40 pr-40" {{action "runScan"}} disabled={{scope.currentCluster.isClusterScanDisabled}}>

--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -329,12 +329,16 @@ export default Resource.extend(Grafana, ResourceUsage, {
     return !!get(this, 'windowsPreferedCluster');
   }),
 
-  isClusterScanDisabled: computed('runningClusterScans', 'systemProject', 'state', 'actionLinks.runSecurityScan', 'isWindows', function() {
-    return (get(this, 'runningClusterScans.length') > 0)
-      || !get(this, 'systemProject')
+  isClusterScanDown: computed('systemProject', 'state', 'actionLinks.runSecurityScan', 'isWindows', function() {
+    return !get(this, 'systemProject')
       || get(this, 'state') !== 'active'
       || !get(this, 'actionLinks.runSecurityScan')
       || get(this, 'isWindows');
+  }),
+
+  isClusterScanDisabled: computed('runningClusterScans.length', 'isClusterScanDown', function() {
+    return (get(this, 'runningClusterScans.length') > 0)
+      || get(this, 'isClusterScanDown');
   }),
 
   unhealthyComponents: computed('componentStatuses.@each.conditions', function() {


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Make CIS schedule and alert buttons disabled more in line with run scan button

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#25997
