### PR TITLE
Splitting up aggressive drain parameters   

### DIFF
--- a/app/components/modal-drain-node/component.js
+++ b/app/components/modal-drain-node/component.js
@@ -10,7 +10,7 @@ export default Component.extend(ModalBase, {
   growl: service(),
 
   layout,
-  classNames: ['large-modal'],
+  classNames: ['medium-modal'],
 
   selection: {},
 

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -970,14 +970,12 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     const maxUnavailableControlplane = get(source, 'maxUnavailableControlplane');
     const maxUnavailableWorker = get(source, 'maxUnavailableWorker') || '';
     const maxUnavailableUnit = maxUnavailableWorker.includes('%') ? 'percentage' : 'count';
-    const deleteLocalData = get(source, 'nodeDrainInput.deleteLocalData');
     const drainInput = get(source, 'nodeDrainInput');
 
     set(this, 'upgradeStrategy.maxUnavailableControlplane', maxUnavailableControlplane);
     set(this, 'upgradeStrategy.maxUnavailableWorker', maxUnavailableWorker.replace('%', ''));
     set(this, 'upgradeStrategy.maxUnavailableUnit', maxUnavailableUnit);
     set(this, 'upgradeStrategy.nodeDrainInput', drainInput ? drainInput : {});
-    set(this, 'upgradeStrategy.nodeDrainInput.deleteLocalData', (typeof deleteLocalData !== 'undefined') ? deleteLocalData.toString() : deleteLocalData);
     set(this, 'upgradeStrategy.drain', get(source, 'drain').toString());
   },
 

--- a/lib/shared/addon/components/drain-node/component.js
+++ b/lib/shared/addon/components/drain-node/component.js
@@ -22,13 +22,20 @@ export default Component.extend({
   view:      computed.not('editable'),
   init() {
     this._super(...arguments);
+    const force = get(this, 'selection.force');
+    const deleteLocalData = get(this, 'selection.force');
 
-    set(this, 'selection.deleteLocalData', (typeof this.selection.deleteLocalData === 'undefined') ? 'false' : this.selection.deleteLocalData.toString());
+    set(this, 'selection.force', typeof force === 'string' ? force === 'true' : !!force);
+    set(this, 'selection.deleteLocalData', typeof deleteLocalData === 'string' ? deleteLocalData === 'true' : !!deleteLocalData);
     set(this, 'usePodGracePeriod', this.selection.gracePeriod === HONOR_GRACE_PERIOD);
     set(this, 'proxyGracePeriod', this.selection.gracePeriod === HONOR_GRACE_PERIOD ? 30 : this.selection.gracePeriod);
     set(this, 'unlimitedTimeout', this.selection.timeout === MAX_TIMEOUT);
     set(this, 'proxyTimeout', this.selection.timeout === MAX_TIMEOUT ? 60 : this.selection.timeout);
   },
+  updateAggressive: observer('aggressive', function() {
+    set(this, 'selection.force', get(this, 'aggressive'));
+    set(this, 'selection.deleteLocalData', get(this, 'aggressive'));
+  }),
   updateGracePeriod: observer('usePodGracePeriod', 'proxyGracePeriod', function() {
     const newGracePeriod = get(this, 'usePodGracePeriod')
       ? HONOR_GRACE_PERIOD
@@ -42,9 +49,6 @@ export default Component.extend({
       : get(this, 'proxyTimeout');
 
     set(this, 'selection.timeout', newTimeout);
-  }),
-  mode: computed('selection.deleteLocalData', function() {
-    return this.selection.deleteLocalData === 'true' ? this.intl.t('drainNode.aggressive.label') : this.intl.t('drainNode.safe.label');
   }),
   gracePeriodForPods: computed('selection.usePodGracePeriod', 'selection.gracePeriod', function() {
     return this.usePodGracePeriod

--- a/lib/shared/addon/components/drain-node/template.hbs
+++ b/lib/shared/addon/components/drain-node/template.hbs
@@ -1,58 +1,98 @@
 <div class="row">
-  <div class="col span-11-of-23">
-    <label class="acc-label">
-      {{t "drainNode.mode"}}
-      {{#if clusterTemplateCreate}}
-        <ClusterTemplateOverrideToggle
-          @path="rancherKubernetesEngineConfig.upgradeStrategy.nodeDrainInput.deleteLocalData"
-          @configVariable={{selection.deleteLocalData}}
-          @addOverride={{addOverride}}
-          @questions={{questions}}
-        />
-      {{/if}}
-    </label>
-    <CheckOverrideAllowed
-      @paramName="rancherKubernetesEngineConfig.upgradeStrategy.nodeDrainInput.deleteLocalData"
-      @applyClusterTemplate={{applyClusterTemplate}}
-      @clusterTemplateRevision={{clusterTemplateRevision}}
-      @questions={{questions}}
-      @value={{mode}}
-    >
-      {{#input-or-display
-          editable=editable
-          value=mode
-      }}
-        <div>
-          <label class="radio mt-0">
-            {{radio-button
-              selection=selection.deleteLocalData
-              value="false"
-              disabled=view
-            }}
-            {{t "drainNode.safe.label"}}
-            <p class="help-block">
-              {{t "drainNode.safe.helpText"}}
-            </p>
-          </label>
-        </div>
-        <div>
-          <label class="radio text-error">
-            {{radio-button
-              selection=selection.deleteLocalData
-              value="true"
-              disabled=view
-            }}
-            {{t "drainNode.aggressive.label"}}
-            <p class="help-block text-error">
-              {{t "drainNode.aggressive.helpText" htmlSafe=true}}
-            </p>
-          </label>
-        </div>
-      {{/input-or-display}}
-    </CheckOverrideAllowed>
+  <div class="col span-6-of-23">
+    <div>
+      <label class="acc-label">
+        {{t "drainNode.deleteLocalData"}}
+        {{#if clusterTemplateCreate}}
+          <ClusterTemplateOverrideToggle
+            @path="rancherKubernetesEngineConfig.upgradeStrategy.nodeDrainInput.deleteLocalData"
+            @configVariable={{selection.deleteLocalData}}
+            @addOverride={{addOverride}}
+            @questions={{questions}}
+          />
+        {{/if}}
+      </label>
+      <CheckOverrideAllowed
+        @paramName="rancherKubernetesEngineConfig.upgradeStrategy.nodeDrainInput.deleteLocalData"
+        @applyClusterTemplate={{applyClusterTemplate}}
+        @clusterTemplateRevision={{clusterTemplateRevision}}
+        @questions={{questions}}
+        @value={{selection.deleteLocalData}}
+      >
+        {{#input-or-display
+            editable=editable
+            value=selection.deleteLocalData
+        }}
+          <div>
+            <label class="radio mt-0">
+              {{radio-button
+                selection=selection.deleteLocalData
+                value=true
+                disabled=view
+              }}
+              {{t "generic.yes"}}
+            </label>
+            <label class="radio">
+              {{radio-button
+                selection=selection.deleteLocalData
+                value=false
+                disabled=view
+              }}
+              {{t "generic.no"}}
+            </label>
+          </div>
+          
+        {{/input-or-display}}
+      </CheckOverrideAllowed>
+    </div>
+    <div class="mt-10">
+      <label class="acc-label mt-5">
+        {{t "drainNode.force"}}
+        {{#if clusterTemplateCreate}}
+          <ClusterTemplateOverrideToggle
+            @path="rancherKubernetesEngineConfig.upgradeStrategy.nodeDrainInput.force"
+            @configVariable={{selection.force}}
+            @addOverride={{addOverride}}
+            @questions={{questions}}
+          />
+        {{/if}}
+      </label>
+      <CheckOverrideAllowed
+        @paramName="rancherKubernetesEngineConfig.upgradeStrategy.nodeDrainInput.force"
+        @applyClusterTemplate={{applyClusterTemplate}}
+        @clusterTemplateRevision={{clusterTemplateRevision}}
+        @questions={{questions}}
+        @value={{selection.force}}
+      >
+        {{#input-or-display
+            editable=editable
+            value=selection.force
+        }}
+          <div>
+            <label class="radio mt-0">
+              {{radio-button
+                selection=selection.force
+                value=true
+                disabled=view
+              }}
+              {{t "generic.yes"}}
+            </label>
+            <label class="radio">
+              {{radio-button
+                selection=selection.force
+                value=false
+                disabled=view
+              }}
+              {{t "generic.no"}}
+            </label>
+          </div>
+          
+        {{/input-or-display}}
+      </CheckOverrideAllowed>
+    </div>
   </div>
 
-  <div class="col span-11-of-23 offset-1-of-23">
+  <div class="col span-16-of-23 offset-1-of-23">
     <label class="acc-label">
       {{t "drainNode.gracePeriod.title"}}
       {{#if clusterTemplateCreate}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -7890,7 +7890,8 @@ drainNode:
   titleOne: 'Drain "{name}"'
   titleMultiple: 'Drain {count} Nodes'
   action: Drain
-  mode: Mode
+  deleteLocalData: Delete Local Data
+  force: Force
   safe:
     label: Safe
     helpText: If a node has standalone pods or ephemeral data it will be cordoned but not drained.


### PR DESCRIPTION
We no longer have safe and aggressive nodes we now
have two properties 'force' and 'deleteLocalData'.


Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#27111
