### PR TITLE
Changing the way configMaps get loaded for RunScanModal

### DIFF
--- a/app/authenticated/cluster/cis/scan/detail/route.js
+++ b/app/authenticated/cluster/cis/scan/detail/route.js
@@ -6,16 +6,10 @@ import { hash } from 'rsvp';
 export default Route.extend({
   globalStore:        service(),
   scope:              service(),
-  securityScanConfig: service(),
   model(params) {
     const scan = get(this, 'globalStore').find('clusterScan', params.scan_id);
     const report = (async() => {
       return (await scan).loadReport('report');
-    })();
-    const configMaps = (async() => {
-      this.securityScanConfig.setReport(await report);
-
-      return this.securityScanConfig.loadAsyncConfigMap(get(this, 'scope.currentCluster'));
     })();
 
     return hash({
@@ -23,7 +17,6 @@ export default Route.extend({
       scan,
       report,
       nodes:        get(this, 'scope.currentCluster.nodes'),
-      configMaps,
     });
   }
 });

--- a/app/authenticated/cluster/cis/scan/route.js
+++ b/app/authenticated/cluster/cis/scan/route.js
@@ -5,7 +5,6 @@ import { hash } from 'rsvp';
 
 export default Route.extend({
   globalStore:        service(),
-  securityScanConfig: service(),
   scope:              service(),
 
   model() {
@@ -19,7 +18,6 @@ export default Route.extend({
 
         return await Promise.all(reportPromises);
       })(),
-      configMaps:               this.securityScanConfig.loadAsyncConfigMap(get(this, 'scope.currentCluster')),
       clusterTemplateRevisions: get(this, 'globalStore').findAll('clustertemplaterevision')
     });
   },

--- a/lib/shared/addon/security-scan-config/service.js
+++ b/lib/shared/addon/security-scan-config/service.js
@@ -1,6 +1,5 @@
 import Service, { inject as service } from '@ember/service';
 import { computed, get, set } from '@ember/object';
-import StatefulPromise from 'shared/utils/stateful-promise';
 
 const CONFIG_MAP_FILE_KEY = 'config.json'
 const CONFIG_MAP_NAMESPACE_ID = 'security-scan';
@@ -12,32 +11,28 @@ export default Service.extend({
   growl:        service(),
   intl:         service(),
   projectStore: service('store'),
+  app:          service(),
 
   FILE_KEY: CONFIG_MAP_FILE_KEY,
 
   report:         null,
-  asyncConfigMap: null,
+  configMaps:     [],
 
   setReport(report) {
     set(this, 'report', report);
   },
 
-  loadAsyncConfigMap(cluster) {
-    if (get(this, 'asyncConfigMap')) {
-      return get(this, 'asyncConfigMap');
-    }
+  async loadAsyncConfigMap(cluster) {
+    set(this, 'cluster', cluster);
+
     const systemProject = get(cluster, 'systemProject');
-    const configMaps = systemProject && systemProject.hasLink('configMaps') && get(cluster, 'state') === 'active' ? systemProject.followLink('configMaps') : []
-    const asyncConfigMap = StatefulPromise.wrap(configMaps, []);
+    const configMapsAsync = systemProject && systemProject.hasLink('configMaps') && get(cluster, 'state') === 'active' ? systemProject.followLink('configMaps') : []
+    const configMaps = await configMapsAsync;
 
-    set(this, 'asyncConfigMap', asyncConfigMap);
+    set(this, 'configMaps', [...configMaps.content]);
 
-    return asyncConfigMap;
+    return configMaps;
   },
-
-  configMaps: computed('asyncConfigMap.value', function() {
-    return get(this, 'asyncConfigMap.value');
-  }),
 
   defaultValue: computed('report.version', function() {
     return { skip: { [get(this, 'report.version')]: [] } };
@@ -51,13 +46,13 @@ export default Service.extend({
     return get(this, 'configMaps').findBy('id', 'security-scan:security-scan-cfg');
   }),
 
-  parsedSecurityScanConfig: computed('securityScanConfig.data.[]', 'securityScanConfig.data.@each', function() {
+  parsedSecurityScanConfig: computed('securityScanConfig.data.[]', 'securityScanConfig.data.@each', 'loadedTrigger', function() {
     try {
       return JSON.parse(get(this, 'securityScanConfig.data')[CONFIG_MAP_FILE_KEY]);
     } catch (error) {
       return get(this, 'defaultValue');
     }
-  }).volatile(),
+  }),
 
   validateSecurityScanConfig() {
     try {


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The RunScanModal was not getting config map changes after the first
time the modal was opened. The results were getting cached. By creating
a new array each time loadAsyncConfigMap is loaded I can guarentee the
computed properties will get re-evaluated.

I also attempted to watch config maps through the project store but
unfortunately updating the data of the config map doesn't seem to
produce a websocket message. Even if the message was created I
don't think I'd be able to watch the value as I'd have to
watch a sub-object 'config.json' which has a period in it. This causes
problems with watching in ember.


Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#26161