### PR TITLE
Add support for custom boot volume size and setting oCPUs for flexibl…

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
@@ -6,6 +6,7 @@ import { get, set, computed, setProperties } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { OCI_REGIONS } from 'shared/utils/oci';
+import { compare } from 'shared/utils/parse-version';
 
 const vcnIdMap = { quick: 'Quick Create', }
 
@@ -98,9 +99,12 @@ export default Component.extend(ClusterDriver, {
         const { okeVersions } = resp;
 
         setProperties(this, {
-          okeVersions:  (get( okeVersions, 'body') || []),
+          okeVersions:  (get( okeVersions, 'body') || []).sort((a, b) => compare(a, b) < 0), // latest version first
           errors:       [],
         });
+
+        // latest version by default
+        set(this, 'config.kubernetesVersion', (get(this, 'okeVersions')[0] || null))
 
         set(this, 'step', 2);
         cb(true);

--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
@@ -7,7 +7,6 @@ import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { OCI_REGIONS } from 'shared/utils/oci';
 
-
 const vcnIdMap = { quick: 'Quick Create', }
 
 const subnetAccessMap = {
@@ -52,7 +51,7 @@ export default Component.extend(ClusterDriver, {
         vcn:                   '',
         securityListId:        '',
         subnetAccess:          'public',
-        cpu:                   0,
+        flexOcpus:             0,
         memory:                0,
         quantityPerSubnet:     1,
         quantityOfNodeSubnets: 1,

--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/template.hbs
@@ -352,7 +352,7 @@
 
           <div class="row">
 
-            <div class="col span-6">
+            <div class="col span-4">
               <label class="acc-label">
                 {{t 'clusterNew.oracleoke.nodeShape.label'}}{{field-required}}
               </label>
@@ -366,10 +366,26 @@
                 <div>{{config.nodeShape}}</div>
               {{/if}}
             </div>
+            {{#if (eq config.nodeShape "VM.Standard.E3.Flex")}}
+              <div class="col span-4">
+                <label class="acc-label" for="input-ocpu-count">
+                  {{t "clusterNew.oracleoke.flexShapeConfig.label"}}
+                </label>{{field-required}}
+                {{input-number
+                  id="input-ocpu-count"
+                  min=1
+                  max=64
+                  value=config.flexOcpus
+                }}
+              </div>
+            {{/if}}
+          </div>
 
-            <div class="col span-6">
+          <div class="row">
+
+            <div class="col span-4">
               <label class="acc-label">
-                {{t 'clusterNew.oracleoke.os.label'}}
+                {{t 'clusterNew.oracleoke.os.label'}}{{field-required}}
               </label>
               {{#if (eq step 4)}}
                 <select class="form-control" onchange={{action (mut config.nodeImage) value="target.value"}}>
@@ -379,10 +395,19 @@
                   {{/each}}
                 </select>
               {{else}}
-                <div>{{ config.nodeImage}}</div>
+                <div>{{config.nodeImage}}</div>
               {{/if}}
             </div>
 
+            <div class="col span-4">
+              <label class="acc-label">
+                {{t "clusterNew.oracleoke.bootVolumeSize.label"}}
+              </label>
+              <div class="input-group">
+                {{input-number min=50 max=32768 value=config.customBootVolumeSize }}
+                <span class="input-group-addon bg-default">{{t "generic.gigabyte"}}</span>
+              </div>
+            </div>
           </div>
 
           <div class="row">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4191,8 +4191,11 @@ clusterNew:
       label: Operating System
     storageType:
       label: Default Persistent Volume Disk Type
-    storageSize:
-      label: Default Persistent Volume Disk Size
+    bootVolumeSize:
+      label: Optionally override default boot volume size for nodes
+      error: Custom boot volume disk size should be greater than the default (46.6 GB)
+    flexShapeConfig:
+      label: Specify the number of OCPUs for the flex shape
       placeholder: e.g. 10
       error: Default Persistent Volume Disk Size should be greater than 0
     localDisk:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

This PR adds support for specifying a custom boot-volume size and specifying the number of oCPUs if a flexible node shapes is selected to the OKE cluster driver. 

Additionally, there is a trivial change to sort the Kubernetes versions from latest to oldest, and to select the most recent version first.

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

New feature.

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-->



Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 
**Depends on:**
- rancher/rancher#29727

Other tracking issues:
- rancher/rancher#29724
- rancher/rancher#29124

Further comments
======



<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->


**OKE cluster driver allowing for OCPUs when flex-shape is selected as well as the ability to override the default boot volume size for nodes:**

![flex-boot-vol-2](https://user-images.githubusercontent.com/13613687/96943346-ab7cec80-148c-11eb-92b7-6528518424bf.gif)



