### PR TITLE
Ensure no exceptions are thrown when handling UI banners

### DIFF
--- a/lib/shared/addon/settings/service.js
+++ b/lib/shared/addon/settings/service.js
@@ -241,29 +241,46 @@ export default Service.extend(Evented, {
         showFooterBanner: false,
       });
     } else {
-      const parsedBanners = JSON.parse(uiBanners);
+      let parsedBanners = {}
 
-      if (isEmpty(parsedBanners.showHeader) || parsedBanners.showHeader.toLowerCase() === 'false') {
-        set(this, 'showHeaderBanner', false);
-      } else {
-        if (parsedBanners.showHeader.toLowerCase() === 'true') {
-          set(this, 'showHeaderBanner', true);
-        }
+      try {
+        parsedBanners = JSON.parse(uiBanners);
+      } catch {
+        // catch SyntaxError
+        setProperties(this, {
+          showHeaderBanner: false,
+          showFooterBanner: false,
+        });
+
+        return
       }
 
-      if (isEmpty(parsedBanners.showFooter) || parsedBanners.showFooter.toLowerCase() === 'false') {
+      if (isEmpty(parsedBanners.showHeader) || typeof parsedBanners.showHeader !== 'string' || parsedBanners.showHeader.toLowerCase() !== 'true') {
+        set(this, 'showHeaderBanner', false);
+      } else {
+        set(this, 'showHeaderBanner', true);
+      }
+
+      if (isEmpty(parsedBanners.showFooter) || typeof parsedBanners.showFooter !== 'string' || parsedBanners.showFooter.toLowerCase() !== 'true') {
         set(this, 'showFooterBanner', false);
       } else {
-        if (parsedBanners.showFooter.toLowerCase() === 'true') {
-          set(this, 'showFooterBanner', true);
-        }
+        set(this, 'showFooterBanner', true);
       }
     }
   }),
 
   bannerContent: computed('uiBanners.@each.{banner}', 'showHeaderBanner', 'showFooterBanner', function() {
-    const uiBanners = get(this, 'uiBanners') ? JSON.parse(get(this, 'uiBanners')) : {};
-    const banner = get(uiBanners, 'banner');
+    const uiBanners = get(this, 'uiBanners');
+
+    let parsedBanners = {}
+
+    try {
+      parsedBanners = JSON.parse(uiBanners);
+    } catch {
+      // catch SyntaxError
+    }
+
+    const banner = get(parsedBanners, 'banner');
 
     if (!isEmpty(banner)) {
       return banner;


### PR DESCRIPTION
Proposed changes
======
Any exceptions during JSON parsing of `ui-banners` setting are now handled; `showHeaders`/`showFooters` fields are checked for being a string; logic was slightly consolidated.

Types of changes
======
Bugfix to prevent being locked out of the UI when an invalid `ui-banners` setting is present.

Linked Issues
======
- rancher/rancher#28504

Further comments
======
An explored alternative was enforcing server-side validation of this setting. However, it appears settings in general do not have validation tied to them, requiring this fail-safe UI approach instead.
