### PR TITLE
Correct the value of ec2SshKey to be an empty string instead of null

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -693,9 +693,7 @@ export default Resource.extend(Grafana, ResourceUsage, {
   },
 
   save(opt) {
-    const eksConfig = get(this, 'eksConfig');
-
-    if (get(this, 'driver') === 'EKS' || (this.isObject(eksConfig) && !this.isEmptyObject(eksConfig))) {
+    if (get(this, 'driver') === 'EKS' || (this.isObject(get(this, 'eksConfig')) && !this.isEmptyObject(get(this, 'eksConfig')))) {
       const options = ({
         ...opt,
         data: {


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
For some reason the local variable eksConfig is undefined when
not running locally but the value is present on 'this'. I'm attempting
to just use the eksConfig attached to 'this.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
https://github.com/rancher/rancher/issues/28541#event-3770683823

Further comments
======
Since this wasn't reproducible locally I verified this using https://releases.rancher.com/ui/eks-config-undefined/index.html

I'm assuming that this is a bundling issue but I'm not positive. If you have any other ideas so that we don't run into this in the future I'm willing to go down another route.
