### PR TITLE
[2.5] Longhorn Uses Default Values on View

### DIFF
--- a/app/components/volume-source/source-csi-volume-longhorn/component.js
+++ b/app/components/volume-source/source-csi-volume-longhorn/component.js
@@ -9,14 +9,15 @@ export default Component.extend(VolumeSource, {
   field: 'csi',
 
   init() {
-    this._super();
-    const { config: { driver, options } } = this;
+    this._super(...arguments);
+
+    const { config: { driver, volumeAttributes } } = this;
 
     if (!driver) {
       set(this, 'config.driver', C.STORAGE.LONGHORN_PROVISIONER_KEY);
     }
 
-    if (!options) {
+    if (!volumeAttributes) {
       set(this, 'config.volumeAttributes', {
         size:                '2Gi',
         numberOfReplicas:    '3',


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Longhorn driver no longer uses the options key, so use the correct volume attributes key instead. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
bug
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#29484

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
