### PR TITLE
Changing the implementation of isObject.

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -898,14 +898,15 @@ export default Resource.extend(Grafana, ResourceUsage, {
     return delta;
   },
 
+  /**
+   * True if obj is a plain object, an instantiated function/class
+   * @param {anything} obj
+   */
   isObject(obj) {
-    if ( !obj || !obj.constructor || !obj.constructor.name ) {
-      return false;
-    }
-
-    const name = obj.constructor.name;
-
-    return name === 'Object' || name === 'Class';
+    return obj                   // Eliminates null/undefined
+      && obj instanceof Object   // Eliminates primitives
+      && typeof obj === 'object' // Eliminates class definitions/functions
+      && !Array.isArray(obj);    // Eliminates arrays
   },
 
   isEmptyObject(obj) {


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The constructor name used within isObject was having it's value changed in production which caused the equality checks to fail.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
https://github.com/rancher/rancher/issues/28541

I verified with https://releases.rancher.com/ui/eks-config-undefined-2/index.html using the build command
`./scripts/build-static -u -f -s -v eks-config-undefined-5`.

I saw that by default ec2SshKey was set to empty string and when I selected a value it would still be assigned when creating a cluster. I do not know the best way to verify the diffing portion.

<img width="770" alt="Screen Shot 2020-09-15 at 7 30 24 PM" src="https://user-images.githubusercontent.com/55104481/93285723-69280780-f78a-11ea-943f-29502126b70a.png">
<img width="765" alt="Screen Shot 2020-09-15 at 7 29 40 PM" src="https://user-images.githubusercontent.com/55104481/93285725-6a593480-f78a-11ea-8224-85be8f574e0b.png">


