### PR TITLE
[2.4.x] Fix log volume format button issue

### DIFF
--- a/app/components/volume-source/source-custom-log-path/template.hbs
+++ b/app/components/volume-source/source-custom-log-path/template.hbs
@@ -14,14 +14,16 @@
   </div>
   <div class="col span-6">
     {{#if editing}}
-      <label class="acc-label pull-left">{{t 'volumeSource.customLogPath.logFormat.label'}}</label>
-      <a role="button" class="btn bg-transparent p-0 text-small pull-right" {{action "useCustomRegex"}}>
-        {{#if useCustomRegex}}
-          {{t 'volumeSource.customLogPath.logFormat.useExistingLogFormat'}}
-        {{else}}
-          {{t 'volumeSource.customLogPath.logFormat.useCustomRegex'}}
-        {{/if}}
-      </a>
+      <div class="clearfix">
+        <label class="acc-label pull-left">{{t 'volumeSource.customLogPath.logFormat.label'}}</label>
+        <a role="button" class="btn bg-transparent p-0 text-small pull-right" {{action "useCustomRegex"}}>
+          {{#if useCustomRegex}}
+            {{t 'volumeSource.customLogPath.logFormat.useExistingLogFormat'}}
+          {{else}}
+            {{t 'volumeSource.customLogPath.logFormat.useCustomRegex'}}
+          {{/if}}
+        </a>
+      </div>
     {{/if}}
     {{#if useCustomRegex}}
       {{#if editing}}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Users cannot click the button for using custom logging format when use log volume
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/26731
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
