### PR TITLE
UI - Enabling desiredNodes field on the EKS driver cluster configuration screen

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-amazoneks/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-amazoneks/template.hbs
@@ -422,7 +422,6 @@
             {{t "nodeDriver.amazoneks.desired.label"}}
           </label>
           {{#input-or-display
-             editable=(eq mode "new")
              value=config.desiredNodes
           }}
             {{input-number value=config.desiredNodes min=1}}


### PR DESCRIPTION
This enabled change or the desired Nodes field in edit mode on the EKS cluster driver screen. Thus, it will be possible to change the number of nodes in a cluster through the Rancher graphical interface.

Types of changes
- New feature (non-breaking change which adds functionality)

Linked Issues
https://github.com/rancher/rancher/issues/27847
 
