### PR TITLE
Hide Local Cluster 

### DIFF
--- a/app/components/page-header-project/component.js
+++ b/app/components/page-header-project/component.js
@@ -24,6 +24,7 @@ export default Component.extend(ThrottledResize, {
   scope:               service(),
   globalStore:         service(),
   router:              service(),
+  settings:            service(),
 
   layout,
   pageScope: null,
@@ -163,12 +164,15 @@ export default Component.extend(ThrottledResize, {
   }),
 
   byCluster: computed('scope.allClusters.@each.id', 'projectChoices.@each.clusterId', 'cluster.id', function() {
+    const hideLocalCluster = get(this.settings, 'shouldHideLocalCluster');
     const currentClusterId = get(this, 'cluster.id');
     const out              = [];
     const navWidth = $('#application nav').width();
 
     get(this, 'scope.allClusters').forEach((cluster) => {
-      getOrAddCluster(cluster);
+      if ((hideLocalCluster && get(cluster, 'id') !== 'local') || !hideLocalCluster) {
+        getOrAddCluster(cluster);
+      }
     });
 
     get(this, 'projectChoices').forEach((project) => {
@@ -179,10 +183,12 @@ export default Component.extend(ThrottledResize, {
         return;
       }
 
-      const entry = getOrAddCluster(cluster);
+      if ((hideLocalCluster && get(cluster, 'id') !== 'local') || !hideLocalCluster) {
+        const entry = getOrAddCluster(cluster);
 
-      entry.projects.push(project);
-      entry.projectWidth = Math.max(entry.projectWidth, width);
+        entry.projects.push(project);
+        entry.projectWidth = Math.max(entry.projectWidth, width);
+      }
     });
 
     out.forEach((entry) => {

--- a/lib/global-admin/addon/clusters/index/controller.js
+++ b/lib/global-admin/addon/clusters/index/controller.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import Controller, { inject as controller } from '@ember/controller';
 import { getOwner } from '@ember/application';
+import { computed, get, set } from '@ember/object';
 
 const headers = [
   {
@@ -61,6 +62,7 @@ export default Controller.extend({
   settings:           service(),
   prefs:              service(),
   router:             service(),
+  globalStore:        service(),
 
   application:        controller(),
   queryParams:        ['mode'],
@@ -71,8 +73,15 @@ export default Controller.extend({
   sortBy:             'name',
   searchText:         null,
   bulkActions:        true,
+  _allClusters:       null,
 
   extraSearchSubFields: NODE_SEARCH_FIELDS,
+
+  init() {
+    this._super(...arguments);
+
+    set(this, '_allClusters', this.globalStore.all('cluster'));
+  },
 
   actions: {
     launchOnCluster(model) {
@@ -96,4 +105,15 @@ export default Controller.extend({
       authenticated.send('switchProject', model.get('defaultProject.id'), 'authenticated.cluster.import', [model.id, { queryParams: { backTo: 'clusters' } }]);
     },
   },
+
+  filteredClusters: computed('_allClusters.@each.{id,state,transitioning,transitioningMessage}', '_allClusters.[]', function() {
+    const hideLocalCluster = get(this.settings, 'shouldHideLocalCluster');
+
+    return get(this, '_allClusters').filter((cluster) => {
+      if ((hideLocalCluster && get(cluster, 'id') !== 'local') || !hideLocalCluster) {
+        return cluster;
+      }
+    });
+  })
+
 });

--- a/lib/global-admin/addon/clusters/index/template.hbs
+++ b/lib/global-admin/addon/clusters/index/template.hbs
@@ -18,7 +18,7 @@
 
 {{#sortable-table
    classNames="grid sortable-table"
-   body=model.clusters
+   body=filteredClusters
    searchText=searchText
    descending=descending
    sortBy=sortBy

--- a/lib/global-admin/addon/clusters/route.js
+++ b/lib/global-admin/addon/clusters/route.js
@@ -4,18 +4,12 @@ import { get } from '@ember/object';
 
 export default Route.extend({
   globalStore: service(),
-  settings:    service(),
 
   model() {
     const store = this.get('globalStore');
-    const hideLocalCluster = get(this.settings, 'shouldHideLocalCluster');
 
     return store.findAll('cluster').then((/* resp */) => {
-      const clusters = store.all('cluster').filter((cluster) => {
-        if ((hideLocalCluster && get(cluster, 'id') !== 'local') || !hideLocalCluster) {
-          return cluster;
-        }
-      });
+      const clusters = store.all('cluster');
 
       if (clusters.length > 0) {
         clusters.forEach((cluster) => {

--- a/lib/global-admin/addon/clusters/route.js
+++ b/lib/global-admin/addon/clusters/route.js
@@ -1,14 +1,21 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { get } from '@ember/object';
 
 export default Route.extend({
   globalStore: service(),
+  settings:    service(),
 
   model() {
     const store = this.get('globalStore');
+    const hideLocalCluster = get(this.settings, 'shouldHideLocalCluster');
 
     return store.findAll('cluster').then((/* resp */) => {
-      const clusters = store.all('cluster');
+      const clusters = store.all('cluster').filter((cluster) => {
+        if ((hideLocalCluster && get(cluster, 'id') !== 'local') || !hideLocalCluster) {
+          return cluster;
+        }
+      });
 
       if (clusters.length > 0) {
         clusters.forEach((cluster) => {

--- a/lib/global-admin/addon/clusters/route.js
+++ b/lib/global-admin/addon/clusters/route.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { get } from '@ember/object';
 
 export default Route.extend({
   globalStore: service(),

--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -113,7 +113,7 @@ export default Component.extend({
   }),
 
   selectedCloudProviderOverrideAvailable: computed(
-    'applyClusterTemplate', 'clusterTemplateCreate', 'clusterTemplateRevision.{id,questions}', 'configName', 'destroyed', 'destroying', 'selectedCloudProvider',
+    'applyClusterTemplate', 'clusterTemplateCreate', 'clusterTemplateRevision.{id,questions}', 'configName', 'selectedCloudProvider', 'isDestroying', 'isDestroyed',
     function() {
       let { clusterTemplateRevision, applyClusterTemplate } = this;
 
@@ -131,7 +131,7 @@ export default Component.extend({
         } else {
           if (this.configName) {
             next(() => {
-              if ( this.destroyed || this.destroying) {
+              if (this.isDestroyed || this.isDestroying) {
                 return;
               }
 
@@ -142,7 +142,7 @@ export default Component.extend({
       } else {
         next(() => {
           if (!this.configName) {
-            if ( this.destroyed || this.destroying) {
+            if (this.isDestroyed || this.isDestroying) {
               return;
             }
 

--- a/lib/shared/addon/settings/service.js
+++ b/lib/shared/addon/settings/service.js
@@ -142,6 +142,15 @@ export default Service.extend(Evented, {
   clusterTemplateEnforcement: alias(`asMap.${ C.SETTING.CLUSTER_TEMPLATE_ENFORCEMENT }.value`),
   uiBanners:                  alias(`asMap.${ C.SETTING.UI_BANNERS }.value`),
   uiIssues:                   alias(`asMap.${ C.SETTING.UI_ISSUES }.value`),
+  hideLocalCluster:           alias(`asMap.${ C.SETTING.HIDE_LOCAL_CLUSTER }.value`),
+
+  shouldHideLocalCluster: computed('hideLocalCluster', function() {
+    if (this.hideLocalCluster === 'true') {
+      return true;
+    }
+
+    return false;
+  }),
 
   asMap: computed('all.@each.{name,value,customized}', function() {
     var out = {};

--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -516,6 +516,8 @@ var C = {
 
     API_HOST:                         'api-host',
     CA_CERTS:                         'cacerts',
+
+    HIDE_LOCAL_CLUSTER:               'hide-local-cluster',
     // CLUSTER_DEFAULTS:              'cluster-defaults',
     AUTH_TOKEN_MAX_TTL_MINUTES:       'auth-token-max-ttl-minutes',
     ENGINE_URL:                       'engine-install-url',


### PR DESCRIPTION
If the new setting `hide-local-cluster` exists and is true we will hide the local cluster from the page header/search and global admin cluster lists page. this doesnt prevent api access.
Additionally if the setting is true and a user attempts to navigate directly to a cluster or project route we will redirect them to the authenticated index route which subsequently redirects to global admin.



<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
New Feature
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#29325
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
