### PR TITLE
Adding yet another condition to the CIS Add Schedule button

### DIFF
--- a/app/authenticated/cluster/cis/scan/route.js
+++ b/app/authenticated/cluster/cis/scan/route.js
@@ -19,7 +19,8 @@ export default Route.extend({
 
         return await Promise.all(reportPromises);
       })(),
-      configMaps: this.securityScanConfig.loadAsyncConfigMap(get(this, 'scope.currentCluster'))
+      configMaps:               this.securityScanConfig.loadAsyncConfigMap(get(this, 'scope.currentCluster')),
+      clusterTemplateRevisions: get(this, 'globalStore').findAll('clustertemplaterevision')
     });
   },
 });

--- a/app/authenticated/cluster/cis/scan/template.hbs
+++ b/app/authenticated/cluster/cis/scan/template.hbs
@@ -23,7 +23,7 @@
           <td colspan="{{sortable.fullColspan}}" class="text-center text-muted pt-20 pb-20">{{t 'cis.scan.table.empty'}}</td>
         </tr>
       {{else if (eq kind "right-actions")}}
-        <button style="margin-left: -5px;" class="btn btn-sm bg-secondary pl-40 pr-40 mr-5" {{action "setSchedule"}} disabled={{scope.currentCluster.isClusterScanDown}}>
+        <button style="margin-left: -5px;" class="btn btn-sm bg-secondary pl-40 pr-40 mr-5" {{action "setSchedule"}} disabled={{scope.currentCluster.isAddClusterScanScheduleDisabled}}>
           {{t 'cis.scan.actions.addSchedule'}}
         </button>
         <button style="margin-left: -5px;" class="btn btn-sm bg-secondary pl-40 pr-40 mr-5" {{action "setAlert"}} disabled={{scope.currentCluster.isClusterScanDown}}>

--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -12,6 +12,7 @@ import { isEmpty } from '@ember/utils';
 import moment from 'moment';
 const TRUE = 'True';
 const CLUSTER_TEMPLATE_ID_PREFIX = 'cattle-global-data:';
+const SCHEDULE_CLUSTER_SCAN_QUESTION_KEY = 'scheduledClusterScan.enabled';
 
 export default Resource.extend(Grafana, ResourceUsage, {
   globalStore: service(),
@@ -334,6 +335,23 @@ export default Resource.extend(Grafana, ResourceUsage, {
       || get(this, 'state') !== 'active'
       || !get(this, 'actionLinks.runSecurityScan')
       || get(this, 'isWindows');
+  }),
+
+  isAddClusterScanScheduleDisabled: computed('isClusterScanDown', 'scheduledClusterScan.enabled', 'clusterTemplateRevision', 'clusterTemplateRevision.questions.@each', function() {
+    if (get(this, 'clusterTemplateRevision') === null) {
+      return get(this, 'isClusterScanDown');
+    }
+
+    if (get(this, 'isClusterScanDown')) {
+      return true;
+    }
+
+    if (get(this, 'scheduledClusterScan.enabled')) {
+      return false;
+    }
+
+    return !get(this, 'clusterTemplateRevision.questions')
+      || get(this, 'clusterTemplateRevision.questions').every((question) => question.variable !== SCHEDULE_CLUSTER_SCAN_QUESTION_KEY)
   }),
 
   isClusterScanDisabled: computed('runningClusterScans.length', 'isClusterScanDown', function() {


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This now checks to see if there's and RKE template.
If there is an RKE template and the scheduleScanned is disabled
the button will be disabled unless there's an override available for
the scheduledClusterScan.enabled field.


Types of changes
======
- New feature (non-breaking change which adds functionality)


Linked Issues
======
rancher/rancher#26150
