### PR TITLE
AKS only works with lowercase "calico"

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-azureaks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-azureaks/component.js
@@ -18,7 +18,7 @@ import {
   aksRegions,
 } from 'ui/utils/azure-choices';
 
-const NETWORK_POLICY = ['Calico']
+const NETWORK_POLICY = ['calico']
 const CHINA_REGION_API_URL = 'https://management.chinacloudapi.cn/';
 const CHINA_REGION_AUTH_URL = 'https://login.chinacloudapi.cn/';
 const NETWORK_PLUGINS = [


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
UI is passing `Calico` to the azure command for AKS and it's not working, but when you us `calico` it works. 

Types of changes
======

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
https://github.com/rancher/rancher/issues/26710

Further comments
======
I haven't tested it but it's currently broken so this seems better than nothing. :) 