### PR TITLE
EKS Empty Subnets

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
@@ -10,6 +10,7 @@ import { equal } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import $ from 'jquery';
 import { rcompare, coerce } from 'semver';
+import { isEmpty } from '@ember/utils';
 
 const REGIONS = ['us-east-2', 'us-east-1', 'us-west-2', 'ap-east-1', 'ap-south-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-southeast-1', 'ap-southeast-2', 'ca-central-1', 'eu-central-1', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'eu-north-1', 'me-south-1', 'sa-east-1'];
 const RANCHER_GROUP         = 'rancher-nodes';
@@ -504,4 +505,16 @@ export default Component.extend(ClusterDriver, {
       });
     });
   },
+
+  willSave() {
+    // temporary measure put in place for rancher/rancher#24652
+    const { config: { subnets } } = this;
+
+    if (isEmpty(subnets)) {
+      set(this, 'config.subnets', []);
+    }
+
+    return this._super(...arguments);
+  },
+
 });


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When we changed the EKS fields to no edit this exposed an issue where sending a null subnet param caused a non-nullable api error on edit because when an input was present we'd always set the subnets to an empty array. This fix ensures that if the subnets are empty we send an empty array until the backend is fixed post 2.4 release.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#26231
rancher/rancher#24652
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
