### PR TITLE
[Master] Fix the issue that users cannot remove proxyUrl of notifier

### DIFF
--- a/app/components/notifier/modal-new-edit/component.js
+++ b/app/components/notifier/modal-new-edit/component.js
@@ -102,8 +102,6 @@ export default Component.extend(ModalBase, NewOrEdit, {
       }
       const ok = this.validate();
 
-      this.willSave()
-
       if (!ok) {
         return resolve();
       }
@@ -213,20 +211,5 @@ export default Component.extend(ModalBase, NewOrEdit, {
     set(this, 'errors', errors);
 
     return get(this, 'errors.length') === 0;
-  },
-
-  willSave() {
-    const notifierType = get(this, 'model.notifierType')
-
-    if (notifierType !== 'email') {
-      const targetConfig = get(this, `model.${ notifierType }Config`)
-
-      if (!get(targetConfig, 'proxyUrl')) {
-        delete targetConfig.proxyUrl
-      }
-      set(this, `model.${ notifierType }Config`, targetConfig)
-    }
-
-    return this._super(...arguments);
   },
 });


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

After users set a proxy url for a notifier, they can not really remove it in alert manager config.
We need to remove the logic in this PR.

It was added for fixing  https://github.com/rancher/rancher/issues/22144 but it introduced  https://github.com/rancher/rancher/issues/26089

We need to fix it in backend.

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

- Bugfix

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/26089
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
Related PR:
https://github.com/rancher/rancher/pull/26129
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
