### PR TITLE
Add support to configure GKE Network Policies

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-googlegke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-googlegke/template.hbs
@@ -326,6 +326,29 @@
           </div>
           <div class="col span-6">
             <label class="acc-label">
+              {{t "clusterNew.googlegke.enableNetworkPolicyConfig.label"}}
+            </label>
+            <div class="form-control-static">
+              <label class={{concat (if editing "text-muted") " mr-20 hand"}}>
+                {{radio-button
+                        selection=config.enableNetworkPolicyConfig
+                        value=true
+                        disabled=editing
+                }} {{t "generic.enabled"}}
+              </label>
+              <label class={{concat (if editing "text-muted") " hand"}}>
+                {{radio-button
+                        selection=config.enableNetworkPolicyConfig
+                        value=false
+                        disabled=editing
+                }} {{t "generic.disabled"}}
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col span-6">
+            <label class="acc-label">
               {{t "clusterNew.googlegke.maintenanceWindow.label"}}
             </label>
             <div class="form-control-static">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3689,6 +3689,8 @@ clusterNew:
       label: Horizontal Pod Autoscaling
     enableNodepoolAutoscaling:
       label: Node Pool Autoscaling
+    enableNetworkPolicyConfig:
+      label: Network Policies
     minNodeCount:
       label: Minimum Node Count
       required: '"Minimum Node Count" is required'


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This adds an additional flag when creating GKE clusters to enable/disable NetworkPolicy support in GKE. This is already possible with the API, but not exposed in the UI.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)
Since it is present in the API, I'd consider this a bugfix.

Linked Issues
======
https://github.com/rancher/rancher/issues/26918

Further comments
======
There is currently an issue in the kontainer-engine. Even though the flag is set in the API, it is not configured correctly on the GKE side: https://github.com/rancher/rancher/issues/26917. Addressed in https://github.com/rancher/kontainer-engine/pull/225.

I'm not quite sure, if I also have to add non-english translations, or what the process is here.