### PR TITLE
[2.4.4] Prevent EKS K8s version upgrades > 1 minor version

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-amazoneks/component.js
@@ -10,6 +10,7 @@ import { equal } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import $ from 'jquery';
 import { isEmpty } from '@ember/utils';
+import { minor, coerce } from 'Semver';
 
 const REGIONS = ['us-east-2', 'us-east-1', 'us-west-2', 'ap-east-1', 'ap-south-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-southeast-1', 'ap-southeast-2', 'ca-central-1', 'cn-north-1', 'cn-northwest-1', 'eu-central-1', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'eu-north-1', 'me-south-1', 'sa-east-1'];
 const RANCHER_GROUP         = 'rancher-nodes';
@@ -281,12 +282,31 @@ export default Component.extend(ClusterDriver, {
 
   versionChoices: computed('versions', function() {
     const {
+      config : { kubernetesVersion: initialVersion },
+      intl,
       kubernetesVersionContent,
       mode,
-      config : { kubernetesVersion: initialVersion }
     } = this;
+    const versionChoices = this.versionChoiceService.parseCloudProviderVersionChoices(kubernetesVersionContent.slice(), initialVersion, mode);
 
-    return this.versionChoiceService.parseCloudProviderVersionChoices(kubernetesVersionContent.slice(), initialVersion, mode);
+    // only EKS and edit - user can only upgrade a single minor version at a time
+    if (this.editing) {
+      const initalMinorVersion = parseInt(minor(coerce(initialVersion)), 10);
+
+      versionChoices.forEach((vc) => {
+        const vcMinorV = parseInt(minor(coerce(vc.value)), 10);
+        const diff     = vcMinorV - initalMinorVersion;
+
+        if (diff > 1) {
+          setProperties(vc, {
+            disabled: true,
+            label:    `${ vc.label } ${ intl.t('formVersions.eks.label') }`,
+          });
+        }
+      })
+    }
+
+    return versionChoices;
   }),
 
 

--- a/lib/shared/addon/components/cluster-driver/driver-amazoneks/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-amazoneks/template.hbs
@@ -112,6 +112,9 @@
             content=versionChoices
             value=config.kubernetesVersion
           }}
+          {{#if editing}}
+            <p class="help-block">{{t "formVersions.eks.helpBlock"}}</p>
+          {{/if}}
         </div>
         <div class="col span-6">
           <label class="acc-label">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -6980,6 +6980,9 @@ formVersions:
   downgrade: "(can't downgrade)"
   notallowed: "(not allowed by template)"
   unsupported: "(unsupported)"
+  eks:
+    label: "(minor version >1 not allowed by EKS)"
+    helpBlock: "Because Amazon EKS runs a highly available control plane, you can update only one minor version at a time."
   helpBlock:
     label: When upgrading Kubernetes versions, please review the <a href="https://groups.google.com/forum/#!forum/kubernetes-announce" target="_blank" rel="nofollow noreferrer noopener">Kubernetes release notes</a> for any breaking changes.
 


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Adds a check to ensure that [on edit users can only upgrade by 1 minor version](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html#aws-management-console). A help block is also rendered to indicate this as well. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
New Feature
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#26908
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
