### PR TITLE
Fix frozen settings modal when parsing invalid JSON setting

### DIFF
--- a/app/components/modal-edit-setting/component.js
+++ b/app/components/modal-edit-setting/component.js
@@ -39,7 +39,15 @@ export default Component.extend(ModalBase, {
     this._super(...arguments);
 
     if (get(this, 'model.kind') === 'json') {
-      set(this, 'formattedValue', JSON.stringify(JSON.parse(get(this, 'model.obj.value')), undefined, 2));
+      let formattedValue = get(this, 'model.obj.value')
+
+      try {
+        formattedValue = JSON.stringify(JSON.parse(formattedValue), undefined, 2)
+      } catch {
+        // catch SyntaxError
+      }
+
+      set(this, 'formattedValue', formattedValue);
     } else {
       set(this, 'value', get(this, 'model.obj.value') || '');
     }


### PR DESCRIPTION
Proposed changes
======
Handle possible exception thrown when opening JSON setting editor modal.

Types of changes
======
Bugfix

Linked Issues
======
https://github.com/rancher/rancher/issues/28504

Further comments
======
Resolves bug found in https://github.com/rancher/rancher/issues/28504#issuecomment-699702037
