### PR TITLE
[2.4.4] fix(MTU form): can not set to 0 after blur

### DIFF
--- a/lib/shared/addon/components/form-network-config/template.hbs
+++ b/lib/shared/addon/components/form-network-config/template.hbs
@@ -197,7 +197,7 @@
         }}
           {{input-integer
             value=config.network.mtu
-            min=1
+            min=0
             classNames="form-control"
             placeholder=(t "clusterNew.rke.networkMTU.detail")
           }}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The default value of MTU is 0, however if user touched the input. Users cannot change it back to 0
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/27016
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
