### PR TITLE
Support for app catalog question variable type "config-map"

### DIFF
--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -681,6 +681,7 @@ C.INITIALIZING_STATES = [
 C.SUPPORTED_SCHEMA_INPUTS = [
   'boolean',
   'certificate',
+  'config-map',
   'date',
   'enum',
   'float',


### PR DESCRIPTION
Proposed changes
======
This adds a new question variable type `config-map` that renders a UI element to pick existing ConfigMaps when installing/upgrading a catalog app, similar to the already existing variable type `secret`.

Types of changes
======
- New feature (non-breaking change which adds functionality)

Linked Issues
======
https://github.com/rancher/rancher/issues/27412

Further comments
======
The UI component to pick ConfigMaps already exists, so it is only necessary to add this as a supported variable input type.

Tested with this helm chart https://github.com/bashofmann/chart-repo/tree/master/charts/rancher-demo/v0.1.0.
