### PR TITLE
[2.4.6] allow project owners to save reg creds

### DIFF
--- a/app/components/cru-registry/component.js
+++ b/app/components/cru-registry/component.js
@@ -86,11 +86,21 @@ export default Component.extend(ViewNewEdit, OptionallyNamespaced, {
 
   willSave() {
     const { primaryResource: pr } = this;
-    const nsId = this.namespace && this.namespace.id;
+    let tempSet = false;
 
-    set(pr, 'namespaceId', nsId ? nsId : TEMP_NAMESPACE_ID);
+    if (isEmpty(get(pr, 'namespaceId'))) {
+      // Namespace is required, but doesn't exist yet... so lie to the validator
+      set(pr, 'namespaceId', TEMP_NAMESPACE_ID);
+
+      tempSet = true;
+    }
 
     let ok = this.validate();
+
+    if (tempSet) {
+      // unset temp so that namespacePromise can takeover from here
+      set(pr, 'namespaceId', null);
+    }
 
     return ok;
   },
@@ -109,15 +119,10 @@ export default Component.extend(ViewNewEdit, OptionallyNamespaced, {
   },
 
   doSave() {
-    let self                       = this;
-    let sup                        = self._super;
-    const { primaryResource: { namespaceId } } = this;
+    let self = this;
+    let sup  = self._super;
 
-    if (isEmpty(namespaceId) || namespaceId === TEMP_NAMESPACE_ID) {
-      return this.namespacePromise().then(() => sup.apply(self, arguments));
-    } else {
-      return sup.apply(self, arguments);
-    }
+    return this.namespacePromise().then(() => sup.apply(self, arguments));
   },
 
   doneSaving() {


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Fix regression in creating registry creds. I misunderstood what willSave was
doing with the namespaceId when I added the ternary check. I simplified and
hopefully clarified what was actually happening when setting temp_id, now use
a local flag to set unset the temp namespace, then allow namespace to handle
saving or not saving the namespace.


<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#27769
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
