### PR TITLE
Remove unnesscary permission request for g suite

### DIFF
--- a/lib/shared/addon/oauth/service.js
+++ b/lib/shared/addon/oauth/service.js
@@ -3,7 +3,7 @@ import { addQueryParam, addQueryParams, popupWindowOptions } from 'shared/utils/
 import { get, set } from '@ember/object';
 import C from 'shared/utils/constants';
 
-const googleOauthScope = 'openid profile email https://www.googleapis.com/auth/admin.directory.user.readonly https://www.googleapis.com/auth/admin.directory.group.readonly';
+const googleOauthScope = 'openid profile email';
 const githubOauthScope = 'read:org';
 
 export default Service.extend({


### PR DESCRIPTION
Proposed changes
======
As discussed in [here](https://github.com/rancher/rancher/issues/23633#issuecomment-590861242), currently the web ui is asking for unnecessary permissions (admin.directory.user.readonly & admin.directory.group.readonly) when redirecting to google page. This causes the consent screen to show "unverified app" and there is a cap on how many users (100)) can be authenticated.
Removing these permissions here should be fine since the rancher server already uses a Service Account with those permissions to get info about user groups.
I've tested it in my organization and the oauth & permissions still works despite having those permissions removed in ui side.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
https://github.com/rancher/rancher/issues/23633