### PR TITLE
[2.5.2] gke project id not set before fetching cluster resources

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
@@ -325,6 +325,9 @@ export default Component.extend(ClusterDriver, {
 
   actions: {
     clickNext() {
+      if (isEmpty(get(this, 'config.projectId'))) {
+        this.parseProjectId();
+      }
       $('BUTTON[type="submit"]').click();
     },
 
@@ -380,18 +383,7 @@ export default Component.extend(ClusterDriver, {
       return;
     }
 
-    const str = get(this, 'config.credential');
-
-    if ( str ) {
-      try {
-        const obj = JSON.parse(str);
-        // Note: this is a Google project id, not ours.
-        const projectId = obj.project_id;
-
-        set(this, 'config.projectId', projectId);
-      } catch (e) {
-      }
-    }
+    this.parseProjectId();
   }),
 
   zoneChanged: observer('config.zone', 'zones.[]', function() {
@@ -668,6 +660,10 @@ export default Component.extend(ClusterDriver, {
   }),
 
   fetchZones() {
+    if (this.saved) {
+      return;
+    }
+
     return get(this, 'globalStore').rawRequest({
       url:    '/meta/gkeZones',
       method: 'POST',
@@ -697,6 +693,10 @@ export default Component.extend(ClusterDriver, {
   },
 
   fetchVersions() {
+    if (this.saved) {
+      return;
+    }
+
     return get(this, 'globalStore').rawRequest({
       url:    '/meta/gkeVersions',
       method: 'POST',
@@ -720,6 +720,10 @@ export default Component.extend(ClusterDriver, {
   },
 
   fetchMachineTypes() {
+    if (this.saved) {
+      return;
+    }
+
     return get(this, 'globalStore').rawRequest({
       url:    '/meta/gkeMachineTypes',
       method: 'POST',
@@ -742,6 +746,10 @@ export default Component.extend(ClusterDriver, {
   },
 
   fetchNetworks() {
+    if (this.saved) {
+      return;
+    }
+
     return get(this, 'globalStore').rawRequest({
       url:    '/meta/gkeNetworks',
       method: 'POST',
@@ -768,6 +776,10 @@ export default Component.extend(ClusterDriver, {
   },
 
   fetchSubnetworks() {
+    if (this.saved) {
+      return;
+    }
+
     const zone = get(this, 'config.zone')
     const locationType = get(this, 'locationType');
 
@@ -793,6 +805,10 @@ export default Component.extend(ClusterDriver, {
   },
 
   fetchServiceAccounts() {
+    if (this.saved) {
+      return;
+    }
+
     return get(this, 'globalStore').rawRequest({
       url:    '/meta/gkeServiceAccounts',
       method: 'POST',
@@ -936,4 +952,18 @@ export default Component.extend(ClusterDriver, {
     return this._super(...arguments);
   },
 
+  parseProjectId() {
+    const str = get(this, 'config.credential');
+
+    if ( str ) {
+      try {
+        const obj = JSON.parse(str);
+        // Note: this is a Google project id, not ours.
+        const projectId = obj.project_id;
+
+        set(this, 'config.projectId', projectId);
+      } catch (e) {
+      }
+    }
+  },
 });

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -994,12 +994,13 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     const maxUnavailableUnit = maxUnavailableWorker.includes('%') ? 'percentage' : 'count';
     const drainInput = get(source, 'nodeDrainInput');
     const timeout = get(source, 'nodeDrainInput.timeout');
+    const drainStatusStr = (get(source, 'drain') || false).toString();
 
     set(this, 'upgradeStrategy.maxUnavailableControlplane', maxUnavailableControlplane);
     set(this, 'upgradeStrategy.maxUnavailableWorker', maxUnavailableWorker.replace('%', ''));
     set(this, 'upgradeStrategy.maxUnavailableUnit', maxUnavailableUnit);
     set(this, 'upgradeStrategy.nodeDrainInput', drainInput ? drainInput : {});
-    set(this, 'upgradeStrategy.drain', get(source, 'drain').toString());
+    set(this, 'upgradeStrategy.drain', drainStatusStr);
 
     // This ensures the UI won't initialize the timeout below the minimum.
     if (timeout !== undefined && timeout <= 0) {

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -881,7 +881,7 @@
                     min=1
                     classNames="form-control"
                     placeholder=(t "clusterNew.rke.etcd.backupConfig.interval.placeholder")
-                    disabled=(unless config.services.etcd.backupConfig.enabled)
+                    disabled=(unless config.services.etcd.backupConfig.enabled true)
                   }}
                   <span class="input-group-addon bg-default">{{t "generic.hours"}}</span>
                 {{/input-or-display}}
@@ -918,7 +918,7 @@
                     min=1
                     classNames="form-control"
                     placeholder=(t "clusterNew.rke.etcd.backupConfig.retention.placeholder")
-                    disabled=(unless config.services.etcd.backupConfig.enabled)
+                    disabled=(unless config.services.etcd.backupConfig.enabled true)
                   }}
                 {{/input-or-display}}
               </CheckOverrideAllowed>

--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -9,6 +9,7 @@ import { isEmpty } from '@ember/utils';
 import C from 'ui/utils/constants';
 import { azure as AzureInfo } from './cloud-provider-info';
 import { next } from '@ember/runloop';
+import { debouncedObserver } from 'ui/utils/debounce';
 
 const azureDefaults = C.AZURE_DEFAULTS;
 const GENERIC_PATH  = 'cluster.rancherKubernetesEngineConfig.cloudProvider.cloudConfig';
@@ -81,29 +82,34 @@ export default Component.extend({
     }
   }),
 
-  configAnswersDidChange: observer('configAnswers', function() {
-    const configAnswers         = get(this, 'configAnswers');
+  configAnswersDidChange: debouncedObserver('mappedConfigAnswers.@each.{key,value}', function() {
+    const mappedAnswers = get(this, 'mappedConfigAnswers');
     const selectedCloudProvider = get(this, 'selectedCloudProvider');
+    const configAnswersOut = {};
+    let pathForSet;
 
     switch (selectedCloudProvider) {
     case 'azure':
-
-      set(this, AZURE_PATH, configAnswers);
+      pathForSet = AZURE_PATH;
 
       break;
 
     case 'amazonec2':
-
-      set(this, AWS_PATH, configAnswers);
+      pathForSet = AWS_PATH;
 
       break;
 
     default:
-
-      set(this, GENERIC_PATH, configAnswers);
+      pathForSet = GENERIC_PATH;
 
       break;
     }
+
+    mappedAnswers.forEach((answer) => {
+      set(configAnswersOut, answer.key, answer.value);
+    });
+
+    set(this, pathForSet, configAnswersOut);
   }),
 
   selectedCloudProviderOverrideAvailable: computed(
@@ -156,6 +162,20 @@ export default Component.extend({
     } else {
       return true;
     }
+  }),
+
+  mappedConfigAnswers: computed('configAnswers', function() {
+    const configAnswers = (get(this, 'configAnswers') || {});
+    const out = [];
+
+    Object.keys(configAnswers).forEach((answerKey) => {
+      out.push({
+        key:   answerKey,
+        value: configAnswers[answerKey]
+      });
+    });
+
+    return out;
   }),
 
   checkDefaults(record) {

--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -134,15 +134,15 @@ export default Component.extend({
           }
         }
       } else {
-        if (!this.configName) {
-          next(() => {
+        next(() => {
+          if (!this.configName) {
             if ( this.destroyed || this.destroying) {
               return;
             }
 
             set(this, 'selectedCloudProvider', this.selectedCloudProvider === 'generic' ? 'generic' : 'none');
-          });
-        }
+          }
+        });
       }
 
       return false;

--- a/lib/shared/addon/components/cru-cloud-provider/template.hbs
+++ b/lib/shared/addon/components/cru-cloud-provider/template.hbs
@@ -146,20 +146,20 @@
 </div>
 
 {{#if (eq selectedCloudProvider "azure")}}
-  {{#each-in configAnswers as |key value|}}
+  {{#each mappedConfigAnswers as |answer|}}
     <div class="row">
       <div class="col span-6">
-        <label class="acc-label pb-0">{{key}}
-          {{#if (get (get azureDescriptions key) "required")}}
+        <label class="acc-label pb-0">{{answer.key}}
+          {{#if (get (get azureDescriptions answer.key) "required")}}
             {{#if (eq mode "new")}}
               {{field-required}}
-            {{else if (and (eq mode "edit") (or (not-eq key "aadClientSecret") clusterTemplateCreate))}}
+            {{else if (and (eq mode "edit") (or (not-eq answer.key "aadClientSecret") clusterTemplateCreate))}}
               {{field-required}}
             {{/if}}
           {{/if}}
           {{#if clusterTemplateCreate}}
             <ClusterTemplateOverrideToggle
-              @path={{concat "rancherKubernetesEngineConfig.cloudProvider.azureCloudProvider." key}}
+              @path={{concat "rancherKubernetesEngineConfig.cloudProvider.azureCloudProvider." answer.key}}
               @configVariable={{configVariable}}
               @addOverride={{addOverride}}
               @questions={{questions}}
@@ -167,33 +167,33 @@
           {{/if}}
         </label>
         <p class="help-block mt-0">
-          {{t (get (get azureDescriptions key) "description") htmlSafe=true}}
+          {{t (get (get azureDescriptions answer.key) "description") htmlSafe=true}}
         </p>
       </div>
       <div class="col span-6">
         <CheckOverrideAllowed
           @applyClusterTemplate={{applyClusterTemplate}}
           @clusterTemplateRevision={{clusterTemplateRevision.clusterConfig}}
-          @paramName={{concat "rancherKubernetesEngineConfig.cloudProvider.azureCloudProvider." key}}
+          @paramName={{concat "rancherKubernetesEngineConfig.cloudProvider.azureCloudProvider." answer.key}}
           @questions={{questions}}
         >
           {{#input-or-display
              editable=(not-eq mode "view")
-             value=(get configAnswers key)
-             obfuscate=(if (eq (get (get azureDescriptions key) "type") "password") true false)
+             value=(get configAnswers answer.key)
+             obfuscate=(if (eq (get (get azureDescriptions answer.key) "type") "password") true false)
           }}
             {{input
               class="form-control input-sm value"
               spellcheck="false"
-              type=(or (get (get azureDescriptions key) "type") "text")
-              value=(mut (get configAnswers key))
+              type=(or (get (get azureDescriptions answer.key) "type") "text")
+              value=answer.value
               placeholder=(t "generic.value")
             }}
           {{/input-or-display}}
         </CheckOverrideAllowed>
       </div>
     </div>
-  {{/each-in}}
+  {{/each}}
 {{/if}}
 
 {{#if (not-eq mode "view")}}


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This issue cropped up after a large dependency upgrade and I believe it has to do with some underlying ember changes. Basically we'd hit a race condition where we'd click next before the observer has had a chance to update the project id.
Found an additional issue where the observer on zone change would cause all the fetchs to fire again after the cluster has saved because we merge the results, I added checks to see if we'd saved as saving was already set false but we hadn't started destroying yet.

Also adds update for broken cloud provider selection

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#29646
rancher/rancher#29685
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
