### PR TITLE
[2.4] Limit Editable Secret Data

### DIFF
--- a/lib/shared/addon/components/form-key-value/component.js
+++ b/lib/shared/addon/components/form-key-value/component.js
@@ -5,6 +5,7 @@ import { get, set, observer } from '@ember/object'
 import Upload from 'shared/mixins/upload';
 import layout from './template';
 import $ from 'jquery';
+import { asciiLike } from 'shared/utils/util';
 
 function applyLinesIntoArray(lines, ary) {
   lines.forEach((line) => {
@@ -136,7 +137,13 @@ export default Component.extend(Upload, {
 
     if ( get(this, 'base64Value') ) {
       ary.forEach((entry) => {
-        entry.value = AWS.util.base64.decode(entry.value).toString();
+        const decoded = AWS.util.base64.decode(entry.value).toString();
+
+        if ( typeof decoded === 'string' && !asciiLike(decoded) ) {
+          set(entry, 'binary', true);
+        }
+
+        entry.value = decoded;
       });
     }
 

--- a/lib/shared/addon/components/form-key-value/template.hbs
+++ b/lib/shared/addon/components/form-key-value/template.hbs
@@ -24,74 +24,101 @@
       </tr>
     </thead>
     <tbody>
-    {{#each ary as |row|}}
-      <tr>
-        <td data-title="{{t keyLabel}}:">
-          {{#if editing}}
-            {{#if keyContent}}
-              <NewSelect
-                @content={{keyContent}}
-                @class="form-control input-sm key"
-                @useContentForDefaultValue={{true}}
-                @value={{row.key}}
-                @placeholder={{keyPlaceholder}}
-                @disabled={{not (and allowEditKey (not-eq row.editable false))}}
-              />
-            {{else}}
-              {{input-paste
-                separators=separators
-                pasted=(action "pastedValues")
-                class="form-control input-sm key"
-                type="text"
-                value=row.key
-                placeholder=keyPlaceholder
-                disabled=(not (and allowEditKey (not-eq row.editable false)))
-              }}
-            {{/if}}
-          {{else}}
-            {{row.key}}
-          {{/if}}
-        </td>
-
-        <td class="valign-top text-center">
-          {{#if editing}}
-            {{t "formKeyValue.separator"}}
-          {{/if}}
-        </td>
-
-        <td data-title="{{t valueLabel}}:">
-          {{#if editing}}
-            {{#if valueContent}}
-              <NewSelect
-                @content={{valueContent}}
-                @class="form-control input-sm key"
-                @useContentForDefaultValue={{true}}
-                @value={{row.value}}
-                @placeholder={{keyPlaceholder}}
-                @disabled={{not (and allowEditKey (not-eq row.editable false))}}
-              />
-            {{else}}
-              {{#if allowMultilineValue}}
-                {{textarea-autogrow class=(concat "form-control input-sm value" (if concealValue " conceal")) spellcheck="false" required=true value=row.value placeholder=valuePlaceholder disabled=(eq row.editable false)}}
+      {{#each ary as |row|}}
+        <tr>
+          <td data-title="{{t keyLabel}}:">
+            {{#if editing}}
+              {{#if keyContent}}
+                <NewSelect
+                  @content={{keyContent}}
+                  @class="form-control input-sm key"
+                  @useContentForDefaultValue={{true}}
+                  @value={{row.key}}
+                  @placeholder={{keyPlaceholder}}
+                  @disabled={{not (and allowEditKey (not-eq row.editable false))}}
+                />
               {{else}}
-                {{input class=(concat "form-control input-sm value" (if concealValue " conceal")) spellcheck="false" type="text" value=row.value placeholder=valuePlaceholder disabled=(eq row.editable false)}}
+                {{input-paste
+                  separators=separators
+                  pasted=(action "pastedValues")
+                  class="form-control input-sm key"
+                  type="text"
+                  value=row.key
+                  placeholder=keyPlaceholder
+                  disabled=(not (and allowEditKey (not-eq row.editable false)))
+                }}
               {{/if}}
+            {{else}}
+              {{row.key}}
             {{/if}}
-          {{else}}
-            <span class="{{if concealValue "conceal"}}">{{nl-to-br row.value}}</span>
-          {{/if}}
-        </td>
-        <td>&nbsp;</td>
-        <td class="valign-top text-right">
-          {{#if (and editing allowRemove)}}
-            <button class="btn bg-primary btn-sm" {{action "remove" row}} disabled={{eq row.editable false}}><i class="icon icon-minus"/><span class="sr-only">{{t "generic.remove"}}</span></button>
-          {{/if}}
-        </td>
-      </tr>
-      {{#unless editing}}
-        <div class="pb-10"></div>
-      {{/unless}}
-    {{/each}}
+          </td>
+
+          <td class="valign-top text-center">
+            {{#if editing}}
+              {{t "formKeyValue.separator"}}
+            {{/if}}
+          </td>
+
+          <td data-title="{{t valueLabel}}:">
+            {{#if editing}}
+              {{#if valueContent}}
+                <NewSelect
+                  @content={{valueContent}}
+                  @class="form-control input-sm key"
+                  @useContentForDefaultValue={{true}}
+                  @value={{row.value}}
+                  @placeholder={{keyPlaceholder}}
+                  @disabled={{not (and allowEditKey (not-eq row.editable false))}}
+                />
+              {{else}}
+                {{#if row.binary}}
+                  {{t "formKeyValue.binary.byte" length=row.value.length}}
+                {{else}}
+                  {{#if allowMultilineValue}}
+                    {{textarea-autogrow
+                      class=(concat "form-control input-sm value" (if concealValue " conceal"))
+                      spellcheck="false"
+                      required=true
+                      value=row.value
+                      placeholder=valuePlaceholder
+                      disabled=(eq row.editable false)
+                    }}
+                  {{else}}
+                    {{input
+                      class=(concat "form-control input-sm value" (if concealValue " conceal"))
+                      spellcheck="false"
+                      type="text"
+                      value=row.value
+                      placeholder=valuePlaceholder
+                      disabled=(eq row.editable false)
+                    }}
+                  {{/if}}
+                {{/if}}
+              {{/if}}
+            {{else}}
+              <span class="{{if concealValue "conceal"}}">{{nl-to-br row.value}}</span>
+            {{/if}}
+          </td>
+          <td>&nbsp;</td>
+          <td class="valign-top text-right">
+            {{#if (and editing allowRemove)}}
+              <button
+                class="btn bg-primary btn-sm"
+                {{action "remove" row}}
+                disabled={{eq row.editable false}}
+              >
+                <i class="icon icon-minus"/>
+                <span class="sr-only">
+                  {{t "generic.remove"}}
+                </span>
+              </button>
+            {{/if}}
+          </td>
+        </tr>
+        {{#unless editing}}
+          <div class="pb-10"></div>
+        {{/unless}}
+      {{/each}}
     </tbody>
   </table>
 {{else if showNoneLabel}}

--- a/lib/shared/addon/utils/util.js
+++ b/lib/shared/addon/utils/util.js
@@ -6,6 +6,16 @@ import { isArray } from '@ember/array';
 import ipaddr from 'ipaddr.js';
 import { decamelize } from '@ember/string';
 
+export function asciiLike(str) {
+  str = str || '';
+  if ( str.match(/[^\r\n\t\x20-\x7F]/) ) {
+    return false;
+  }
+
+  return true;
+}
+
+
 export function arrayDiff(a, b) {
   return a.filter((i) => {
     return !b.includes(i);
@@ -583,6 +593,7 @@ export function extractUniqueStrings(strings) {
 }
 
 var Util = {
+  asciiLike,
   absoluteUrl,
   addAuthorization,
   addQueryParam,

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -6364,6 +6364,13 @@ formKeyValue:
     label: Value
     placeholder: Value
   protip: 'ProTip: Paste lines of key=value pairs into any key field for easy bulk entry.'
+  binary:
+    byte: |
+      {length, plural,
+      =1 {# byte}
+      other {# bytes}
+      }
+
 
 formImage:
   label: Docker Image


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When a editing secret with binary non-UTF-8 data (e.g. pkcs12 encoded cert) the UI will break that data upon save. As we do in dashboard we won't allow users to edit secret data rows that contain non-UTF-8 data. Users can still add and remove rows, included the non-UTF-8 data row.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#27439
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
====== 
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
