### PR TITLE
Adding requestId and responseType to saml logins

### DIFF
--- a/lib/login/addon/components/login-saml/component.js
+++ b/lib/login/addon/components/login-saml/component.js
@@ -9,7 +9,7 @@ export default Component.extend({
 
   actions: {
     authenticate() {
-      get(this, 'saml').login(get(this, 'provider'), get(this, 'publicKey')).catch( ( err ) => {
+      get(this, 'saml').login(get(this, 'provider'), get(this, 'requestId'), get(this, 'publicKey'), get(this, 'responseType')).catch( ( err ) => {
         set(this, 'errors', [err.message])
       });
     }

--- a/lib/login/addon/login/controller.js
+++ b/lib/login/addon/login/controller.js
@@ -22,7 +22,7 @@ export default Controller.extend({
   router:              service(),
   session:             service(),
 
-  queryParams:         ['errorMsg', 'resetPassword', 'errorCode', 'publicKey'],
+  queryParams:         ['errorMsg', 'resetPassword', 'errorCode', 'requestId', 'publicKey', 'responseType'],
   waiting:             false,
   adWaiting:           false,
   localWaiting:        false,

--- a/lib/login/addon/login/template.hbs
+++ b/lib/login/addon/login/template.hbs
@@ -39,7 +39,9 @@
             {{login-saml
               action=(action "started")
               provider="shibboleth"
+              requestId=requestId
               publicKey=publicKey
+              responseType=responseType
             }}
           {{/if}}
 
@@ -78,7 +80,9 @@
             {{login-saml
               action=(action "started")
               provider="ping"
+              requestId=requestId
               publicKey=publicKey
+              responseType=responseType
             }}
           {{/if}}
 
@@ -86,7 +90,9 @@
             {{login-saml
               action=(action "started")
               provider="adfs"
+              requestId=requestId
               publicKey=publicKey
+              responseType=responseType
             }}
           {{/if}}
 
@@ -94,7 +100,9 @@
             {{login-saml
               action=(action "started")
               provider="okta"
+              requestId=requestId
               publicKey=publicKey
+              responseType=responseType
             }}
           {{/if}}
 
@@ -102,7 +110,9 @@
             {{login-saml
               action=(action "started")
               provider="keycloak"
+              requestId=requestId
               publicKey=publicKey
+              responseType=responseType
             }}
           {{/if}}
         {{/if}}

--- a/lib/shared/addon/saml/service.js
+++ b/lib/shared/addon/saml/service.js
@@ -9,12 +9,14 @@ export default Service.extend({
   app:           service(),
   intl:          service(),
 
-  login(providerName, publicKey) {
+  login(providerName, requestId, publicKey, responseType) {
     const finalUrl = window.location.origin;
     const provider     = get(this, 'access.providers').findBy('id', providerName);
     const args = {
       finalRedirectUrl: finalUrl,
-      publicKey
+      requestId,
+      publicKey,
+      responseType
     };
 
     return provider.doAction('login', args).then( ( resp ) => {


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
I mistakenly didn't add these two fields when replacing socketId with
publicKey.


Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancherlabs/rancher-security#444

