### PR TITLE
Adding a selected cis profile to the profile options if it's not present

### DIFF
--- a/lib/shared/addon/cis-helpers/service.js
+++ b/lib/shared/addon/cis-helpers/service.js
@@ -19,15 +19,15 @@ export default Service.extend({
     return this.createProfileKey(scanConfig.cisScanConfig.profile, scanConfig.cisScanConfig.overrideBenchmarkVersion);
   },
 
-  profileToClusterScanConfig(profile) {
-    const profileBenchmark = this.cisScanProfiles[profile];
+  profileToClusterScanConfig(profileRaw) {
+    const [benchmark, profile] = profileRaw.toLowerCase().split(' ');
 
     return {
       cisScanConfig: {
         failuresOnly:             false,
         skip:                     null,
-        profile:                  profileBenchmark.profile,
-        overrideBenchmarkVersion: profileBenchmark.benchmark
+        overrideBenchmarkVersion: benchmark,
+        profile,
       }
     }
   },

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -23,6 +23,7 @@ import Semver, { major, minor }  from 'semver';
 import { on } from '@ember/object/evented';
 import deepSet from 'ember-deep-set';
 import { coerceVersion } from 'shared/utils/parse-version';
+import { ucFirst } from 'shared/utils/util';
 
 const EXCLUDED_KEYS = ['name'];
 const EXCLUDED_CHILDREN_KEYS = ['extra_args', 'nodelocal', 'dns', 'extraArgs'];
@@ -932,10 +933,30 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
   }),
 
 
-  cisProfileDisplay: computed('cisProfile', 'cisHelpers.cisScanProfileOptions', function() {
-    const profile = get(this, 'cisHelpers.cisScanProfileOptions').find((option) => option.value === get(this, 'cisProfile'));
+  cisProfileDisplay: computed('cisProfile', 'cisScanProfileOptions', function() {
+    const profile = get(this, 'cisScanProfileOptions').find((option) => option.value === get(this, 'cisProfile'));
 
     return profile ? profile.label : '';
+  }),
+
+  cisScanProfileOptions: computed('cisProfile', 'cisHelpers.cisScanProfileOptions', function() {
+    const selectedProfile = get(this, 'cisProfile')
+    const options = get(this, 'cisHelpers.cisScanProfileOptions');
+    const foundProfile = options.find((option) => option.value === selectedProfile);
+
+    if (!foundProfile && selectedProfile) {
+      const splitProfile = selectedProfile.split(' ');
+
+      splitProfile[1] = ucFirst(splitProfile[1]);
+      const missingOption = {
+        label: splitProfile.join(' '),
+        value: splitProfile
+      }
+
+      return [missingOption, ...options];
+    }
+
+    return options;
   }),
 
   initScheduledClusterScan() {

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -997,7 +997,7 @@
                   {{new-select
                     id="cis-scan-profile"
                     classNames="form-control"
-                    content=cisHelpers.cisScanProfileOptions
+                    content=cisScanProfileOptions
                     value=cisProfile
                     disabled=(not scheduledClusterScan.enabled)
                   }}


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When upgrading rancher the old 1.4 cis profiles were removed which prevented
the currently selected profile for scheduled scans to be selected.

This adds a selected profile to the options if it's not present allowing the
profile to be selected by default. If a different profile is selected and saved
the option will no longer be present. This option will also not be present in
the manual run scan modal.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#27867
rancher/rancher#27866
rancher/rancher#27374

