### PR TITLE
[backport] Ensure the datacenter changes value if the credentials change

### DIFF
--- a/lib/nodes/addon/components/driver-vmwarevsphere/component.js
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/component.js
@@ -196,6 +196,10 @@ export default Component.extend(NodeDriver, {
     }
   }),
 
+  cloudCredentialIdObserver: observer('model.cloudCredentialId', function() {
+    set(this, 'config.datacenter', null);
+  }),
+
   datacenterContent: computed('model.cloudCredentialId', async function() {
     const options = await this.requestOptions('data-centers', get(this, 'model.cloudCredentialId'));
 
@@ -514,7 +518,7 @@ export default Component.extend(NodeDriver, {
     return true;
   },
   async requestOptions(resource, cloudCredentialId, dataCenter, library) {
-    if (!cloudCredentialId) {
+    if (!cloudCredentialId || dataCenter === null) {
       return [];
     }
 


### PR DESCRIPTION
Proposed changes
======
I noticed fields wouldn't update if the credentials changed
if the datacenter value stayed the same. This ensures that
all of the other values will recompute by forcing the datacenter
value to change.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#26997

