### PR TITLE
Fix registry credentials so that it doesn't crash

### DIFF
--- a/app/components/cru-registry/component.js
+++ b/app/components/cru-registry/component.js
@@ -84,10 +84,8 @@ export default Component.extend(ViewNewEdit, OptionallyNamespaced, {
   hostname:  window.location.host,
 
   willSave() {
-    const {
-      namespace: { id: nsId },
-      primaryResource: pr,
-    } = this;
+    const { primaryResource: pr } = this;
+    const nsId = this.namespace && this.namespace.id;
 
     set(pr, 'namespaceId', nsId ? nsId : TEMP_NAMESPACE_ID);
 


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Object destructuring expects the entire object to be present. When
'Available to all namespaces in this project' is used the namespace
object isn't defined which causes the save to fail due to an null
exception.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#26981
rancher/rancher#27117
