### PR TITLE
(backport) Add Cape Town (af-south-1) as a supported AWS region.

### DIFF
--- a/lib/shared/addon/utils/amazon.js
+++ b/lib/shared/addon/utils/amazon.js
@@ -565,6 +565,7 @@ export const INSTANCE_TYPES = [
 // These need to match the supported list in docker-machine:
 // https://github.com/docker/machine/blob/master/drivers/amazonec2/region.go
 export const REGIONS = [
+  'af-south-1',
   'ap-northeast-1',
   'ap-northeast-2',
   'ap-southeast-1',


### PR DESCRIPTION

Types of changes
======
- New feature (non-breaking change which adds functionality)

Linked Issues
======
rancher/rancher#27088