### PR TITLE
Dashboard integration

### DIFF
--- a/app/update-password/controller.js
+++ b/app/update-password/controller.js
@@ -19,7 +19,8 @@ export default Controller.extend({
   init() {
     this._super(...arguments);
     set(this, 'showCurrent', !get(this, 'access.userCode.password'));
-    set(this, 'landing', get(this, `setting.${ C.SETTING.UI_DEFAULT_LANDING }`));
+    // set(this, 'landing', get(this, `setting.${ C.SETTING.UI_DEFAULT_LANDING }`));
+    set(this, 'landing', 'ember');
   },
 
   actions: {
@@ -37,7 +38,7 @@ export default Controller.extend({
   }),
 
   currentPassword: computed('', function() {
-    return get(this, 'access.userCode.password') || null;
+    return get(this, 'access.userCode.password') || (this.firstLogin ? 'admin' : null);
   }),
 
   complete(success) {
@@ -50,8 +51,8 @@ export default Controller.extend({
 
         get(this, 'settings').set(C.SETTING.TELEMETRY, value);
         get(this, 'settings').set(C.SETTING.EULA_AGREED, (new Date()).toISOString());
-        get(this, 'settings').set(C.SETTING.UI_DEFAULT_LANDING, landing);
-        get(this, 'prefs').set(C.PREFS.LANDING, landing);
+        // get(this, 'settings').set(C.SETTING.UI_DEFAULT_LANDING, landing);
+        // get(this, 'prefs').set(C.PREFS.LANDING, landing);
       }
 
       get(this, 'access').set('firstLogin', false);

--- a/app/update-password/template.hbs
+++ b/app/update-password/template.hbs
@@ -19,21 +19,23 @@
       cancelDisabled=true
   }}
     {{#if firstLogin}}
-      <hr/>
-      <h3 class="mt-20 text-left">{{t 'modalEditPassword.firstLogin.setView'}}</h3>
-      <div class="image-radio-container mt-20">
-        <div class="image-radio">
-          <button class="{{if (eq landing 'ember') 'checked' ''}}" type="button" {{action "setView" "ember" }}>
-            <img src="{{app.baseAssets}}assets/images/cluster-multi.svg"/>
-          </button>
-          <p class="text-muted text-small">{{t "landingPage.emberLong" }}</p>
-        </div>
+      <div class="hide">
+        <hr/>
+        <h3 class="mt-20 text-left">{{t 'modalEditPassword.firstLogin.setView'}}</h3>
+        <div class="image-radio-container mt-20">
+          <div class="image-radio">
+            <button class="{{if (eq landing 'ember') 'checked' ''}}" type="button" {{action "setView" "ember" }}>
+              <img src="{{app.baseAssets}}assets/images/cluster-multi.svg"/>
+            </button>
+            <p class="text-muted text-small">{{t "landingPage.emberLong" }}</p>
+          </div>
 
-        <div class="image-radio">
-          <button class="{{if (eq landing 'vue') 'checked' ''}}" type="button" {{action "setView" "vue" }}>
-            <img src="{{app.baseAssets}}assets/images/cluster-single.svg"/>
-          </button>
-          <p class="text-muted text-small">{{t "landingPage.vueLong" }}</p>
+          <div class="image-radio">
+            <button class="{{if (eq landing 'vue') 'checked' ''}}" type="button" {{action "setView" "vue" }}>
+              <img src="{{app.baseAssets}}assets/images/cluster-single.svg"/>
+            </button>
+            <p class="text-muted text-small">{{t "landingPage.vueLong" }}</p>
+          </div>
         </div>
       </div>
 
@@ -42,7 +44,7 @@
         <label class="text-small">{{input type="checkbox" checked=model.optIn}} {{t 'telemetryOpt.label'}}</label> <a href="{{settings.docsBase}}/faq/telemetry" class="text-small" target="_blank" rel="noopener nofollow">{{t 'telemetryOpt.learnMore.label'}}</a>
       </div>
       <div>
-        <label class="text-small">{{input type="checkbox" checked=agreedToEula}} {{t 'telemetryOpt.eula.prefix' appName=settings.appName}} <a href="{{settings.eulaLink}}" target="_blank" rel="noopener nofollow">{{t 'telemetryOpt.eula.link' appName=settings.appName}}</a> {{t 'telemetryOpt.eula.suffix' appName=settings.appName}}</label>
+        <label class="text-small">{{input type="checkbox" checked=agreedToEula}} {{t 'telemetryOpt.eula.prefix' appName=settings.appName}} <a href="{{settings.eulaLink}}" target="_blank" rel="noopener nofollow">{{t 'telemetryOpt.eula.link' appName=settings.appName}}</a> {{t 'telemetryOpt.eula.suffix' appName=settings.appName}}{{field-required}}</label>
       </div>
     {{/if}}
   {{/input-edit-password}}

--- a/lib/global-admin/addon/clusters/index/controller.js
+++ b/lib/global-admin/addon/clusters/index/controller.js
@@ -42,6 +42,13 @@ const headers = [
     sort:           ['memoryUsage', 'name'],
     translationKey: 'clustersPage.memory.label',
     width:          125,
+  },
+  {
+    name:        'explorer',
+    searchField: false,
+    sort:        false,
+    label:       '',
+    width:       100,
   }
 ];
 
@@ -82,6 +89,7 @@ export default Controller.extend({
         authenticated.send('switchProject', model.get('defaultProject.id'), 'authenticated.host-templates', [model.id, { queryParams: { backTo: 'clusters' } }]);
       }
     },
+
     useKubernetes(model) {
       let authenticated = getOwner(this).lookup('route:authenticated');
 

--- a/lib/global-admin/addon/components/cluster-row/component.js
+++ b/lib/global-admin/addon/components/cluster-row/component.js
@@ -1,7 +1,9 @@
 import Component from '@ember/component';
 import layout from './template';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
+  scope:   service(),
   layout,
   model:    null,
   tagName:  '',

--- a/lib/global-admin/addon/components/cluster-row/template.hbs
+++ b/lib/global-admin/addon/components/cluster-row/template.hbs
@@ -110,6 +110,9 @@
       {{/if}}
     </td>
   {{/if}}
+  <td class="text-right">
+    <a class="btn btn-sm bg-primary" href="{{concat scope.dashboardBase 'c/' model.id '/explorer'}}">{{t 'clusterRow.explorer'}}</a>
+  </td>
   <td data-title="{{dt.actions}}" class="actions">
     {{action-menu model=model}}
   </td>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3283,6 +3283,7 @@ clusterRow:
   addHost: Add Nodes
   importCluster: Use existing Kubernetes
   loginDefault: Login
+  explorer: Explorer
 
 clusterTemplateRow:
   label: 'RKE Template'
@@ -9619,7 +9620,7 @@ telemetryOpt:
   eula:
     prefix: I agree to the
     link: Terms and Conditions
-    suffix: 'for using {appName}.'
+    suffix: 'for using {appName}'
 
 tooltipLink:
   list: List


### PR DESCRIPTION
- Hide the option for the default landing page from the first-login modal.  It will just always be Ember for now.  You can still set this in user prefs.
- Add Dashboard link on each row of the cluster list
