### PR TITLE
[backport] Reset registry modal step on each open

### DIFF
--- a/app/components/modal-drain-node/component.js
+++ b/app/components/modal-drain-node/component.js
@@ -16,6 +16,11 @@ export default Component.extend(ModalBase, {
 
   resources: alias('modalService.modalOpts.resources'),
 
+  init() {
+    this._super(...arguments);
+    this.selection = {};
+  },
+
   actions: {
     drain() {
       const nodeDrainInput = { ...get(this, 'selection') };


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The modal was persisting the selection state between multiple
closing and openings of the modal. This now resets the selection
state.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#27339