### PR TITLE
[2.4] Filter Global Role Bindings Creating User

### DIFF
--- a/lib/global-admin/addon/components/form-global-roles/component.js
+++ b/lib/global-admin/addon/components/form-global-roles/component.js
@@ -135,7 +135,7 @@ export default Component.extend({
     let hasTranslation = true;
 
     if (!isEmpty(user)) {
-      usersGlobalRoleBindings.pushObjects(user.globalRoleBindings);
+      usersGlobalRoleBindings.pushObjects(user.globalRoleBindings.filterBy('groupPrincipalId', null));
     } else {
       usersGlobalRoleBindings.pushObjects(groupGlobalRoleBindings.slice());
     }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When we assign a new role binding to a group we are actually creating a new global role binding. When an admin (or user with perms) creates additional users after global role bindings have been assigned a group, the creator will see these new global role bindings show up in the role list as checked. This is because the user create page keeps track of all roles that are active on init so that we may add/remove roles on edit, the save logic here see's these unchecked roles as roles that existed and are now removed. Subsequently sending off delete calls and removes the global role binding for that group. The creator is none the wiser since the role is not added to the new user.
Adding a filter (groupPrincipalId=null) to this initialization fixes the issue.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
