### PR TITLE
[2.4] A tenancy should be a valid compartment since it is technically the r…

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
@@ -337,7 +337,7 @@ export default Component.extend(ClusterDriver, {
 
     const compartmentId = get(this, 'config.compartmentId');
 
-    if (!compartmentId.startsWith('ocid1.compartment')) {
+    if (!compartmentId.startsWith('ocid1.compartment') && !compartmentId.startsWith('ocid1.tenancy')) {
       errors.push('A valid compartment OCID is required');
     }
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This change updates the (JavaScript) validation logic to allow the tenancy to be used as a valid compartment since it is technically the 'root compartment'.

The driver nor the OKE platform have issues provisioning a cluster and VCN to the root compartment / tenancy. Therefore, we should loosen up the overly restrictive validation. 

<!-- 
What types of changes does your code introduce to Rancher?
-->
Types of changes
======

- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======

[Here](https://github.com/rancher-plugins/kontainer-engine-driver-oke/issues/13)


Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
Backwards compatible change.
