### PR TITLE
Replacing SAML socketId with publicKey

### DIFF
--- a/lib/login/addon/components/login-saml/component.js
+++ b/lib/login/addon/components/login-saml/component.js
@@ -9,7 +9,7 @@ export default Component.extend({
 
   actions: {
     authenticate() {
-      get(this, 'saml').login(get(this, 'provider'), get(this, 'socketId')).catch( ( err ) => {
+      get(this, 'saml').login(get(this, 'provider'), get(this, 'publicKey')).catch( ( err ) => {
         set(this, 'errors', [err.message])
       });
     }

--- a/lib/login/addon/login/controller.js
+++ b/lib/login/addon/login/controller.js
@@ -22,7 +22,7 @@ export default Controller.extend({
   router:              service(),
   session:             service(),
 
-  queryParams:         ['errorMsg', 'resetPassword', 'errorCode', 'socketId'],
+  queryParams:         ['errorMsg', 'resetPassword', 'errorCode', 'publicKey'],
   waiting:             false,
   adWaiting:           false,
   localWaiting:        false,

--- a/lib/login/addon/login/template.hbs
+++ b/lib/login/addon/login/template.hbs
@@ -39,7 +39,7 @@
             {{login-saml
               action=(action "started")
               provider="shibboleth"
-              socketId=socketId
+              publicKey=publicKey
             }}
           {{/if}}
 
@@ -78,7 +78,7 @@
             {{login-saml
               action=(action "started")
               provider="ping"
-              socketId=socketId
+              publicKey=publicKey
             }}
           {{/if}}
 
@@ -86,7 +86,7 @@
             {{login-saml
               action=(action "started")
               provider="adfs"
-              socketId=socketId
+              publicKey=publicKey
             }}
           {{/if}}
 
@@ -94,7 +94,7 @@
             {{login-saml
               action=(action "started")
               provider="okta"
-              socketId=socketId
+              publicKey=publicKey
             }}
           {{/if}}
 
@@ -102,7 +102,7 @@
             {{login-saml
               action=(action "started")
               provider="keycloak"
-              socketId=socketId
+              publicKey=publicKey
             }}
           {{/if}}
         {{/if}}

--- a/lib/shared/addon/saml/service.js
+++ b/lib/shared/addon/saml/service.js
@@ -9,12 +9,12 @@ export default Service.extend({
   app:           service(),
   intl:          service(),
 
-  login(providerName, socketId) {
+  login(providerName, publicKey) {
     const finalUrl = window.location.origin;
     const provider     = get(this, 'access.providers').findBy('id', providerName);
     const args = {
       finalRedirectUrl: finalUrl,
-      socketId
+      publicKey
     };
 
     return provider.doAction('login', args).then( ( resp ) => {


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The backend changes for socketId weren't working with HA clusters so
it was decided to replace socketId with publicKey.


Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#444

