### PR TITLE
[v2.4] Vsphere Resource Pool Sub-Directory Fix

### DIFF
--- a/lib/nodes/addon/components/driver-vmwarevsphere/component.js
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/component.js
@@ -564,11 +564,7 @@ export default Component.extend(NodeDriver, {
   mapPoolOptionsToContent(pathOptions) {
     return pathOptions.map((pathOption) => {
       let splitOptions = pathOption.split('/')
-      let label = splitOptions.get('lastObject')
-
-      if (label === 'Resources' && splitOptions.length >= 2) {
-        label = splitOptions.slice(-2).join('/')
-      }
+      let label = splitOptions.slice(2).join('/')
 
       return {
         label,


### PR DESCRIPTION
Changes the label for a resource pool to be the full path minus the first two pieces.

e.g. `/RNCH-HE-FMT/host/FMT2.R620.1/Resources/luther/testerrr`
label was: `testerrr`
label will be `FMT2.R620.1/Resources/luther/testerrr`

https://github.com/rancher/rancher/issues/24507