### PR TITLE
Remove min k8s version check for hosted cloud provider clusters

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
@@ -12,10 +12,12 @@ import $ from 'jquery';
 
 const REGIONS = ['us-east-2', 'us-east-1', 'us-west-2', 'ap-east-1', 'ap-south-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-southeast-1', 'ap-southeast-2', 'ca-central-1', 'eu-central-1', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'eu-north-1', 'me-south-1', 'sa-east-1'];
 const RANCHER_GROUP         = 'rancher-nodes';
+// from https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
 const VERSIONS = ['1.12', '1.13', '1.14', '1.15'];
 
 export default Component.extend(ClusterDriver, {
-  intl:                     service(),
+  intl:                 service(),
+  versionChoiceService: service('version-choices'),
   layout,
 
   configField:              'amazonElasticContainerServiceConfig',
@@ -277,6 +279,17 @@ export default Component.extend(ClusterDriver, {
       }
     }
   }),
+
+  versionChoices: computed('versions', function() {
+    const {
+      kubernetesVersionContent = [],
+      mode,
+      config : { kubernetesVersion: initialVersion }
+    } = this;
+
+    return this.versionChoiceService.parseCloudProviderVersionChoices(kubernetesVersionContent.reverse(), initialVersion, mode);
+  }),
+
 
   filteredKeyPairs: computed('allKeyPairs', function() {
     return get(this, 'allKeyPairs').sortBy('KeyName');

--- a/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
@@ -9,6 +9,7 @@ import { Promise, resolve } from 'rsvp';
 import { equal } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import $ from 'jquery';
+import { rcompare, coerce } from 'semver';
 
 const REGIONS = ['us-east-2', 'us-east-1', 'us-west-2', 'ap-east-1', 'ap-south-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-southeast-1', 'ap-southeast-2', 'ca-central-1', 'eu-central-1', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'eu-north-1', 'me-south-1', 'sa-east-1'];
 const RANCHER_GROUP         = 'rancher-nodes';
@@ -287,7 +288,7 @@ export default Component.extend(ClusterDriver, {
       config : { kubernetesVersion: initialVersion }
     } = this;
 
-    return this.versionChoiceService.parseCloudProviderVersionChoices(kubernetesVersionContent.reverse(), initialVersion, mode);
+    return this.versionChoiceService.parseCloudProviderVersionChoices(kubernetesVersionContent.sort((v1, v2) => rcompare(coerce(v1), coerce(v2))), initialVersion, mode);
   }),
 
 

--- a/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
@@ -73,9 +73,9 @@ export default Component.extend(ClusterDriver, {
           set(this, 'cluster.amazonElasticContainerServiceConfig.accessKey', null);
         }
       }
-
-      set(this, 'initialVersion', get(this, 'config.kubernetesVersion'));
     }
+
+    set(this, 'initialVersion', get(this, 'config.kubernetesVersion'));
   },
 
   willDestroyElement() {

--- a/lib/shared/addon/components/cluster-driver/driver-amazoneks/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-amazoneks/template.hbs
@@ -107,13 +107,10 @@
           <label class="acc-label">
             {{t "nodeDriver.amazoneks.kubernetesVersion.label"}}
           </label>
-          {{form-versions
-            cluster=cluster
-            editing=(eq mode "edit")
+          {{new-select
+            classNames="form-control"
+            content=versionChoices
             value=config.kubernetesVersion
-            versions=kubernetesVersionContent
-            initialVersion=initialVersion
-            showNotAllowed=false
           }}
         </div>
         <div class="col span-6">

--- a/lib/shared/addon/components/cluster-driver/driver-azureaks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-azureaks/component.js
@@ -33,10 +33,12 @@ const NETWORK_PLUGINS = [
 ];
 
 export default Component.extend(ClusterDriver, {
-  globalStore:  service(),
-  intl:         service(),
-  settings:     service(),
+  globalStore:          service(),
+  intl:                 service(),
+  settings:             service(),
+  versionChoiceService: service('version-choices'),
   layout,
+
   configField:  'azureKubernetesServiceConfig',
 
   zones:                  aksRegions,
@@ -119,11 +121,13 @@ export default Component.extend(ClusterDriver, {
       }
 
       return hash(aksRequest).then((resp) => {
+        const { mode }                      = this;
         const { versions, virtualNetworks } = resp;
+        const isEdit                        = mode === 'edit';
         const versionz                      = (get(versions, 'body') || []);
-        const initialVersion                = Semver.maxSatisfying(versionz, this.defaultK8sVersionRange);
+        const initialVersion                = isEdit ? this.config.kubernetesVersion : Semver.maxSatisfying(versionz, this.defaultK8sVersionRange);
 
-        if (initialVersion) {
+        if (!isEdit && initialVersion) {
           set(this, 'cluster.azureKubernetesServiceConfig.kubernetesVersion', initialVersion);
         }
 
@@ -175,6 +179,17 @@ export default Component.extend(ClusterDriver, {
       });
     }
   })),
+
+  versionChoices: computed('versions', function() {
+    const {
+      versions = [],
+      mode,
+      config : { kubernetesVersion: initialVersion }
+    } = this;
+
+    // azure versions come in oldest to newest
+    return this.versionChoiceService.parseCloudProviderVersionChoices(( versions || [] ).reverse(), initialVersion, mode);
+  }),
 
   networkChoice: computed({
     set( key, value = '' ) {

--- a/lib/shared/addon/components/cluster-driver/driver-azureaks/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-azureaks/template.hbs
@@ -135,13 +135,10 @@
             <label class="acc-label" for="azureaks-kube-version">
               {{t "clusterNew.azureaks.kubernetesVersion.label"}}
             </label>
-            {{form-versions
-              cluster=cluster
-              editing=(eq mode "edit")
-              initialVersion=config.kubernetesVersion
+            {{new-select
+              classNames="form-control"
+              content=versionChoices
               value=config.kubernetesVersion
-              versions=versions
-              showNotAllowed=false
             }}
           </div>
           <div class="col span-6">

--- a/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
@@ -180,7 +180,9 @@ const oauthScopesMapper = {
 };
 
 export default Component.extend(ClusterDriver, {
-  intl: service(),
+  intl:                 service(),
+  settings:             service(),
+  versionChoiceService: service('version-choices'),
 
   layout,
   configField:            'googleKubernetesEngineConfig',
@@ -436,10 +438,10 @@ export default Component.extend(ClusterDriver, {
     }
 
     const versions = get(this, 'versionChoices') || [];
-    const exists = versions[versions.indexOf(current)];
+    const exists = versions.findBy('value', current);
 
     if ( !exists ) {
-      set(this, 'config.masterVersion', versions[0]);
+      set(this, 'config.masterVersion', get(versions, 'firstObject.value'));
     }
   }),
 
@@ -557,7 +559,13 @@ export default Component.extend(ClusterDriver, {
   }),
 
   versionChoices: computed('versions.validMasterVersions.[]', 'config.masterVersion', function() {
-    return get(this, 'versions.validMasterVersions');
+    const {
+      versions: { validMasterVersions = [] },
+      config:   { masterVersion },
+      mode,
+    } = this;
+
+    return this.versionChoiceService.parseCloudProviderVersionChoices(validMasterVersions, masterVersion, mode);
   }),
 
   locationContent: computed('config.zone', function() {

--- a/lib/shared/addon/components/cluster-driver/driver-googlegke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-googlegke/template.hbs
@@ -136,15 +136,11 @@
           <label class="acc-label">
             {{t "clusterNew.googlegke.masterVersion.label"}}
           </label>
-          {{form-versions
-            cluster=cluster
-            editing=editing
-            initialVersion=config.masterVersion
+          {{new-select
+            classNames="form-control"
+            content=versionChoices
             value=config.masterVersion
-            versions=versionChoices
-            showNotAllowed=false
           }}
-
           {{#if (and editing (not-eq initialMasterVersion config.masterVersion))}}
             {{banner-message
               icon="icon-alert"

--- a/lib/shared/addon/version-choices/service.js
+++ b/lib/shared/addon/version-choices/service.js
@@ -1,0 +1,42 @@
+import Service from '@ember/service';
+import Semver from 'semver';
+import { setProperties } from '@ember/object';
+import { satisfies, coerceVersion } from 'shared/utils/parse-version';
+import C from 'shared/utils/constants';
+import { alias } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+
+export default Service.extend({
+  intl:     service(),
+  settings: service(),
+
+  defaultK8sVersionRange: alias(`settings.${ C.SETTING.VERSION_SYSTEM_K8S_DEFAULT_RANGE }`),
+
+  parseCloudProviderVersionChoices(versions, providerVersion, mode) {
+    let {
+      intl,
+      defaultK8sVersionRange
+    } = this;
+    const maxVersionRange = defaultK8sVersionRange.split(' ').pop();
+
+    return versions.map((version) => {
+      if (satisfies(coerceVersion(version), maxVersionRange)) {
+        const out = {
+          label: version,
+          value: version,
+        };
+
+        if (mode === 'edit') {
+          if (Semver.lt(version, providerVersion)) {
+            setProperties(out, {
+              disabled: true,
+              label:    `${ out.label } ${ intl.t('formVersions.downgrade') }`
+            });
+          }
+        }
+
+        return out;
+      }
+    });
+  }
+});

--- a/lib/shared/addon/version-choices/service.js
+++ b/lib/shared/addon/version-choices/service.js
@@ -27,7 +27,7 @@ export default Service.extend({
         };
 
         if (mode === 'edit') {
-          if (Semver.lt(version, providerVersion)) {
+          if (Semver.lt(coerceVersion(version), coerceVersion(providerVersion))) {
             setProperties(out, {
               disabled: true,
               label:    `${ out.label } ${ intl.t('formVersions.downgrade') }`

--- a/lib/shared/app/version-choices/service.js
+++ b/lib/shared/app/version-choices/service.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/version-choices/service';


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Adds a new service which parses version from the various cloud provider version
list. I moved this to a new service rather than use form-versions because
form-versions is already fairly complicated with how it has to deal with RKE
Templates and unknown patch versions. It was simpler, cleaner, and faster to
move the CP cluster version parsing to a service and use new select because the
versions coming down do not include unknown patch versions. Addtionally going
this route allows us to not have to test all clusters for regressions, only CP ones.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
New Feature
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#26255
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
