### PR TITLE
EKS Driver Observer Issue

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
@@ -246,28 +246,29 @@ export default Component.extend(ClusterDriver, {
   }),
 
   vpcsChanged: observer('config.virtualNetwork', 'vpcSubnetMode', function() {
-    const vnet = get(this, 'config.virtualNetwork');
-    const subnets = get(this, 'config.subnets');
-    const mode = get(this, 'vpcSubnetMode');
+    if (!this.primaryResource.isTransitioning) {
+      const vnet                 = get(this, 'config.virtualNetwork');
+      const subnets              = get(this, 'config.subnets');
+      const mode                 = get(this, 'vpcSubnetMode');
+      const hasInitializedValues = vnet || subnets;
 
-    const hasInitializedValues = vnet || subnets;
+      if (vnet && mode === 'custom') {
+        this.loadSubnets(this.authCreds()).catch((err) => {
+          get(this, 'errors').pushObject(err);
+        });
+        // We check for initialized values here because as part of
+        // the saving process this observer gets triggered with
+        // uninitialized values. This was causing a save to switch
+        // the step to step 3 rather than remaining on the last
+        // page until the saving was complete.
+      } else if (mode === 'default' && hasInitializedValues) {
+        setProperties(get(this, 'config'), {
+          virtualNetwork: null,
+          subnets:        [],
+        });
 
-    if (vnet && mode === 'custom') {
-      this.loadSubnets(this.authCreds()).catch((err) => {
-        get(this, 'errors').pushObject(err);
-      });
-    // We check for initialized values here because as part of
-    // the saving process this observer gets triggered with
-    // uninitialized values. This was causing a save to switch
-    // the step to step 3 rather than remaining on the last
-    // page until the saving was complete.
-    } else if (mode === 'default' && hasInitializedValues) {
-      setProperties(get(this, 'config'), {
-        virtualNetwork: null,
-        subnets:        [],
-      });
-
-      set(this, 'step', 3);
+        set(this, 'step', 3);
+      }
     }
   }),
 


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
After the Amazon cluster was saved but as we were transitioning away from the launch screen the vpcs observer fires because of a dependency change which would fire off the call to load the vpcs. This is not ideal because the cluster credentials have been cleared at this point and the call would fail causing an error message to show. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#26208
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
