### PR TITLE
Improving how we handle a failure to get a scanConfig

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -123,7 +123,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
   clusterTemplatesEnforced:     false,
   selectedClusterTemplateId: null,
   upgradeStrategy:           {},
-  scheduledClusterScan:      {},
+  scheduledClusterScan:      { enabled: false },
 
   isNew:                        equal('mode', 'new'),
   isEdit:                       equal('mode', 'edit'),
@@ -1083,7 +1083,12 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     set(cluster, 'rancherKubernetesEngineConfig.upgradeStrategy', get(this, 'upgradeStrategy'));
 
     if (get(this, 'scheduledClusterScan.enabled')) {
-      set(this, 'scheduledClusterScan.scanConfig', this.cisHelpers.profileToClusterScanConfig(get(this, 'cisProfile')));
+      try {
+        set(this, 'scheduledClusterScan.scanConfig', this.cisHelpers.profileToClusterScanConfig(get(this, 'cisProfile')));
+      } catch (ex) {
+        set(this, 'scheduledClusterScan.scanConfig', null);
+        console.error('There was a problem attempting to map a profile to a clusterScanConfig', ex, get(this, 'cisProfile'));
+      }
     } else {
       set(this, 'scheduledClusterScan.scanConfig', null);
       set(this, 'scheduledClusterScan.scheduleConfig', null);


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
It appears that sometimes the cisscanconfig schema isn't present (I haven't
been able to consistently reproduce) which causes the UI to prevent the user
from saving changes to their cluster. Though I think this could be fixed
by the backend I'd like to stop the bleeding and have the UI handle this
better and still allow saving.

So there's two things that are here to help out.
1. I added a default value to the initial empty object just in case it never gets set
elsewhere.
2. If an exception is thrown while creating the scanConfig
we now just prevent the schedule from being set since it wouldn't work
anyway.

Either of these should allow saving to proceed.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#26996

