### PR TITLE
Populate OKE cluster creation values dynamically

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
@@ -2,36 +2,10 @@ import Component from '@ember/component'
 import ClusterDriver from 'shared/mixins/cluster-driver';
 import layout from './template';
 import { equal } from '@ember/object/computed'
-import { compare } from 'shared/utils/parse-version';
 import { get, set, computed, setProperties } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { hash } from 'rsvp';
 
-const regionMap = {
-  'Mumbai':    'ap-mumbai-1',
-  'Seoul':     'ap-seoul-1',
-  'Tokyo':     'ap-tokyo-1',
-  'Toronto':   'ca-toronto-1',
-  'Frankfurt': 'eu-frankfurt-1',
-  'Zurich':    'eu-zurich-1',
-  'Sao Paolo': 'sa-saopaulo-1',
-  'London':    'uk-london-1',
-  'Ashburn':   'us-ashburn-1',
-  'Phoenix':   'us-phoenix-1',
-  'Amsterdam': 'eu-amsterdam-1',
-  'Hyderabad': 'ap-hyderabad-1',
-  'Jeddah':    'me-jeddah-1',
-  'Osaka':     'ap-osaka-1',
-  'Melbourne': 'ap-melbourne-1',
-  'Sydney':    'ap-sydney-1',
-  'Chuncheon': 'ap-chuncheon-1',
-  'Montreal':  'ca-montreal-1',
-}
-
-const k8sVersionMap = {
-  'v1.16.8': 'v1.16.8', // default
-  'v1.15.7': 'v1.15.7',
-  'v1.14.8': 'v1.14.8',
-}
 
 const vcnIdMap = { quick: 'Quick Create', }
 
@@ -40,49 +14,15 @@ const subnetAccessMap = {
   private: 'Private',
 }
 
-const nodeShapeMap = {
-  'VM.Standard1.1':          'VM.Standard1.1',
-  'VM.Standard1.2':          'VM.Standard1.2',
-  'VM.Standard1.4':          'VM.Standard1.4',
-  'VM.Standard1.8':          'VM.Standard1.8',
-  'VM.Standard1.16':         'VM.Standard1.16',
-  'VM.Standard2.1':          'VM.Standard2.1',
-  'VM.Standard2.2':          'VM.Standard2.2',
-  'VM.Standard2.4':          'VM.Standard2.4',
-  'VM.Standard2.8':          'VM.Standard2.8',
-  'VM.Standard2.16':         'VM.Standard2.16',
-  'VM.Standard2.24':         'VM.Standard2.24',
-  'BM.Standard.E2.64':       'BM.Standard.E2.64',
-  'BM.Standard2.52':         'BM.Standard2.52',
-  'BM.Standard.B1.44':       'BM.Standard.B1.44',
-  'BM.DenseIO2.52':          'BM.DenseIO2.52',
-  'BM.HPC2.36':              'BM.HPC2.36',
-  'VM.Standard.E2.1.Micro':  'VM.Standard.E2.1.Micro',
-  'VM.Standard.E2.2':        'VM.Standard.E2.2',
-  'VM.GPU2.1':               'VM.GPU2.1',
-  'VM.GPU2.2':               'VM.GPU2.2',
-  'VM.GPU3.1':               'VM.GPU3.1',
-  'VM.GPU3.2':               'VM.GPU3.2',
-  'VM.GPU3.4':               'VM.GPU3.4',
-  'VM.GPU3.8':               'VM.GPU3.8',
-}
-
-const imageMap = {
-  'Oracle-Linux-7.6': 'Oracle-Linux-7.6',
-  'Oracle-Linux-7.5': 'Oracle-Linux-7.5',
-  'Oracle-Linux-7.4': 'Oracle-Linux-7.4',
-}
-
 export default Component.extend(ClusterDriver, {
   intl:            service(),
   layout,
   configField:     'okeEngineConfig',
-
   instanceConfig:  '',
   step:            1,
   lanChanged:      null,
   refresh:         false,
-  vcnCreationMode: '',
+  vcnCreationMode: 'none',
   vpcs:                    null,
   subnets:                 null,
   eipIds:                  null,
@@ -104,8 +44,10 @@ export default Component.extend(ClusterDriver, {
         secretKey:             '',
         clusterName:           '',
         vcnCidr:               '10.0.0.0/16',
-        kubernetesVersion:     'v1.16.8',
+        kubernetesVersion:     '',
         region:                'us-phoenix-1',
+        nodeShape:             'VM.Standard2.1',
+        nodeImage:             '',
         vcn:                   '',
         securityListId:        '',
         subnetAccess:          'public',
@@ -130,27 +72,104 @@ export default Component.extend(ClusterDriver, {
   },
 
   actions: {
-    // TODO implement authenticateOCI
 
     authenticateOCI(cb) {
-      setProperties(this, {
+      const store = get(this, 'globalStore')
+      const data = {
+        tenancyOCID:          get(this, 'cluster.okeEngineConfig.tenancyId'),
+        userOCID:             get(this, 'cluster.okeEngineConfig.userOcid'),
+        region:               get(this, 'cluster.okeEngineConfig.region'),
+        fingerprint:          get(this, 'cluster.okeEngineConfig.fingerprint'),
+        privateKey:           get(this, 'cluster.okeEngineConfig.privateKeyContents'),
+        privateKeyPassphrase: get(this, 'cluster.okeEngineConfig.privateKeyPassphrase'),
+        compartmentOCID:      get(this, 'cluster.okeEngineConfig.compartmentId')
+      };
 
-        'errors':                                       null,
-        'config.userOcid':             (get(this, 'config.userOcid') || '').trim(),
-        'config.secretKey':            (get(this, 'config.secretKey') || '').trim(),
-        'config.privateKeyPassphrase': (get(this, 'config.privateKeyPassphrase') || '').trim(),
-        'config.region':               (get(this, 'config.region')),
 
+      const ociRequest = {
+        okeVersions: store.rawRequest({
+          url:    '/meta/oci/okeVersions',
+          method: 'POST',
+          data
+        }),
+        regions: store.rawRequest({
+          url:    '/meta/oci/regions',
+          method: 'POST',
+          data
+        })
+      }
+
+      return hash(ociRequest).then((resp) => {
+        const { okeVersions, regions } = resp;
+
+        setProperties(this, {
+          okeVersions:  (get( okeVersions, 'body') || []),
+          regions:      (get( regions, 'body') || []),
+          errors:       [],
+        });
+
+        set(this, 'step', 2);
+        cb(true);
+      }).catch((xhr) => {
+        const err = xhr.body.message || xhr.body.code || xhr.body.error;
+
+        setProperties(this, { errors: [err], });
+
+        cb(false, [err]);
       });
-
-      set(this, 'step', 2);
-      cb(true);
     },
-
-    // TODO re-implement loadNodeConfig
     loadNodeConfig(cb) {
-      set(this, 'step', 3);
-      cb(true);
+      const store = get(this, 'globalStore')
+      const data = {
+        tenancyOCID:          get(this, 'cluster.okeEngineConfig.tenancyId'),
+        userOCID:             get(this, 'cluster.okeEngineConfig.userOcid'),
+        region:               get(this, 'cluster.okeEngineConfig.region'),
+        fingerprint:          get(this, 'cluster.okeEngineConfig.fingerprint'),
+        privateKey:           get(this, 'cluster.okeEngineConfig.privateKeyContents'),
+        privateKeyPassphrase: get(this, 'cluster.okeEngineConfig.privateKeyPassphrase'),
+        compartmentOCID:      get(this, 'cluster.okeEngineConfig.compartmentId')
+      };
+
+
+      const ociRequest = {
+        availabilityDomains: store.rawRequest({
+          url:    '/meta/oci/availabilityDomains',
+          method: 'POST',
+          data
+        }),
+        nodeShapes: store.rawRequest({
+          url:    '/meta/oci/nodeShapes',
+          method: 'POST',
+          data
+        }),
+        nodeImages: store.rawRequest({
+          url:    '/meta/oci/nodeOkeImages',
+          method: 'POST',
+          data
+        })
+      }
+
+      return hash(ociRequest).then((resp) => {
+        const {
+          availabilityDomains, nodeShapes, nodeImages,
+        } = resp;
+
+        setProperties(this, {
+          availabilityDomais:   (get(availabilityDomains, 'body') || []),
+          nodeShapes:           (get( nodeShapes, 'body') || [] ).reverse(),
+          nodeImages:           (get( nodeImages, 'body') || [] ),
+          errors:                [],
+        });
+
+        set(this, 'step', 3);
+        cb(true);
+      }).catch((xhr) => {
+        const err = xhr.body.message || xhr.body.code || xhr.body.error;
+
+        setProperties(this, { errors: [err] });
+
+        cb(false, [err]);
+      });
     },
 
     // TODO implement loadInstanceConfig
@@ -210,9 +229,6 @@ export default Component.extend(ClusterDriver, {
 
         return;
       }
-      if (get(this, 'config.nodeImage') === '') {
-        set(this, 'config.nodeImage', imageMap['Oracle-Linux-7.6']);
-      }
       if (get(this, 'config.vcnCompartmentId') === '') {
         set(this, 'config.vcnCompartmentId', get(this, 'config.compartmentId'));
       }
@@ -235,18 +251,8 @@ export default Component.extend(ClusterDriver, {
       });
     }
   },
-
   maxNodeCount: computed('clusterQuota.slave', () => {
     return 256;
-  }),
-  regionChoices: Object.entries(regionMap).map((e) => ({
-    label: e[0],
-    value: e[1]
-  })),
-  selectedRegion: computed('config.region', function() {
-    const region = get(this, 'config.region');
-
-    return region;
   }),
   vcnChoices: Object.entries(vcnIdMap).map((e) => ({
     label: e[1],
@@ -266,48 +272,11 @@ export default Component.extend(ClusterDriver, {
 
     return subnetAccess && subnetAccessMap[subnetAccess];
   }),
-  nodeShapeChoices: Object.entries(nodeShapeMap).map((e) => ({
-    label: e[1],
-    value: e[0]
-  })),
-  selectednodeShape: computed('config.nodeShape', function() {
-    const nodeShape = get(this, 'config.nodeShape');
-
-    return nodeShape && nodeShapeMap[nodeShape];
-  }),
-  imageChoices: Object.entries(imageMap).map((e) => ({
-    label: e[1],
-    value: e[0]
-  })),
-  selectedImage: computed('config.nodeImage', function() {
-    const nodeImage = get(this, 'config.nodeImage');
-
-    return nodeImage && imageMap[nodeImage];
-  }),
-  k8sVersionChoices: Object.entries(k8sVersionMap).map((e) => ({
-    label: e[1],
-    value: e[0]
-  })),
-  k8sUpgradeVersionChoices: computed('config.kubernetesVersion', function() {
-    let supportedVersions = Object.assign({}, k8sVersionMap);
-    var currentVersion = get(this, 'config.kubernetesVersion');
-
-    Object.keys(supportedVersions)
-      .filter((key) => (compare(key, currentVersion) < 0))
-      .forEach((key) => delete supportedVersions[key]);
-
-    return Object.entries(supportedVersions).map((e) => ({
-      label: e[1],
-      value: e[0]
-    }));
-  }),
-  selectedk8sVersion: computed('config.kubernetesVersion', function() {
-    const k8sVersion = get(this, 'config.kubernetesVersion');
-
-    return k8sVersion && k8sVersionMap[k8sVersion];
-  }),
   canAuthenticate: computed('config.tenancyId', 'config.compartmentId', 'config.userOcid', 'config.fingerprint', 'config.privateKeyContents', function() {
     return get(this, 'config.tenancyId') && get(this, 'config.compartmentId') && get(this, 'config.userOcid') && get(this, 'config.fingerprint') && get(this, 'config.privateKeyContents') ? false : true;
+  }),
+  canAddK8sVersion: computed('config.region', 'config.kubernetesVersion', function() {
+    return !(get(this, 'config.region') && get(this, 'config.kubernetesVersion'));
   }),
 
   canSaveVCN: computed('vcnCreationMode', 'config.vcnName', 'config.loadBalancerSubnetName1', 'config.loadBalancerSubnetName2', 'config.subnetAccess', 'config.vcnCidr', function() {
@@ -324,8 +293,8 @@ export default Component.extend(ClusterDriver, {
 
     return true;
   }),
-  canCreateCluster: computed('config.nodeShape', function() {
-    return get(this, 'config.nodeShape') ? false : true;
+  canCreateCluster: computed('config.nodeShape', 'config.nodeImage', function() {
+    return !(get(this, 'config.nodeShape') && get(this, 'config.nodeImage'));
   }),
 
   // Add custom validation beyond what can be done from the config API schema
@@ -346,7 +315,7 @@ export default Component.extend(ClusterDriver, {
 
     const compartmentId = get(this, 'config.compartmentId');
 
-    if (!compartmentId.startsWith('ocid1.compartment') && !compartmentId.startsWith('ocid1.tenancy')) {
+    if (!compartmentId.startsWith('ocid1.compartment')) {
       errors.push('A valid compartment OCID is required');
     }
 
@@ -372,14 +341,9 @@ export default Component.extend(ClusterDriver, {
   },
   willSave() {
     if (get(this, 'mode') === 'new') {
-      if (get(this, 'config.nodeImage') === '') {
-        set(this, 'config.nodeImage', imageMap['Oracle-Linux-7.6']);
-      }
       if (get(this, 'config.vcnCompartmentId') === '') {
         set(this, 'config.vcnCompartmentId', get(this, 'config.compartmentId'));
       }
-
-
       if (get(this, 'config.subnetAccess') === 'public') {
         set(this, 'config.enablePrivateNodes', false);
       } else {

--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/template.hbs
@@ -1,7 +1,7 @@
 {{#accordion-list showExpandAll=false as |al expandFn|}}
 
 
-  {{!-- Only allow edits to tenancy, compartment, and region configuration for new cluster --}}
+{{!-- Only allow edits to tenancy, compartment, and region configuration for new cluster --}}
   {{#accordion-list-item title=(t "clusterNew.oracleoke.access.title")
                          detail=(t "clusterNew.oracleoke.access.detail")
                          expandAll=expandAll
@@ -10,28 +10,22 @@
   }}
 
     <div class="row">
-      <div class="col span-6 mb-0">
-        <label class="acc-label">{{t 'clusterNew.oracleoke.tenancyOCID.label'}}{{field-required}}</label>
+      <div class="col span-6">
+        <label class="acc-label">
+          {{t 'clusterNew.oracleoke.tenancyOCID.label'}}{{field-required}}
+        </label>
         {{#input-or-display editable=isNew value=config.tenancyId}}
           {{input type="text" name="tenancy" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.tenancyOCID.placeholder') value=config.tenancyId}}
         {{/input-or-display}}
       </div>
 
 
-      <div class="col span-6 mb-0">
-        <label class="acc-label">{{t 'clusterNew.oracleoke.compartmentOCID.label'}}{{field-required}}</label>
+      <div class="col span-6">
+        <label class="acc-label">
+          {{t 'clusterNew.oracleoke.compartmentOCID.label'}}{{field-required}}
+        </label>
         {{#input-or-display editable=isNew value=config.compartmentId}}
           {{input type="text" name="compartment" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.compartmentOCID.placeholder') value=config.compartmentId}}
-        {{/input-or-display}}
-      </div>
-
-      <div class="col span-6">
-        <label class="acc-label">{{t 'clusterNew.oracleoke.region.label'}}{{field-required}}</label>
-        {{#input-or-display editable=isNew value=selectedRegion}}
-          {{searchable-select class="form-control"
-                              content=regionChoices
-                              value=config.region
-          }}
         {{/input-or-display}}
       </div>
 
@@ -41,21 +35,27 @@
     <div class="row">
 
       <div class="col span-6">
-        <label class="acc-label">{{t 'clusterNew.oracleoke.userOcid.label'}}{{field-required}}</label>
+        <label class="acc-label">
+          {{t 'clusterNew.oracleoke.userOcid.label'}}{{field-required}}
+        </label>
         {{#input-or-display editable=(or isNew editing) value=config.userOcid}}
           {{input type="text" name="username" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.userOcid.placeholder') value=config.userOcid}}
         {{/input-or-display}}
       </div>
 
       <div class="col span-6">
-        <label class="acc-label">{{t 'clusterNew.oracleoke.userFingerprint.label'}}{{field-required}}</label>
+        <label class="acc-label">
+          {{t 'clusterNew.oracleoke.userFingerprint.label'}}{{field-required}}
+        </label>
         {{#input-or-display editable=(or isNew editing) value=config.fingerprint}}
           {{input type="text" name="fingerprint" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.userFingerprint.placeholder') value=config.fingerprint}}
         {{/input-or-display}}
       </div>
 
       <div class="col span-6">
-        <label class="acc-label">{{t 'clusterNew.oracleoke.secretKeyPassphrase.label'}}</label>
+        <label class="acc-label">
+          {{t 'clusterNew.oracleoke.secretKeyPassphrase.label'}}
+        </label>
         {{#input-or-display editable=(or isNew editing) value=config.privateKeyPassphrase}}
           {{input type="password" name="password" classNames="form-control" concealValue=true placeholder=(t 'clusterNew.oracleoke.secretKeyPassphrase.placeholder') value=config.privateKeyPassphrase}}
         {{/input-or-display}}
@@ -94,7 +94,7 @@
   {{/if}}
 
   {{#if (and (gte step 2) editing)}}
-    {{!-- edit cluster --}}
+  {{!-- edit cluster --}}
     {{#accordion-list-item title=(t "clusterNew.oracleoke.cluster.title")
                            detail=(t "clusterNew.oracleoke.cluster.detail")
                            showExpand=false
@@ -103,20 +103,42 @@
                            expand=(action expandFn)
     }}
       <div class="row">
+        <div class="col span-6">
+          <label class="acc-label">
+            {{t 'clusterNew.oracleoke.region.label'}}{{field-required}}
+          </label>
+          {{#if (eq step 2)}}
+            {{#input-or-display editable=isNew value=config.region}}
+              {{input type="text" name="region" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.region.placeholder') value=config.region}}
+            {{/input-or-display}}
+          {{/if}}
+        </div>
+      </div>
+      <div class="row">
 
         <div class="col span-4">
-          <label class="acc-label">{{t 'clusterNew.oracleoke.version.label'}}</label>
-          {{#input-or-display editable=(or (eq mode "new") eq mode "editing") value=selectedk8sVersion}}
-            {{new-select class="form-control"
-                         content=k8sUpgradeVersionChoices
-                         value=config.kubernetesVersion
-            }}
-          {{/input-or-display}}
+          <label class="acc-label">
+            {{t 'clusterNew.oracleoke.version.label'}}
+          </label>
+          {{#if (eq step 2)}}
+            <select class="form-control" onchange={{action (mut config.kubernetesVersion) value="target.value"}}>
+              <option>  </option>
+              {{#each okeVersions as |choice|}}
+                {{#if (lte config.kubernetesVersion choice)}}
+                  <option value={{choice}} selected={{eq config.kubernetesVersion choice}}>{{choice}}</option>
+                {{/if}}
+              {{/each}}
+            </select>
+          {{else}}
+            <div>{{config.kubernetesVersion}}</div>
+          {{/if}}
         </div>
 
 
         <div class="col span-4">
-          <label class="acc-label">{{t 'clusterNew.oracleoke.quantityPerSubnet.label'}}</label>
+          <label class="acc-label">
+            {{t 'clusterNew.oracleoke.quantityPerSubnet.label'}}
+          </label>
           {{#input-or-display editable=(or (eq mode "new") eq mode "editing") value=config.quantityPerSubnet}}
             {{input-integer min=1 max=maxNodeCount value=config.quantityPerSubnet classNames="form-control" placeholder=(t 'clusterNew.oracleoke.quantityPerSubnet.placeholder')}}
             <p class="help-block">
@@ -139,7 +161,7 @@
     {{/if}}
 
   {{else}}
-    {{!-- new cluster --}}
+  {{!-- new cluster --}}
     {{#if (gte step 2)}}
       {{#accordion-list-item title=(t "clusterNew.oracleoke.cluster.title")
                              detail=(t "clusterNew.oracleoke.cluster.detail")
@@ -148,20 +170,41 @@
                              expandAll=al.expandAll
                              expand=(action expandFn)
       }}
-
         <div class="row">
-          <div class="col span-6 mb-0">
-            <label class="acc-label">{{t 'clusterNew.oracleoke.version.label'}}</label>
-            {{#input-or-display editable=(and (eq step 2) isNew) value=selectedk8sVersion}}
-              {{new-select class="form-control"
-                           content=k8sVersionChoices
-                           value=config.kubernetesVersion
-              }}
-            {{/input-or-display}}
+          <div class="col span-4 mb-0">
+            <label class="acc-label">
+              {{t 'clusterNew.oracleoke.region.label'}}
+            </label>
+            {{#if (eq step 2)}}
+              <select class="form-control" onchange={{action (mut config.region) value="target.value"}}>
+                {{#each regions as |choice|}}
+                  <option value={{choice}} selected={{eq config.region choice}}>{{choice}}</option>
+                {{/each}}
+              </select>
+            {{else}}
+              <div>{{config.region}}</div>
+            {{/if}}
+          </div>
+          <div class="col span-4 mb-0">
+            <label class="acc-label">
+              {{t 'clusterNew.oracleoke.version.label'}}
+            </label>
+            {{#if (eq step 2)}}
+              <select class="form-control" onchange={{action (mut config.kubernetesVersion) value="target.value"}}>
+                <option>  </option>
+                {{#each okeVersions as |choice|}}
+                  <option value={{choice}} selected={{eq config.kubernetesVersion choice}}>{{choice}}</option>
+                {{/each}}
+              </select>
+            {{else}}
+              <div>{{config.kubernetesVersion}}</div>
+            {{/if}}
           </div>
 
-          <div class="col span-6 mb-0">
-            <label class="acc-label">{{t 'clusterNew.oracleoke.quantityPerSubnet.label'}}</label>
+          <div class="col span-4 mb-0">
+            <label class="acc-label">
+              {{t 'clusterNew.oracleoke.quantityPerSubnet.label'}}
+            </label>
             {{#input-or-display editable=(and (eq step 2) isNew) value=config.quantityPerSubnet}}
               {{input-integer min=1 max=maxNodeCount value=config.quantityPerSubnet classNames="form-control" placeholder=(t 'clusterNew.oracleoke.quantityPerSubnet.placeholder')}}
               <p class="help-block">
@@ -175,6 +218,7 @@
       {{#if (eq step 2)}}
         {{save-cancel editing=(eq mode 'edit')
                       save="loadNodeConfig"
+                      saveDisabled=canAddK8sVersion
                       cancel=close
                       createLabel="clusterNew.oracleoke.cluster.next"
                       savingLabel="clusterNew.oracleoke.cluster.loading"
@@ -310,26 +354,37 @@
       }}
         <div class="row">
 
-
           <div class="row">
+
             <div class="col span-6">
-              <label class="acc-label">{{t 'clusterNew.oracleoke.nodeShape.label'}}{{field-required}}</label>
-              {{#input-or-display editable=(and (eq step 4) isNew) value=selectednodeShape}}
-                {{searchable-select class="form-control"
-                                    content=nodeShapeChoices
-                                    value=config.nodeShape
-                }}
-              {{/input-or-display}}
+              <label class="acc-label">
+                {{t 'clusterNew.oracleoke.nodeShape.label'}}{{field-required}}
+              </label>
+              {{#if (eq step 4)}}
+                <select class="form-control" onchange={{action (mut config.nodeShape) value="target.value"}}>
+                  {{#each nodeShapes as |choice|}}
+                    <option value={{choice}} selected={{eq config.nodeShape choice}}>{{choice}}</option>
+                  {{/each}}
+                </select>
+              {{else}}
+                <div>{{config.nodeShape}}</div>
+              {{/if}}
             </div>
 
             <div class="col span-6">
-              <label class="acc-label">{{t 'clusterNew.oracleoke.os.label'}}</label>
-              {{#input-or-display editable=isNew value=selectedImage}}
-                {{searchable-select class="form-control"
-                                    content=imageChoices
-                                    value=config.nodeImage
-                }}
-              {{/input-or-display}}
+              <label class="acc-label">
+                {{t 'clusterNew.oracleoke.os.label'}}
+              </label>
+              {{#if (eq step 4)}}
+                <select class="form-control" onchange={{action (mut config.nodeImage) value="target.value"}}>
+                  <option>  </option>
+                  {{#each nodeImages as |choice|}}
+                    <option value={{choice}} selected={{eq config.nodeImage choice}}>{{choice}}</option>
+                  {{/each}}
+                </select>
+              {{else}}
+                <div>{{ config.nodeImage}}</div>
+              {{/if}}
             </div>
 
           </div>
@@ -337,7 +392,9 @@
           <div class="row">
 
             <div class="col span-4">
-              <label class="acc-label pt-5">{{t "clusterNew.oracleoke.nodeSSHKey.label"}}</label>
+              <label class="acc-label pt-5">
+                {{t "clusterNew.oracleoke.nodeSSHKey.label"}}
+              </label>
             </div>
             {{input-text-file
               classNames="box"
@@ -352,8 +409,6 @@
             }}
 
           </div>
-
-
 
         </div>
 
@@ -375,4 +430,3 @@
 
 
 {{/accordion-list}}
-


### PR DESCRIPTION
Proposed changes
======

This PR adds support for retrieving OKE cluster creation form values dynamically via the OKE [cluster driver](https://github.com/rancher-plugins/kontainer-engine-driver-oke).

<img width="1299" alt="Screen Shot 2020-05-07 at 1 01 27 PM" src="https://user-images.githubusercontent.com/30269407/81339459-1794a100-9063-11ea-920b-a8289d91a1a1.png">


Types of changes
======

Improves the usability of OKE cluster creation form values in a backwards compatible manner.

Linked Issues
======

Depends on [rancher/rancher#26963](https://github.com/rancher/rancher/pull/26963)


Further comments
======

Fetching values from the OCI API is a followup from this[ review/PR.](https://github.com/rancher/ui/pull/3931)

