### PR TITLE
Correcting disable field for scheduledClusterScan in RKE

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -999,7 +999,7 @@
                     classNames="form-control"
                     content=cisHelpers.cisScanProfileOptions
                     value=cisProfile
-                    disabled=(not (eq scheduledClusterScan.enabled "true"))
+                    disabled=(not scheduledClusterScan.enabled)
                   }}
                 {{/input-or-display}}
               </CheckOverrideAllowed>
@@ -1030,7 +1030,7 @@
                     value=scheduledClusterScan.scheduleConfig.cronSchedule
                     classNames="form-control"
                     placeholder=(t "clusterNew.rke.cisScan.scheduled.interval.placeholder")
-                    disabled=(not (eq scheduledClusterScan.enabled "true"))
+                    disabled=(not scheduledClusterScan.enabled)
                   }}
                 {{else}}
                   <div>{{scheduledClusterScan.scheduleConfig.cronSchedule}}</div>
@@ -1070,8 +1070,9 @@
                     value=scheduledClusterScan.scheduleConfig.retention
                     classNames="form-control"
                     placeholder=(t "clusterNew.rke.etcd.backupConfig.retention.placeholder")
-                    disabled=(not (eq scheduledClusterScan.enabled "true"))
+                    disabled=(not scheduledClusterScan.enabled)
                   }}
+                  {{log true scheduledClusterScan.enabled}}
                 {{/input-or-display}}
               </CheckOverrideAllowed>
             </div>


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Correcting disable field for scheduledClusterScan in RKE

I converted the enabled value back to a boolean instead of it being a string
but I forgot to switch the three disabled fields to expect a boolean.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#26245


