### PR TITLE
[backport] Removing annotations from nodetemplate clones

### DIFF
--- a/app/models/nodetemplate.js
+++ b/app/models/nodetemplate.js
@@ -44,6 +44,14 @@ export default Resource.extend({
     }
   }),
 
+  cloneForNew() {
+    const copy = this._super();
+
+    delete copy.annotations;
+
+    return copy;
+  },
+
   actions: {
     edit() {
       let driver = get(this, 'driver');


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Cloning annotations was causing problems with how binding tracking
was working. Specifically it caused problems when
annotations.ownerBindingsCreated was present.

This removes the annotations entirely as recommended by @rmweir .

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======

rancher/rancher#26946