### PR TITLE
fix typo

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3397,7 +3397,7 @@ clusterNew:
         label: Scheduler
         tooltip: "The scheduler component manages when and where to run pods in your cluster."
       controllerManager:
-        label: Controller Manaager
+        label: Controller Manager
         tooltip: "The controller manager manages the core control loops that are shipped with Kubernetes."
       authenticator:
         label: Authenticator


### PR DESCRIPTION
This fixes a small typo in the new EKS provisioning UI