### PR TITLE
Suppress exceptions when parsing JSON settings, default to raw value

### DIFF
--- a/lib/shared/addon/components/settings/danger-zone/component.js
+++ b/lib/shared/addon/components/settings/danger-zone/component.js
@@ -69,9 +69,17 @@ export default Component.extend({
       }
 
       if (get(details, 'kind') === 'json') {
+        let settingValue = out.get('obj.value')
+
+        try {
+          settingValue = JSON.stringify(JSON.parse(settingValue), undefined, 2)
+        } catch {
+          // catch SyntaxError
+        }
+
         setProperties(out, {
           hide:       true,
-          parsedJSON: JSON.stringify(JSON.parse(out.get('obj.value')), undefined, 2),
+          parsedJSON: settingValue,
         });
       }
 


### PR DESCRIPTION
Proposed changes
======
In settings `danger-zone` component, suppress exceptions when parsing JSON settings, defaulting to raw value on any failure.

Types of changes
======
Bugfix

Linked Issues
======
https://github.com/rancher/rancher/issues/28504

Further comments
======
Resolves error missed by #4136, implements approach proposed in https://github.com/rancher/rancher/issues/28504#issuecomment-685967570. 
