### PR TITLE
A tenancy should be a valid compartment (main)

### DIFF
--- a/lib/nodes/addon/components/driver-oci/component.js
+++ b/lib/nodes/addon/components/driver-oci/component.js
@@ -74,7 +74,7 @@ export default Component.extend(NodeDriver, {
     let compartment = get(this, 'config.nodeCompartmentId');
 
     if (token !== null && token !== '' && compartment !== null && compartment !== ''
-    && compartment.startsWith('ocid1.compartment')) {
+    && (compartment.startsWith('ocid1.compartment') || compartment.startsWith('ocid1.tenancy'))) {
       const auth = {
         type:  'cloud',
         token
@@ -99,7 +99,7 @@ export default Component.extend(NodeDriver, {
     let compartment = get(this, 'config.nodeCompartmentId');
 
     if (token !== null && token !== '' && compartment !== null && compartment !== ''
-    && compartment.startsWith('ocid1.compartment')) {
+    && (compartment.startsWith('ocid1.compartment') || compartment.startsWith('ocid1.tenancy'))) {
       const auth = {
         type:  'cloud',
         token
@@ -180,7 +180,10 @@ export default Component.extend(NodeDriver, {
     if (!get(this, 'config.nodeShape')) {
       errors.push('Specifying a oci node shape is required');
     }
-    if (!get(this, 'config.nodeCompartmentId') || !get(this, 'config.nodeCompartmentId').startsWith('ocid1.compartment')) {
+    if (!get(this, 'config.nodeCompartmentId')) {
+      errors.push('Specifying an oci node compartment is required');
+    }
+    if (!get(this, 'config.nodeCompartmentId').startsWith('ocid1.compartment') && !get(this, 'config.nodeCompartmentId').startsWith('ocid1.tenancy')) {
       errors.push('Specifying a valid oci node compartment is required');
     }
     if (!get(this, 'config.nodeAvailabilityDomain')) {
@@ -189,7 +192,7 @@ export default Component.extend(NodeDriver, {
     if (!get(this, 'config.vcnCompartmentId')) {
       set(this, 'config.vcnCompartmentId', get(this, 'config.nodeCompartmentId'));
     } else {
-      if (!get(this, 'config.vcnCompartmentId').startsWith('ocid1.compartment')) {
+      if (!get(this, 'config.vcnCompartmentId').startsWith('ocid1.compartment') && !get(this, 'config.vcnCompartmentId').startsWith('ocid1.tenancy')) {
         errors.push('Specifying a valid oci VCN compartment is required');
       }
     }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This change updates the (JavaScript) validation logic to allow the tenancy to be used as a valid compartment since it is technically the 'root compartment'.

The driver nor the OCI platform have issues provisioning a compute nodes to the root compartment / tenancy. Therefore, we should loosen up the overly restrictive validation. 

<!-- 
What types of changes does your code introduce to Rancher?
-->
Types of changes
======

- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======

[Here](https://github.com/rancher-plugins/rancher-machine-driver-oci/issues/3)


Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
Backwards compatible change.

Backport to 2.4 forthcoming.