### PR TITLE
Fixing a jquery usage error

### DIFF
--- a/lib/alert/addon/components/alert-select/component.js
+++ b/lib/alert/addon/components/alert-select/component.js
@@ -20,7 +20,7 @@ export default Select.extend({
         return;
       }
 
-      const toBottom = $('body').height() - $($()[0]).offset().top - 60; // eslint-disable-line
+      const toBottom = $('body').height() - $(this.element).offset().top - 60; // eslint-disable-line
 
       set(this, 'maxHeight', toBottom < MAX_HEIGHT ? toBottom : MAX_HEIGHT)
 


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When deprecating the old usage of jquery I erroneously
converted this section. The element wasn't being referenced
properly anymore. This fixes an exception which was preventing
the page from rendering monitoring metric options.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#26829
