### PR TITLE
(backport) Add Cape Town (af-south-1) as a supported AWS region.

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -10,7 +10,6 @@ RUN apt-get -qq update \
   && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends \
   git ca-certificates nodejs yarn  \
   hicolor-icon-theme g++ google-chrome-stable \
-  && npm install -g yarn \
   && update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10 \
   && yarn config set cache-folder /var/cache/yarn \
   && rm -rf /var/lib/apt/lists/*

--- a/lib/shared/addon/utils/amazon.js
+++ b/lib/shared/addon/utils/amazon.js
@@ -444,6 +444,7 @@ export const INSTANCE_TYPES = [
 // These need to match the supported list in docker-machine:
 // https://github.com/docker/machine/blob/master/drivers/amazonec2/region.go
 export const REGIONS = [
+  'af-south-1',
   'ap-northeast-1',
   'ap-northeast-2',
   'ap-southeast-1',


### PR DESCRIPTION
Backport of https://github.com/rancher/ui/pull/3962