### PR TITLE
[backport] Switching from min value to default value for upgradeStrategy timeout

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -64,8 +64,6 @@ const INGRESSCHOICES = [
 
 const AVAILABLE_STRATEGIES = ['local', 's3'];
 
-const NODE_DRAIN_INPUT_TIMEOUT_MIN = 1;
-
 const {
   CLUSTER_TEMPLATE_IGNORED_OVERRIDES,
   NETWORK_CONFIG_DEFAULTS: { DEFAULT_BACKEND_TYPE }
@@ -991,9 +989,10 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
   initUpgradeStrategy() {
     const upgradeStrategy = get(this, 'primaryResource.rancherKubernetesEngineConfig.upgradeStrategy');
+    const defaultUpgradeStrategy = this.getDefaultUpgradeStrategy();
     const source = upgradeStrategy
       ? upgradeStrategy
-      : this.getDefaultUpgradeStrategy();
+      : defaultUpgradeStrategy;
 
     const maxUnavailableControlplane = get(source, 'maxUnavailableControlplane');
     const maxUnavailableWorker = get(source, 'maxUnavailableWorker') || '';
@@ -1008,8 +1007,10 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     set(this, 'upgradeStrategy.drain', get(source, 'drain').toString());
 
     // This ensures the UI won't initialize the timeout below the minimum.
-    if (timeout !== undefined && timeout < NODE_DRAIN_INPUT_TIMEOUT_MIN) {
-      set(this, 'upgradeStrategy.nodeDrainInput.timeout', NODE_DRAIN_INPUT_TIMEOUT_MIN);
+    if (timeout !== undefined && timeout <= 0) {
+      const defaultTimeout = get(defaultUpgradeStrategy, 'nodeDrainInput.timeout');
+
+      set(this, 'upgradeStrategy.nodeDrainInput.timeout', defaultTimeout);
     }
   },
 


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Turns out that the min value that the backend accepts won't allow
upgrades to complete. This switches the value to the default value to
mitigate that issue.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#27333