### PR TITLE
Make the default scheduledClusterScan.enabled to be a boolean

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -168,7 +168,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     }
     setProperties(this, {
       scheduledClusterScan: {
-        enabled:        'false',
+        enabled:        false,
         scheduleConfig: {
           cronSchedule: '0 0 * * *',
           retention:    24


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Enabled was being set to 'false' instead of false but this was being
masked by the execution of initScheduledClusterScan. When the
KDM values werent present initScheduledClusterScan was doing
an early exit and no longer masking the poor 'false' default value.

This will further improve the earlier solution for rancher/rancher#26996.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#26996.
