### PR TITLE
Fix JS failure when searching through apps without description

### DIFF
--- a/lib/shared/addon/components/catalog-index/component.js
+++ b/lib/shared/addon/components/catalog-index/component.js
@@ -144,7 +144,7 @@ export default Component.extend({
       return all;
     }
 
-    return all.filter((tpl) => tpl.name.toLowerCase().includes(search) || tpl.description.toLowerCase().includes(search));
+    return all.filter((tpl) => (tpl.name && tpl.name.toLowerCase().includes(search)) || (tpl.description && tpl.description.toLowerCase().includes(search)));
   }),
 
   arrangedContent: computed('matchingSearch.@each.categoryLowerArray', 'category', function() {


### PR DESCRIPTION
Proposed changes
======
Fix JS failure when searching through catalog apps if an app is missing the optional description metadata field

Types of changes
======
Bugfix

Linked Issues
======
https://github.com/rancher/rancher/issues/27188
