### PR TITLE
[2.4.6] Allow pod scale to be set 0 or null

### DIFF
--- a/app/components/container/form-scale/template.hbs
+++ b/app/components/container/form-scale/template.hbs
@@ -1,122 +1,169 @@
 {{#if editing}}
   <div>
-    <label class="pb-5 acc-label">{{t 'formScale.label'}}</label>
+    <label class="pb-5 acc-label">
+      {{t "formScale.label"}}
+    </label>
     {{#if canAdvanced}}
       <div class="pull-right text-small">
-        <a role="button" class="btn bg-transparent p-0" {{action "showAdvanced"}}>{{t 'formScale.showAdvanced'}}</a>
+        <a
+          role="button"
+          class="btn bg-transparent p-0"
+          {{action "showAdvanced"}}
+        >
+          {{t "formScale.showAdvanced"}}
+        </a>
       </div>
     {{/if}}
   </div>
 {{/if}}
-
 {{#if (and advancedShown canChangeScaleMode)}}
   <div class="radio">
     <label>
       {{radio-button selection=scaleMode value="deployment"}}
       <i class="icon icon-lg icon-service"></i>
-      {{t 'formScale.scaleMode.deploymentPrefix' scale=asInteger}}
+      {{t "formScale.scaleMode.deploymentPrefix" scale=asInteger}}
       {{#if (eq scaleMode "deployment")}}
-        {{input-integer safeStyle="width: 60px; padding: 0 2px; display: inline-block" value=userInput min=1 max=max}}
+        {{input-integer
+          safeStyle="width: 60px; padding: 0 2px; display: inline-block"
+          value=userInput
+          min=min
+          max=max
+          nullable=true
+        }}
       {{else}}
         {{asInteger}}
       {{/if}}
-      {{t 'formScale.scaleMode.scaleSuffix' scale=asInteger}}
+      {{t "formScale.scaleMode.scaleSuffix" scale=asInteger}}
     </label>
   </div>
   <div class="radio">
     <label>
       {{radio-button selection=scaleMode value="daemonSet"}}
       <i class="icon icon-lg icon-globe"></i>
-      {{t 'formScale.scaleMode.daemonSet'}}
+      {{t "formScale.scaleMode.daemonSet"}}
     </label>
   </div>
   <div class="radio">
     <label>
       {{radio-button selection=scaleMode value="statefulSet"}}
       <i class="icon icon-lg icon-database"></i>
-      {{t 'formScale.scaleMode.statefulSetPrefix' scale=asInteger}}
+      {{t "formScale.scaleMode.statefulSetPrefix" scale=asInteger}}
       {{#if (eq scaleMode "statefulSet")}}
-        {{input-integer safeStyle="width: 60px; padding: 0 2px; display: inline-block" value=userInput min=1 max=max}}
+        {{input-integer
+          safeStyle="width: 60px; padding: 0 2px; display: inline-block"
+          value=userInput
+          min=min
+          max=max
+          nullable=true
+        }}
       {{else}}
         {{asInteger}}
       {{/if}}
-      {{t 'formScale.scaleMode.scaleSuffix' scale=asInteger}}
+      {{t "formScale.scaleMode.scaleSuffix" scale=asInteger}}
     </label>
   </div>
   <div class="radio">
     <label>
       {{radio-button selection=scaleMode value="cronJob"}}
       <i class="icon icon-lg icon-history"></i>
-      {{t 'formScale.scaleMode.cronJob'}}
-      {{~#if (eq scaleMode "cronJob")~}}
-        : {{input safeStyle="width: 150px; padding: 0 2px; display: inline-block;" value=workload.cronJobConfig.schedule}}
-      {{~/if~}}
+      {{t "formScale.scaleMode.cronJob"}}
+      {{#if (eq scaleMode "cronJob")}}
+        :
+        {{input
+          safeStyle="width: 150px; padding: 0 2px; display: inline-block;"
+          value=workload.cronJobConfig.schedule
+        }}
+      {{/if}}
     </label>
     {{#if (eq scaleMode "cronJob")}}
-      <p class="text-small text-muted" style="margin: 0 0 0 45px;">{{pretty-cron workload.cronJobConfig.schedule 'toString'}}</p>
+      <p class="text-small text-muted" style="margin: 0 0 0 45px;">
+        {{pretty-cron workload.cronJobConfig.schedule "toString"}}
+      </p>
     {{/if}}
   </div>
   <div class="radio">
     <label>
       {{radio-button selection=scaleMode value="job"}}
       <i class="icon icon-lg icon-file"></i>
-      {{t 'formScale.scaleMode.job'}}
+      {{t "formScale.scaleMode.job"}}
     </label>
   </div>
 {{else}}
   <div class="form-control-static">
     {{#if (eq scaleMode "deployment")}}
       <i class="icon icon-lg icon-service"></i>
-      {{t 'formScale.scaleMode.deploymentPrefix' scale=asInteger}}
+      {{t "formScale.scaleMode.deploymentPrefix" scale=asInteger}}
       {{#if editing}}
-        {{input-integer safeStyle="width: 60px; padding: 0 2px; display: inline-block" value=userInput min=1 max=max}}
+        {{input-integer
+          safeStyle="width: 60px; padding: 0 2px; display: inline-block"
+          value=userInput
+          min=min
+          max=max
+          nullable=true
+        }}
       {{else}}
         {{asInteger}}
       {{/if}}
-      {{t 'formScale.scaleMode.scaleSuffix' scale=asInteger}}
+      {{t "formScale.scaleMode.scaleSuffix" scale=asInteger}}
     {{else if (eq scaleMode "statefulSet")}}
       <i class="icon icon-lg icon-database"></i>
-      {{t 'formScale.scaleMode.statefulSetPrefix' scale=asInteger}}
+      {{t "formScale.scaleMode.statefulSetPrefix" scale=asInteger}}
       {{#if editing}}
-        {{input-integer safeStyle="width: 60px; padding: 0 2px; display: inline-block" value=userInput min=1 max=max}}
+        {{input-integer
+          safeStyle="width: 60px; padding: 0 2px; display: inline-block"
+          value=userInput
+          min=min
+          max=max
+        }}
       {{else}}
         {{asInteger}}
       {{/if}}
-      {{t 'formScale.scaleMode.scaleSuffix' scale=asInteger}}
+      {{t "formScale.scaleMode.scaleSuffix" scale=asInteger}}
     {{else if (eq scaleMode "replicaSet")}}
       <i class="icon icon-lg icon-service"></i>
-      {{t 'formScale.scaleMode.replicaSetPrefix' scale=asInteger}}
+      {{t "formScale.scaleMode.replicaSetPrefix" scale=asInteger}}
       {{#if editing}}
-        {{input-integer safeStyle="width: 60px; padding: 0 2px; display: inline-block" value=userInput min=min max=max}}
+        {{input-integer
+          safeStyle="width: 60px; padding: 0 2px; display: inline-block"
+          value=userInput
+          min=min
+          max=max
+        }}
       {{else}}
         {{asInteger}}
       {{/if}}
-      {{t 'formScale.scaleMode.scaleSuffix' scale=asInteger}}
+      {{t "formScale.scaleMode.scaleSuffix" scale=asInteger}}
     {{else if (eq scaleMode "replicationController")}}
       <i class="icon icon-lg icon-service"></i>
-      {{t 'formScale.scaleMode.replicationControllerPrefix' scale=asInteger}}
+      {{t "formScale.scaleMode.replicationControllerPrefix" scale=asInteger}}
       {{#if editing}}
-        {{input-integer safeStyle="width: 60px; padding: 0 2px; display: inline-block" value=userInput min=min max=max}}
+        {{input-integer
+          safeStyle="width: 60px; padding: 0 2px; display: inline-block"
+          value=userInput
+          min=min
+          max=max
+        }}
       {{else}}
         {{asInteger}}
       {{/if}}
-      {{t 'formScale.scaleMode.scaleSuffix' scale=asInteger}}
+      {{t "formScale.scaleMode.scaleSuffix" scale=asInteger}}
     {{else if (eq scaleMode "daemonSet")}}
       <i class="icon icon-lg icon-globe"></i>
-      {{t 'formScale.scaleMode.daemonSet'}}
+      {{t "formScale.scaleMode.daemonSet"}}
     {{else if (eq scaleMode "job")}}
-      <i class="icon icon-lg icon-file"></i>
-      {{t 'formScale.scaleMode.job'}}
+      <i class="icon icon-lg icon-file"></i>{{t "formScale.scaleMode.job"}}
     {{else if (eq scaleMode "cronJob")}}
       <i class="icon icon-lg icon-history"></i>
-      {{t 'formScale.scaleMode.cronJob'}}
+      {{t "formScale.scaleMode.cronJob"}}
       <div class="mt-10 ml-50 mr-50">
         {{#if editing}}
           {{input value=workload.cronJobConfig.schedule}}
         {{else}}
           {{workload.cronJobConfig.schedule}}
         {{/if}}
-        <p class="text-small text-muted">{{pretty-cron workload.cronJobConfig.schedule 'toString'}}</p>
+        <p class="text-small text-muted">
+          {{pretty-cron workload.cronJobConfig.schedule "toString"}}
+        </p>
       </div>
     {{else}}
       {{scaleMode}}?

--- a/lib/shared/addon/components/input-integer/component.js
+++ b/lib/shared/addon/components/input-integer/component.js
@@ -13,7 +13,8 @@ export function sanitize(val) {
 export default TextField.extend({
   layout,
 
-  editing: true,
+  editing:  true,
+  nullable: false,
 
   attributeBindings: ['pattern', 'inputmode'],
   pattern:           '[0-9]*',
@@ -53,17 +54,19 @@ export default TextField.extend({
     let num = parseInt(val, 10);
     let min = parseInt(this.get('min'), 10);
 
-    if ( !isNaN(num) && !isNaN(min) && num < min ) {
-      val = `${ min }`;
-    }
-
-    if ( !isNaN(num)) {
-      if (!isNaN(min) && num < min ) {
+    if (!this.nullable) {
+      if ( !isNaN(num) && !isNaN(min) && num < min ) {
         val = `${ min }`;
       }
-    } else {
-      if (!isNaN(min) && ( num < min || isNaN(num) )) {
-        val = `${ min }`;
+
+      if ( !isNaN(num)) {
+        if (!isNaN(min) && num < min ) {
+          val = `${ min }`;
+        }
+      } else {
+        if (!isNaN(min) && ( num < min || isNaN(num) )) {
+          val = `${ min }`;
+        }
       }
     }
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Pod scale minimum was incorrectly set to 1. This sets the default back
to 0. Adds a nullible flag to input-int as this is allowed in most cases
where we are using the component. Defaults to false.

Formatting fixes


<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#28168
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
