### PR TITLE
Making the CIS scan enabled radio buttons function on edit

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -945,8 +945,10 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     const scanConfig = get(this, 'primaryResource.scheduledClusterScan.scanConfig') || this.cisHelpers.profileToClusterScanConfig(defaultProfileOption);
     const scheduleConfig = get(this, 'primaryResource.scheduledClusterScan.scheduleConfig') ||  get(this, 'scheduledClusterScan.scheduleConfig');
     const cisProfile =  this.cisHelpers.clusterScanConfigToProfile(scanConfig);
+    const enabled = get(this, 'primaryResource.scheduledClusterScan.enabled');
 
     set(this, 'scheduledClusterScan', scheduledClusterScan);
+    set(this, 'scheduledClusterScan.enabled', typeof enabled === 'string' ? enabled === 'true' : !!enabled);
     set(this, 'scheduledClusterScan.scanConfig', scanConfig);
     set(this, 'scheduledClusterScan.scheduleConfig', scheduleConfig);
     set(this, 'cisProfile', cisProfile);

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -952,7 +952,7 @@
                     <label class="text-muted">
                       {{radio-button
                         selection=scheduledClusterScan.enabled
-                        value="true"
+                        value=true
                         disabled=isScheduledClusterScanDisabled
                       }}
                       {{t "generic.yes"}}
@@ -960,7 +960,7 @@
                     <label class="text-muted">
                       {{radio-button
                         selection=scheduledClusterScan.enabled
-                        value="false"
+                        value=false
                         disabled=isScheduledClusterScanDisabled
                       }}
                       {{t "generic.no"}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3976,7 +3976,7 @@ clusterNew:
         view:
           count: "{value}"
           percentage: "{value}%"
-        label: Maxiumum Worker Nodes Unavailable
+        label: Maximum Worker Nodes Unavailable
         placeholder: e.g. 6
         mode:
           percentage: Percentage


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Making the CIS scan enabled radio buttons function on edit

When editing a cluster the value of scheduledClusterScan.enabled comes
back as a string rather than a boolean. I just ensure the value will be a
boolean to make sure the value is displayed on the radio buttons as
expected.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#26245
