### PR TITLE
EKS V2 Clusters Syncing & Save

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -705,7 +705,6 @@ export default Resource.extend(Grafana, ResourceUsage, {
       const nodeGroupConfigSpec = get(this, 'globalStore').getById('schema', 'nodegroup');
 
       if (isEmpty(this.id)) {
-
         replaceNullWithEmptyDefaults(get(this, 'eksConfig'), get(eksClusterConfigSpec, 'resourceFields'));
 
         if (!isEmpty(get(this, 'eksConfig.nodeGroups'))) {
@@ -798,9 +797,9 @@ export default Resource.extend(Grafana, ResourceUsage, {
       } catch (e){}
 
       if (k === 'nodeGroups') {
-        if (!isEmpty(lhsMatch)) {
+        if (!isEmpty(rhsMatch)) {
           // node groups need ALL data so short circut and send it all
-          set(delta, k, lhsMatch);
+          set(delta, k, rhsMatch);
         } else {
           // all node groups were deleted
           set(delta, k, []);

--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -675,7 +675,10 @@ export default Resource.extend(Grafana, ResourceUsage, {
       return this._super(...arguments);
     }
 
-    // this is NOT a generic object diff. It tries to be as generic as possible but it does interface with specific Ids that generic objs may not have
+    // this is NOT a generic object diff.
+    // It tries to be as generic as possible but it does make certain assumptions regarding nulls and emtpy arrays/objects
+    // if LHS (upstream) is null and RHS (eks config) is empty we do not count this as a change
+    // additionally null values on the RHS will be ignored as null cant be sent in this case
     function diff(lhs, rhs) {
       const delta = {};
       const rhsKeys = Object.keys(rhs);

--- a/lib/shared/addon/components/cluster-driver/driver-eks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-eks/component.js
@@ -18,12 +18,34 @@ import layout from './template';
 const DEFAULT_NODE_GROUP_CONFIG = {
   desiredSize:   2,
   diskSize:      20,
+  ec2SshKey:     '',
   gpu:           false,
   instanceType:  't3.medium',
   maxSize:       2,
   minSize:       2,
   nodegroupName: '',
+  subnets:       [],
   type:          'nodeGroup',
+};
+
+const DEFAULT_EKS_CONFIG = {
+  amazonCredentialSecret: '',
+  displayName:            '',
+  imported:               false,
+  kmsKey:                 '',
+  kubernetesVersion:      '',
+  loggingTypes:           [],
+  nodeGroups:             [],
+  privateAccess:          false,
+  publicAccess:           true,
+  publicAccessSources:    [],
+  region:                 'us-west-2',
+  secretsEncryption:      false,
+  securityGroups:         [],
+  serviceRole:            '',
+  subnets:                [],
+  tags:                   {},
+  type:                   'eksclusterconfigspec',
 };
 
 export default Component.extend(ClusterDriver, {
@@ -84,16 +106,10 @@ export default Component.extend(ClusterDriver, {
       const kubernetesVersion = this.kubernetesVersionContent.firstObject;
 
       set(ngConfig, 'version', kubernetesVersion);
+      set(DEFAULT_EKS_CONFIG, 'kubernetesVersion', kubernetesVersion);
+      set(DEFAULT_EKS_CONFIG, 'nodeGroups', [this.globalStore.createRecord(ngConfig)]);
 
-      config = this.globalStore.createRecord({
-        kubernetesVersion,
-        privateAccess:       false,
-        publicAccess:        true,
-        region:              'us-west-2',
-        type:                'eksclusterconfigspec',
-        nodeGroups:          [this.globalStore.createRecord(ngConfig)],
-        kmsKey:              ''
-      });
+      config = this.globalStore.createRecord(DEFAULT_EKS_CONFIG);
 
       if (!isEmpty(cloudCredentials)) {
         const singleMatch = cloudCredentials.find((cc) => {
@@ -361,12 +377,18 @@ export default Component.extend(ClusterDriver, {
 
   versionChoices: computed('kubernetesVersionContent', function() {
     const {
-      config : { kubernetesVersion: initialVersion },
+      config,
       intl,
       kubernetesVersionContent,
       mode,
     } = this;
-    const versionChoices = this.versionChoiceService.parseCloudProviderVersionChoices(kubernetesVersionContent.slice(), initialVersion, mode);
+    let { kubernetesVersion: initialVersion } = config;
+
+    if (isEmpty(initialVersion)) {
+      initialVersion = kubernetesVersionContent[0];
+    }
+
+    const  versionChoices = this.versionChoiceService.parseCloudProviderVersionChoices(kubernetesVersionContent.slice(), initialVersion, mode);
 
     // only EKS and edit - user can only upgrade a single minor version at a time
     if (this.editing) {
@@ -473,11 +495,13 @@ export default Component.extend(ClusterDriver, {
     const ourClusterSpec = get(originalCluster, 'eksConfig')
     const upstreamSpec = get(originalCluster, 'eksStatus.upstreamSpec');
 
-    Object.keys(ourClusterSpec).forEach((k) => {
-      if (isEmpty(get(ourClusterSpec, k)) && !isEmpty(get(upstreamSpec, k))) {
-        set(this, `config.${ k }`, get(upstreamSpec, k));
-      }
-    });
+    if (!isEmpty(upstreamSpec)) {
+      Object.keys(ourClusterSpec).forEach((k) => {
+        if (isEmpty(get(ourClusterSpec, k)) && !isEmpty(get(upstreamSpec, k))) {
+          set(this, `config.${ k }`, get(upstreamSpec, k));
+        }
+      });
+    }
   },
 
   authCreds() {
@@ -656,20 +680,11 @@ export default Component.extend(ClusterDriver, {
       {
         displayName,
         subnets,
-        nodeGroups
       }
     } = this;
 
     if (isEmpty(subnets)) {
       set(this, 'config.subnets', []);
-    }
-
-    if (!isEmpty(nodeGroups)) {
-      nodeGroups.forEach((ng) => {
-        if (isEmpty(ng.ec2SshKey)) {
-          delete ng.ec2SshKey; // key is taken literally, meaning '' will be a "valid" key, so if its empty just be safe and drop the key
-        }
-      });
     }
 
     if (isEmpty(displayName) || displayName === '(null)') {

--- a/lib/shared/addon/components/cluster-driver/driver-eks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-eks/component.js
@@ -14,39 +14,7 @@ import ClusterDriver from 'shared/mixins/cluster-driver';
 import { EKS_REGIONS, EKS_VERSIONS, INSTANCE_TYPES, nameFromResource } from 'shared/utils/amazon';
 import { randomStr } from 'shared/utils/util';
 import layout from './template';
-
-const DEFAULT_NODE_GROUP_CONFIG = {
-  desiredSize:   2,
-  diskSize:      20,
-  ec2SshKey:     '',
-  gpu:           false,
-  instanceType:  't3.medium',
-  maxSize:       2,
-  minSize:       2,
-  nodegroupName: '',
-  subnets:       [],
-  type:          'nodeGroup',
-};
-
-const DEFAULT_EKS_CONFIG = {
-  amazonCredentialSecret: '',
-  displayName:            '',
-  imported:               false,
-  kmsKey:                 '',
-  kubernetesVersion:      '',
-  loggingTypes:           [],
-  nodeGroups:             [],
-  privateAccess:          false,
-  publicAccess:           true,
-  publicAccessSources:    [],
-  region:                 'us-west-2',
-  secretsEncryption:      false,
-  securityGroups:         [],
-  serviceRole:            '',
-  subnets:                [],
-  tags:                   {},
-  type:                   'eksclusterconfigspec',
-};
+import { DEFAULT_NODE_GROUP_CONFIG, DEFAULT_EKS_CONFIG } from 'ui/models/cluster';
 
 export default Component.extend(ClusterDriver, {
   intl:                 service(),

--- a/lib/shared/addon/components/cluster-driver/driver-eks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-eks/component.js
@@ -109,6 +109,8 @@ export default Component.extend(ClusterDriver, {
 
       set(this, 'cluster.eksConfig', config);
     } else {
+      this.syncUpstreamConfig();
+
       const initalTags = { ...( config.tags || {} ) };
 
       set(this, 'initalTags', initalTags);
@@ -466,6 +468,18 @@ export default Component.extend(ClusterDriver, {
     return disabled;
   }),
 
+  syncUpstreamConfig() {
+    const originalCluster = get(this, 'model.originalCluster')
+    const ourClusterSpec = get(originalCluster, 'eksConfig')
+    const upstreamSpec = get(originalCluster, 'eksStatus.upstreamSpec');
+
+    Object.keys(ourClusterSpec).forEach((k) => {
+      if (isEmpty(get(ourClusterSpec, k)) && !isEmpty(get(upstreamSpec, k))) {
+        set(this, `config.${ k }`, get(upstreamSpec, k));
+      }
+    });
+  },
+
   authCreds() {
     let {
       config: {
@@ -663,6 +677,12 @@ export default Component.extend(ClusterDriver, {
     }
 
     return this._super(...arguments);
+  },
+
+  doSave(opt) {
+    return get(this, 'primaryResource').save(opt).then((newData) => {
+      return this.mergeResult(newData);
+    });
   },
 
 });

--- a/lib/shared/addon/components/node-group-row/component.js
+++ b/lib/shared/addon/components/node-group-row/component.js
@@ -4,6 +4,7 @@ import { INSTANCE_TYPES } from 'shared/utils/amazon';
 import { get, set, observer, computed } from '@ember/object';
 import { on } from '@ember/object/evented';
 import { equal } from '@ember/object/computed';
+import { isEmpty } from '@ember/utils';
 
 export default Component.extend({
   layout,
@@ -17,7 +18,18 @@ export default Component.extend({
   model:         null,
   versions:      null,
 
+  nameIsEditable: true,
+
   editing:       equal('mode', 'edit'),
+  init() {
+    this._super(...arguments);
+
+    if (this.editing) {
+      if (!isEmpty(this.model.nodegroupName)) {
+        set(this, 'nameIsEditable', false);
+      }
+    }
+  },
   actions: {
     setTags(section) {
       set(this, 'model.tags', section);

--- a/lib/shared/addon/components/node-group-row/template.hbs
+++ b/lib/shared/addon/components/node-group-row/template.hbs
@@ -16,11 +16,16 @@
         <label class="acc-label">
           {{t "nodeGroupRow.name.label"}}
         </label>
-        <Input
-          @type="text"
-          @value={{mut model.nodegroupName}}
-          @classNames="form-control"
-        />
+        {{#input-or-display
+          editable=nameIsEditable
+          value=model.nodegroupName
+        }}
+          <Input
+            @type="text"
+            @value={{mut model.nodegroupName}}
+            @classNames="form-control"
+          />
+        {{/input-or-display}}
       </div>
       <div class="col span-6">
         <label class="acc-label">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3334,6 +3334,8 @@ clusterNew:
     none: No policies are defined
     required: A Default Pod Security Policy is required when support is enabled.
   amazoneks:
+    errors:
+      clusterSpec: 'Unable to parse the clusters upstream spec. Is the cluster ready?'
     label: Amazon Elastic Container Service for Kubernetes
     shortLabel: Amazon EKS
     ingressWarning: "Note: Currently Amazon EKS will not create an ingress controller when launching a new cluster. If you need this functionality you will have to create an ingress controller manually after cluster creation."
@@ -5825,14 +5827,14 @@ editApiKey:
     day: A day from now
     month: A month from now
     year: A year from now
-    max: 
+    max:
       label: "{time} - Maximum allowed"
       unit:
         minutes: "{count, plural, =1 {# Minute} other {# Minutes}}"
-        hours: "{count, plural, =1 {# Hour} other {# Hours}}" 
+        hours: "{count, plural, =1 {# Hour} other {# Hours}}"
         days: "{count, plural, =1 {# Day} other {# Days}}"
         years: "{count, plural, =1 {# Year} other {# Years}}"
-        
+
     custom: Custom
   description:
     placeholder: "Optional: e.g. This key is used by the app servers to deploy containers"


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
To add support for syncing between EKS and Rancher both ways the backend has made changes to the way we save clusters on edit. 

When we initialize the EKS cluster component we'll first sync the contents of the upstream spec on to our eks config giving us the synced state. 

When we save the cluster, if the driver is EKS we'll loop through the EKS config, identifying and creating a new delta of only the changed fields by comparing the config to the upstream spec. 

Additionally we must preserve empty arrays and empty maps, so i've made every attempt to distinguish these between actually empty arrays and objects and null values in the upstream vs initialized empty arrays and objects that must exist for UI components to work. For example, the key value component that is used to facilitate tag entries requires an empty object to function, not null or undefined. So if a user edits a cluster that doesn't have any tags the upstream value would be `null` but on save the UI cluster model would have an empty object for the tags key. This would normally be reported as a diff in most JS object comparison libs. But since the upstream value is null and we have an empty array/object we'll just omit the key as unchanged.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Enhancement
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#28541

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
