### PR TITLE
Add Azure German Public locations to the provider choices

### DIFF
--- a/lib/shared/addon/utils/azure-choices.js
+++ b/lib/shared/addon/utils/azure-choices.js
@@ -41,6 +41,14 @@ export let regions = {
       'displayName': 'West Europe',
     },
     {
+      'name':        'germanynorth',
+      'displayName': 'Germany North',
+    },
+    {
+      'name':        'germanywescentral',
+      'displayName': 'Germany West Central',
+    },
+    {
       'name':        'japanwest',
       'displayName': 'Japan West',
     },

--- a/lib/shared/addon/utils/azure-choices.js
+++ b/lib/shared/addon/utils/azure-choices.js
@@ -45,7 +45,7 @@ export let regions = {
       'displayName': 'Germany North',
     },
     {
-      'name':        'germanywescentral',
+      'name':        'germanywestcentral',
       'displayName': 'Germany West Central',
     },
     {


### PR DESCRIPTION
# Proposed changes
Adding German Public locations to the Azure choices

# Types of changes
New feature

# Linked Issues
https://github.com/rancher/rancher/issues/28082

# Comments
Check the infrastructure pages for double-checking the locations, marked with (Public) are in the `AzurePublicCloud` while the (Sovereign) is in the `AzureGermanCloud`.
- https://azure.microsoft.com/en-us/global-infrastructure/data-residency
- https://azure.microsoft.com/en-us/global-infrastructure/geographies