### PR TITLE
[2.4.4] Hide Windows logging warning in k8s 1.18

### DIFF
--- a/lib/logging/addon/components/logging/new-edit/component.js
+++ b/lib/logging/addon/components/logging/new-edit/component.js
@@ -10,7 +10,9 @@ import { resolve } from 'rsvp';
 import { next, later } from '@ember/runloop';
 import C from 'ui/utils/constants';
 import { on } from '@ember/object/evented';
+import Semver from 'semver';
 
+const MIN_WINDOWS_NO_WARNING = '1.18.1';
 const INVALID_PREFIX_CHAR = ['\\', '/', '*', '?', '"', '<', '>', '|', ` `, ',', '#'];
 
 export default Component.extend(NewOrEdit, {
@@ -178,6 +180,17 @@ export default Component.extend(NewOrEdit, {
   pageChange: on('init', observer('originalModel.customTargetConfig.content', function() {
     this.initCustomContent()
   })),
+
+  showWindowsWarning: computed('scope.currentCluster.version.gitVersion', 'scope.currentCluster.isWindows', function() {
+    const { scope: { currentCluster } } = this;
+    const currentVersion = Semver.coerce(currentCluster.version.gitVersion);
+
+    if (currentCluster.isWindows && currentCluster.isVxlan && Semver.lt(currentVersion, MIN_WINDOWS_NO_WARNING)) {
+      return true;
+    }
+
+    return false;
+  }),
 
   parseValue(value) {
     let fileObj = {}

--- a/lib/logging/addon/components/logging/new-edit/template.hbs
+++ b/lib/logging/addon/components/logging/new-edit/template.hbs
@@ -4,7 +4,7 @@
   </h1>
 </section>
 
-{{#if (and scope.currentCluster.isWindows scope.currentCluster.isVxlan)}}
+{{#if showWindowsWarning}}
   {{banner-message
     icon="icon-alert"
     color="bg-warning mb-10"


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Hide Windows logging warning in k8s 1.18
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/20968
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
