### PR TITLE
Handle mismatch between the region name and the region identifier for…

### DIFF
--- a/lib/nodes/addon/components/driver-oci/component.js
+++ b/lib/nodes/addon/components/driver-oci/component.js
@@ -185,9 +185,13 @@ export default Component.extend(NodeDriver, {
     if (!get(this, 'config.subnetId') || !get(this, 'config.subnetId').startsWith('ocid1.subnet')) {
       errors.push('Specifying a valid oci subnet OCID is required');
     }
-    // phoenix has a different region identifier
+    // phoenix and ashburn have different region identifiers
     if (get(this, 'config.region').includes('phoenix')) {
       if (!get(this, 'config.subnetId').includes('phx') || !get(this, 'config.vcnId').includes('phx')) {
+        errors.push('The VCN and subnet must reside in the same region as the compute instance');
+      }
+    } else if (get(this, 'config.region').includes('ashburn')) {
+      if (!get(this, 'config.subnetId').includes('iad') || !get(this, 'config.vcnId').includes('iad')) {
         errors.push('The VCN and subnet must reside in the same region as the compute instance');
       }
     } else {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This change updates the (JavaScript) validation logic to handle mismatch between the region name and the region identifier for IAD/Ashburn in a addition to the what we have to do for PHX/Phoenix.

i.e. the region identifier format in the [OCIDs](https://docs.cloud.oracle.com/en-us/iaas/Content/General/Concepts/identifiers.htm) for phx and iad differ from the format used in all the other regions.

| Region        | Identifier           |
| ------------- |:-------------:| 
| us-ashburn-1     | iad |
| us-phoenix-1     | phx |
| ap-chuncheon-1     | ap-chuncheon-1 |
| ap-hyderabad-1     | ap-hyderabad-1 |
| ap-melbourne-1     | ap-melbourne-1 |
| ap-mumbai-1     | ap-mumbai-1 |
| ap-osaka-1     | ap-osaka-1 |
| ap-seoul-1     | ap-seoul-1 |
| ap-sydney-1     | ap-sydney-1
| ap-tokyo-1     | ap-tokyo-1 |
| ca-montreal-1     | ca-montreal-1 |
| ca-toronto-1     | ca-toronto-1 |
| eu-amsterdam-1     | eu-amsterdam-1 |
| eu-frankfurt-1     | eu-frankfurt-1 |
| eu-zurich-1     | eu-zurich-1 |
| me-jeddah-1     | me-jeddah-1 |
| sa-saopaulo-1     | sa-saopaulo-1 |
| uk-london-1     | uk-london-1 |

<!-- 
What types of changes does your code introduce to Rancher?
-->
Types of changes
======

- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======

[Here](https://github.com/rancher-plugins/rancher-machine-driver-oci/issues/2)


Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
Backwards compatible change.
