### PR TITLE
Add warning when Rancher Monitoring Namespace exists

### DIFF
--- a/lib/monitoring/addon/cluster-setting/route.js
+++ b/lib/monitoring/addon/cluster-setting/route.js
@@ -3,43 +3,51 @@ import { get, set } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { on } from '@ember/object/evented';
 import C from 'ui/utils/constants';
-import { hash } from 'rsvp';
 
 export default Route.extend({
-  session:     service(),
-  scope:       service(),
-  globalStore: service(),
+  session:      service(),
+  scope:        service(),
+  globalStore:  service(),
+  clusterStore: service(),
 
-  model() {
-    const store = get(this, 'globalStore');
+  async model() {
+    const globalStore = get(this, 'globalStore');
 
     const cluster = get(this, 'scope.currentCluster');
     const project = get(cluster, 'systemProject');
 
+    const namespaces = await this.clusterStore.findAll('namespace');
+    const cattleMonitoringNamespaceExists = namespaces.any((ns) => ns.id === 'cattle-monitoring-system');
+
     if ( !project || !get(cluster, 'enableClusterMonitoring') ) {
-      return { apps: [], }
+      return {
+        apps: [],
+        cattleMonitoringNamespaceExists
+      }
     }
 
-    return hash({
-      apps: store.rawRequest({
-        url:    `/v3/project/${ get(project, 'id') }/apps`,
-        method: 'GET',
-      }).then((res) => {
-        const out = [];
-        const apps = get(res, 'body.data') || [];
-        const clusterApp = apps.findBy('name', 'cluster-monitoring');
-        const operatorApp = apps.findBy('name', 'monitoring-operator');
-
-        if ( clusterApp ) {
-          out.push(store.createRecord(clusterApp));
-        }
-        if ( operatorApp ) {
-          out.push(store.createRecord(operatorApp));
-        }
-
-        return out;
-      }),
+    let res = await globalStore.rawRequest({
+      url:    `/v3/project/${ get(project, 'id') }/apps`,
+      method: 'GET',
     });
+
+    const out = [];
+    const apps = get(res, 'body.data') || [];
+    const clusterApp = apps.findBy('name', 'cluster-monitoring');
+    const operatorApp = apps.findBy('name', 'monitoring-operator');
+
+    if ( clusterApp ) {
+      out.push(globalStore.createRecord(clusterApp));
+    }
+    if ( operatorApp ) {
+      out.push(globalStore.createRecord(operatorApp));
+    }
+
+
+    return {
+      apps: out,
+      cattleMonitoringNamespaceExists
+    }
   },
 
   setDefaultRoute: on('activate', function() {

--- a/lib/monitoring/addon/cluster-setting/template.hbs
+++ b/lib/monitoring/addon/cluster-setting/template.hbs
@@ -1,1 +1,4 @@
-{{enable-monitoring apps=model.apps}}
+{{enable-monitoring
+  apps=model.apps
+  showMonitoringV2Warning=model.cattleMonitoringNamespaceExists
+}}

--- a/lib/monitoring/addon/components/enable-monitoring/component.js
+++ b/lib/monitoring/addon/components/enable-monitoring/component.js
@@ -47,6 +47,7 @@ export default Component.extend(ReservationCheck, CatalogUpgrade, {
   justDeployed:                false,
   enablePrometheusPersistence: false,
   enableGrafanaPersistence:    false,
+  showMonitoringV2Warning:     false,
   enableNodeExporter:          true,
   prometheusPersistenceSize:   '50Gi',
   grafanaPersistenceSize:      '10Gi',

--- a/lib/monitoring/addon/components/enable-monitoring/template.hbs
+++ b/lib/monitoring/addon/components/enable-monitoring/template.hbs
@@ -1,6 +1,12 @@
-{{#banner-message color="bg-warning"}}
-  <p>{{t 'banner.monitoring' dashboardLink=scope.dashboardLink docsBase=scope.docsBase htmlSafe=true}}</p>
-{{/banner-message}}
+{{#if showMonitoringV2Warning}}
+  {{#banner-message color="bg-warning"}}
+    <p>{{t 'banner.monitoringV2Warning' dashboardLink=scope.dashboardLink docsBase=scope.docsBase htmlSafe=true}}</p>
+  {{/banner-message}}
+{{else}}
+  {{#banner-message color="bg-info"}}
+    <p>{{t 'banner.monitoring' dashboardLink=scope.dashboardLink docsBase=scope.docsBase htmlSafe=true}}</p>
+  {{/banner-message}}
+{{/if}}
 
 {{#if canSaveMonitor}}
   <section class="header clearfix">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -999,22 +999,13 @@ banner:
   alerting: Alerting is <a href="{docsBase}/reference/deprecation">deprecated</a> in Rancher v2.5+. Check out the updated version of alerting which is integrated with monitoring in <a href="{dashboardLink}/monitoring">Cluster Explorer</a>.
   cis: CIS scans are <a href="{docsBase}/reference/deprecation">deprecated</a> in Rancher v2.5+. Check out the updated version of CIS scans in <a href="{dashboardLink}/cis">Cluster Explorer</a>.
   dashboard: Try out the <a href="{dashboardLink}">Cluster Explorer</a> for a new way to view and manage your Kubernetes resources.
-<<<<<<< HEAD
   istio: The latest versions of Istio are only available in <a href="{dashboardLink}/istio">Cluster Explorer</a>.
   logging: Logging is <a href="{docsBase}/reference/deprecation">deprecated</a> in Rancher v2.5+. Check out the updated version of logging in <a href="{dashboardLink}/logging">Cluster Explorer</a>.
   multiclusterapp: Multi-cluster apps are <a href="{docsBase}/reference/deprecation">deprecated</a> in Rancher v2.5+. Deploying apps to multiple clusters is available using Fleet in <a href="{dashboardBase}c/local/fleet">Cluster Explorer</a>.
   monitoring: Monitoring is <a href="{docsBase}/reference/deprecation">deprecated</a> in Rancher v2.5+. Check out the updated version of monitoring in <a href="{dashboardLink}/monitoring">Cluster Explorer</a>.
+  monitoringV2Warning:  Monitoring is <a href="{docsBase}/reference/deprecation">deprecated</a> in Rancher v2.5+. The new Rancher Monitoring chart is currently deployed, check out the updated version in <a href="{dashboardLink}/monitoring">Cluster Explorer</a>.
   notifiers: Notifiers are <a href="{docsBase}/reference/deprecation">deprecated</a> in Rancher v2.5+. Check out the updated version of notifiers which is integrated with monitoring in <a href="{dashboardLink}/monitoring">Cluster Explorer</a>.
   pipeline: Pipelines are <a href="{docsBase}/reference/deprecation">deprecated</a> in Rancher v2.5+. Check out Fleet in <a href="{dashboardBase}c/local/fleet">Cluster Explorer</a>.
-=======
-  istio: The latest versions of Istio are only available in <a href="{dashboardLink}/istio">Cluster Explorer</a>. See <a href="{docsBase}">docs</a> for details on what's new and how to migrate.
-  logging: We've made big improvements to logging in <a href="{dashboardLink}/logging">Cluster Explorer</a>.  See <a href="{docsBase}">docs</a> for details on what's new and how to migrate.
-  multiclusterapp: We've updated deploying apps at scale with Fleet in Cluster Explorer.
-  monitoring: We've made big improvements to monitoring in <a href="{dashboardLink}/monitoring">Cluster Explorer</a>.  See <a href="{docsBase}">docs</a> for details on what's new and how to migrate.
-  monitoringV2Warning: Monitoring is currently deployed in <a href="{dashboardLink}/monitoring">Cluster Explorer</a> and needs to be removed through <a href="{dashboardLink}/monitoring">Cluster Explorer</a> to enable monitoring Rancher.
-  notifiers: We've updated notifiers to be directly integrated with monitoring in <a href="{dashboardLink}/monitoring">Cluster Explorer</a>. See docs for details on what's new and how to migrate.
-  pipeline: We've updated deploying apps at scale with Fleet in <a href="{dashboardLink}/fleet">Cluster Explorer</a>.
->>>>>>> 0ecbe240f... Add warning when Rancher Monitoring Namespace exists
 
 catalogPage:
   istio:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -999,12 +999,22 @@ banner:
   alerting: Alerting is <a href="{docsBase}/reference/deprecation">deprecated</a> in Rancher v2.5+. Check out the updated version of alerting which is integrated with monitoring in <a href="{dashboardLink}/monitoring">Cluster Explorer</a>.
   cis: CIS scans are <a href="{docsBase}/reference/deprecation">deprecated</a> in Rancher v2.5+. Check out the updated version of CIS scans in <a href="{dashboardLink}/cis">Cluster Explorer</a>.
   dashboard: Try out the <a href="{dashboardLink}">Cluster Explorer</a> for a new way to view and manage your Kubernetes resources.
+<<<<<<< HEAD
   istio: The latest versions of Istio are only available in <a href="{dashboardLink}/istio">Cluster Explorer</a>.
   logging: Logging is <a href="{docsBase}/reference/deprecation">deprecated</a> in Rancher v2.5+. Check out the updated version of logging in <a href="{dashboardLink}/logging">Cluster Explorer</a>.
   multiclusterapp: Multi-cluster apps are <a href="{docsBase}/reference/deprecation">deprecated</a> in Rancher v2.5+. Deploying apps to multiple clusters is available using Fleet in <a href="{dashboardBase}c/local/fleet">Cluster Explorer</a>.
   monitoring: Monitoring is <a href="{docsBase}/reference/deprecation">deprecated</a> in Rancher v2.5+. Check out the updated version of monitoring in <a href="{dashboardLink}/monitoring">Cluster Explorer</a>.
   notifiers: Notifiers are <a href="{docsBase}/reference/deprecation">deprecated</a> in Rancher v2.5+. Check out the updated version of notifiers which is integrated with monitoring in <a href="{dashboardLink}/monitoring">Cluster Explorer</a>.
   pipeline: Pipelines are <a href="{docsBase}/reference/deprecation">deprecated</a> in Rancher v2.5+. Check out Fleet in <a href="{dashboardBase}c/local/fleet">Cluster Explorer</a>.
+=======
+  istio: The latest versions of Istio are only available in <a href="{dashboardLink}/istio">Cluster Explorer</a>. See <a href="{docsBase}">docs</a> for details on what's new and how to migrate.
+  logging: We've made big improvements to logging in <a href="{dashboardLink}/logging">Cluster Explorer</a>.  See <a href="{docsBase}">docs</a> for details on what's new and how to migrate.
+  multiclusterapp: We've updated deploying apps at scale with Fleet in Cluster Explorer.
+  monitoring: We've made big improvements to monitoring in <a href="{dashboardLink}/monitoring">Cluster Explorer</a>.  See <a href="{docsBase}">docs</a> for details on what's new and how to migrate.
+  monitoringV2Warning: Monitoring is currently deployed in <a href="{dashboardLink}/monitoring">Cluster Explorer</a> and needs to be removed through <a href="{dashboardLink}/monitoring">Cluster Explorer</a> to enable monitoring Rancher.
+  notifiers: We've updated notifiers to be directly integrated with monitoring in <a href="{dashboardLink}/monitoring">Cluster Explorer</a>. See docs for details on what's new and how to migrate.
+  pipeline: We've updated deploying apps at scale with Fleet in <a href="{dashboardLink}/fleet">Cluster Explorer</a>.
+>>>>>>> 0ecbe240f... Add warning when Rancher Monitoring Namespace exists
 
 catalogPage:
   istio:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Adds Check for the `cattle-monitoring-system` namespace, if the namespace exists we assume the new Rancher Monitoring chart has been installed. 

This may not cover all edge cases because this only verifies the namespace exists. One issue I see is that the chart was installed then removed and the namespace still exists for what ever reason. We'd still show this warning. Afaict, there is no way to load the workloads for the new chart as the workloads exists in the namespace without a project. Loading the workloads would let us do the same podspec check we do in dashboard. I dont see this as being a deal breaker though, as this is only a warning, its doesn't stop the user from actually enabling monitoring. If that is the desired result perhaps the backend should disabled/remove the link from the cluster as they should be able to read if the chart is installed. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
New Feature
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#29006

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
