### PR TITLE
Add Cape Town (af-south-1) as a supported AWS region.

### DIFF
--- a/lib/shared/addon/utils/amazon.js
+++ b/lib/shared/addon/utils/amazon.js
@@ -565,6 +565,7 @@ export const INSTANCE_TYPES = [
 // These need to match the supported list in docker-machine:
 // https://github.com/docker/machine/blob/master/drivers/amazonec2/region.go
 export const REGIONS = [
+  'af-south-1',
   'ap-northeast-1',
   'ap-northeast-2',
   'ap-southeast-1',


### PR DESCRIPTION
Proposed changes
======
Add AWS South Africa (Cape Town) as a supported AWS region.

Types of changes
======
New Feature

Linked Issues
======
https://github.com/rancher/rancher/issues/27042

Further comments
======
Based this pull request off the one to add Azure South Africa. af-south-1 is not a supported region for EKS, so I have not included that.