### PR TITLE
[2.5] cosmetic: template dropdown full width consistent across all breakpoints

### DIFF
--- a/lib/global-admin/addon/components/new-multi-cluster-app/template.hbs
+++ b/lib/global-admin/addon/components/new-multi-cluster-app/template.hbs
@@ -357,7 +357,7 @@
       {{#if previewOpen}}
         <div class="tabs">
           <div class="tab-header row">
-            <div class="col span-4">
+            <div>
               <label class="acc-label">{{t "newMultiClusterApp.templateFiles"}}</label>
               {{searchable-select
                 content=filenames


### PR DESCRIPTION
Proposed changes
======
Cosmetic request

There is a feature in Rancher UI, not sure what the correct name is -- I'm calling it the 'chart preview' feature. It can be found by navigating from the main menu **Apps->Launch->Chart->PREVIEW** and looks like this:
![image](https://user-images.githubusercontent.com/182515/93020680-a8195a00-f5de-11ea-8646-53d30f20356f.png)

This feature can be a convenient way to quickly evaluate new charts. 👍 

With that said, I'm seeing some cosmetic behavior that could be better - a "quality of life" opportunity having to do with the its responsiveness currently works.

I'm seeing that at smaller browser window widths (breakpoints) this dropdown presents at full width, but at higher widths (e.g. MBP16" maximized browser window for one example) the current [classes](https://github.com/rancher/ui/blob/3c711f751829946eca72131efb1f1df47f1b94d1/lib/global-admin/addon/components/new-multi-cluster-app/template.hbs#L360) constrain the dropdown to 33% of the width of the parent div.

<details>
  <summary>Example</summary>

  ![breakpoint](https://user-images.githubusercontent.com/182515/93020811-ab611580-f5df-11ea-8b01-af00f4a2e479.gif)
</details>

With certain larger charts it can become an annoying default, most obviously when the chart in question has a lot going on (e.g. [sentry](https://github.com/sentry-kubernetes/charts/tree/5.1.0)).

This is my first contribution to Rancher, I read through the [wiki](https://github.com/rancher/rancher/wiki/Rancher-2.5) and I think I'm on track, but but apologies if I missed something. At least in my anecdotal testing on Chrome Canary/macOS, it seems removing these classes restores things back to what I'd consider a 'normal' situation.

With the rise of Helm into a CNCF [graduated status](https://www.cncf.io/announcement/2020/04/30/cloud-native-computing-foundation-announces-helm-graduation/), it seems likely Helm charts will only grow in adoption and size. I hope you consider including this PR so future Rancher users benefit from a more convenient UX as they evaluate larger Helm charts. Thanks for your consideration.

Types of changes
======
 - Cosmetic tweak

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<details>
<summary>Before</summary>

![before](https://user-images.githubusercontent.com/182515/93020358-d5650880-f5dc-11ea-8859-7c873a01e6ea.gif)
</details>

<details>
  <summary>After</summary>

  ![after](https://user-images.githubusercontent.com/182515/93020394-14935980-f5dd-11ea-827a-e5586fbf9e4e.gif)
</details>

