### PR TITLE
Only adding the scope param in oath logins for google

### DIFF
--- a/lib/shared/addon/oauth/service.js
+++ b/lib/shared/addon/oauth/service.js
@@ -65,11 +65,15 @@ export default Service.extend({
       redirect = addQueryParam(redirect, 'forward', forwardUrl);
     }
 
-    let url = addQueryParams(authRedirect, {
-      scope:          authType === 'googleoauth' ? googleOauthScope : undefined,
+    const params = {
       state:          this.generateLoginStateKey(authType),
       redirect_uri:   redirect,
-    });
+    };
+
+    if (authType === 'googleoauth') {
+      params.scope = googleOauthScope;
+    }
+    const url = addQueryParams(authRedirect, params);
 
     window.location.href = url;
   },


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Looks like the undefined scope was getting added to the query
params for the redirect url. This change prevents the scope
param from being present for anything but google.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#27175


