### PR TITLE
Forward port EC2 Node Template KMS Keys Error Handling

### DIFF
--- a/lib/nodes/addon/components/driver-amazonec2/component.js
+++ b/lib/nodes/addon/components/driver-amazonec2/component.js
@@ -3,7 +3,7 @@ import { scheduleOnce } from '@ember/runloop';
 import EmberObject, {
   observer, computed, get, set, setProperties
 } from '@ember/object';
-import { Promise, resolve, reject } from 'rsvp';
+import { Promise, resolve } from 'rsvp';
 import { alias, equal } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
@@ -47,8 +47,9 @@ export default Component.extend(NodeDriver, {
     this._super(...arguments);
 
     setProperties(this, {
+      allKmsKeys: [],
+      allSubnets: [],
       clients:    {},
-      allSubnets: []
     });
 
     let cur = get(this, 'config.securityGroup');
@@ -474,16 +475,12 @@ export default Component.extend(NodeDriver, {
 
       return resolve(set(this, 'allKmsKeys', kmsKeys));
     } catch (err) {
-      if (err && err.name === 'UnknownError' && err.message === '502') {
-        // KMS keys are limited by permissions so if we can't list them we should show an input instead of failing.
-        set(this, 'loadFailedKmsKeys', true);
+      console.warn('Unable to load KMS Keys.', err); // eslint-disable-line
+      // node template owners MAY not have access to KMS keys via IAM so dont kill everything because they dont
+      // its not required
+      set(this, 'loadFailedKmsKeys', true);
 
-        return resolve();
-      }
-
-      get(this, 'errors').pushObject(err);
-
-      return reject(false, err);
+      return resolve();
     }
   },
 

--- a/lib/nodes/addon/components/driver-amazonec2/template.hbs
+++ b/lib/nodes/addon/components/driver-amazonec2/template.hbs
@@ -364,21 +364,18 @@
             <label class="acc-label">
               {{t "clusterNew.amazoneks.secretsEncryption.kmsHelpLabel"}}
             </label>
+            {{searchable-select
+              classNames="form-control"
+              optionValuePath="KeyArn"
+              optionLabelPath="KeyArn"
+              content=allKmsKeys
+              value=(mut config.kmsKey)
+              allowCustom=true
+            }}
             {{#if loadFailedKmsKeys}}
-              <Input
-                @type="text"
-                value={{mut config.kmsKey}}
-                @classNames="form-control"
-              />
-            {{else}}
-              <NewSelect
-                class="form-control"
-                @value={{mut config.kmsKey}}
-                @content={{allKmsKeys}}
-                @useContentForDefaultValue={{true}}
-                @optionValuePath="KeyArn"
-                @optionLabelPath="KeyArn"
-              />
+              <p class="help-block text-warning">
+                {{t "clusterNew.amazoneks.secretsEncryption.failure"}}
+              </p>
             {{/if}}
           </div>
         </div>

--- a/lib/shared/addon/components/searchable-select/component.js
+++ b/lib/shared/addon/components/searchable-select/component.js
@@ -376,7 +376,11 @@ export default Component.extend({
       if (kc === C.KEY.CR || kc === C.KEY.LF) {
         event.preventDefault();
 
-        const $activeTarget = get(this, '$activeTarget');
+        let $activeTarget = get(this, '$activeTarget');
+
+        if (!$activeTarget) {
+          $activeTarget = this.$(this.element).find('.searchable-options > .searchable-option:first-child')
+        }
 
         if ($activeTarget) {
           // activeTarget is prompt

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3353,6 +3353,7 @@ clusterNew:
       disabled: None
       kms: "KMS Key: Select or Enter KMS Key that will be used to encrypt secrets"
       kmsHelpLabel: KMS Key ARN
+      failure: There was a problem loading KMS Encryption keys but you may still enter a KeyARN if you know it.
     tags:
       label: Tags
       addActionLabel: Add Tag


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Handles the loadKmsKeys call more generically. Prior to this we only displayed the text input for kms keys if the call failed in a specific way but that was too specific. The KMS encryption is not required to create the template so there is no need to throw an error and stop the user from proceeding should the call fail.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#28719
rancher/rancher#28724
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
![Screen Shot 2020-09-03 at 9 26 05 AM](https://user-images.githubusercontent.com/858614/92141698-a4f4c180-edc7-11ea-9532-57429c5ec50a.png)
![Screen Shot 2020-09-03 at 9 17 00 AM](https://user-images.githubusercontent.com/858614/92141703-a7571b80-edc7-11ea-8067-854ec126109c.png)

<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
