### PR TITLE
Fixed dropdown menues on touch devices (ipad)

### DIFF
--- a/app/styles/components/_page-header.scss
+++ b/app/styles/components/_page-header.scss
@@ -25,10 +25,6 @@ $project-nav-active: $dropdown-link-hover-bg !default;
     align-items: center;
 
     .ember-basic-dropdown-content {
-      body.touch & {
-        position: static;
-      }
-
       font-size:  15px;
     }
 

--- a/app/styles/layout/_medium.scss
+++ b/app/styles/layout/_medium.scss
@@ -243,8 +243,8 @@
   /* Class added via JS when toggled open */
   .nav-open {
     .nav-list {
-      max-height: 100vh;
-      height: 100vh;
+      max-height: none;
+      height: auto;
     }
   }
 
@@ -355,6 +355,10 @@
     .ember-basic-dropdown-content {
       width: inherit;
     }
+  }
+
+  .ember-basic-dropdown-content {
+    position: static;
   }
 
   .fixed-header-actions {


### PR DESCRIPTION
… drop down menues in mobile

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Overwriting position: absolute on .ember-basic-dropdown-content class is fine for the mobile menu, but makes the submenus unuseable on big screens, where the normal desktop page is rendered. Moved to _medium.scss so it's still present on small screens but doesn't effect big screen-touch devices like iPads.

Seconds change removes fixed height on mobile-menu. If you hold your phone horizontally and open the menu, dropdowns at the end (like Tools) aren't visible, because they are cut by the fixed size of 100vh (which is not very much in horizontal mode).


Types of changes
======

What types of changes does your code introduce to Rancher?
- Bugfix


Linked Issues
======

https://github.com/rancher/rancher/issues/27833
https://github.com/rancher/rancher/issues/23298

Further comments
======

If full height of the mobile menu (vertical) is wanted it should be added as min-height. But I don't see any need for it.

Tested on:
- iPad Pro (12,9")
- iPhone 11 Pro
- Google Pixel 3a
- macOS (Safari/Chrome)

