### PR TITLE
[2.3.7] remove ebs encryption that didn't need to be backported

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-amazoneks/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-amazoneks/template.hbs
@@ -479,28 +479,6 @@
               {{/input-or-display}}
             </div>
           </div>
-          <div class="col span-6 col span-height col full-height col-top mb-20">
-            <div class="no-padding-margin full-height">
-              <label class="acc-label" for="ebs-encryption">
-                {{t "nodeDriver.amazoneks.encryptEbs.label"}}
-              </label>
-              <div>
-                {{#input-or-display
-                   editable=(eq mode "new")
-                   value=config.ebsEncryption
-                }}
-                  {{input
-                    id="ebs-encryption"
-                    type="checkbox"
-                    checked=config.ebsEncryption
-                  }}
-                {{/input-or-display}}
-              </div>
-              <p class="help-block">
-                {{t "nodeDriver.amazoneks.encryptEbs.detail"}}
-              </p>
-            </div>
-          </div>
         </div>
       </div>
       <div class="row">


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
I mistakenly backported the encrypt ebs input when backporting another fix. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#26518
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
