### PR TITLE
Adding custom field to the simple expire and converting to ms

### DIFF
--- a/app/components/modal-edit-apikey/template.hbs
+++ b/app/components/modal-edit-apikey/template.hbs
@@ -128,6 +128,37 @@
               {{t "editApiKey.ttl.year"}}
             </label>
           </div>
+          <div class="radio">
+            <label>
+              {{radio-button
+                selection=expire
+                value="custom"
+              }}&nbsp;
+              {{t "editApiKey.ttl.custom"}} - {{ttlCustomMin}}
+              {{input-number
+                disabled=(not (eq expire "custom"))
+                min=0
+                max=ttlCustomMax
+                classNames="form-control inline-block initial-width"
+                value=customTTL
+              }}
+              <select
+                disabled={{not (eq expire "custom")}}
+                style="width: 100px"
+                class="form-control inline-block"
+                onchange={{action (mut ttlUnit) value="target.value"}}
+              >
+                {{#each ttlUnitOptions as |ttlUnitOption|}}
+                  <option
+                    value="{{ttlUnitOption}}"
+                    selected={{eq ttlUnit ttlUnitOption}}
+                  >
+                    {{ttlUnitOption}}
+                  </option>
+                {{/each}}
+              </select>
+            </label>
+          </div>
         {{else}}
           <div class="radio">
             <label>


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
- We wanted to allow users to enter a custom date when there isn't a default ttl
- We also wanted to switch from minites to ms to be consistent with the past



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

Linked Issues
======
rancher/rancher#28678

![Screen Shot 2020-09-01 at 1 05 00 PM](https://user-images.githubusercontent.com/55104481/91900689-e2d0d900-ec53-11ea-8634-878489358a36.png)
