### PR TITLE
Removing appliedSpec before saving driver-rke

### DIFF
--- a/lib/shared/addon/mixins/cluster-driver.js
+++ b/lib/shared/addon/mixins/cluster-driver.js
@@ -120,7 +120,7 @@ export default Mixin.create({
 
   validate() {
     const model = get(this, 'cluster');
-    const errors = model.validationErrors();
+    const errors = model.validationErrors(['appliedSpec']);
 
     set(this, 'errors', errors);
 

--- a/lib/shared/addon/mixins/new-or-edit.js
+++ b/lib/shared/addon/mixins/new-or-edit.js
@@ -22,7 +22,7 @@ export default Mixin.create({
 
   validate() {
     var model = get(this, 'primaryResource');
-    var errors = model.validationErrors();
+    var errors = model.validationErrors(['appliedSpec']);
 
     if ( errors.get('length') ) {
       set(this, 'errors', errors);


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Unfortunately the backend is sometimes saving invalid models which causes the validation of appliedSpec to fail. To avoid this validation we're now ignoring the appliedSpec where this can go wrong.


Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
https://github.com/rancher/rancher/issues/27333#issuecomment-665244361

Notes
======
The validation is happening in multiple places. To add the plumbing for ignoring the appliedSpec to each place seemed excessive for a temporary fix. If you don't want me to remove the appliedSpec do you have any thoughts on making the change small? If not, I think I'll add the plumbing either to the model that's being validated or as props being passed to the components/mixins.

