### PR TITLE
[2.4] Filter out OL-8.x images until it is supported by OCI machine driver.

### DIFF
--- a/lib/nodes/addon/components/driver-oci/component.js
+++ b/lib/nodes/addon/components/driver-oci/component.js
@@ -111,7 +111,7 @@ export default Component.extend(NodeDriver, {
         }
       });
 
-      return this.mapToContent(options);
+      return this.mapToContent(this.filterOut(options, 'Oracle-Linux-8'));
     }
 
     return {
@@ -153,6 +153,11 @@ export default Component.extend(NodeDriver, {
         label: option,
         value: option
       }));
+    }
+  },
+  filterOut(folderOptions, filter) {
+    if (folderOptions && typeof folderOptions.map === 'function') {
+      return folderOptions.filter((entry) => !entry.includes(filter));
     }
   },
   validate() {


### PR DESCRIPTION
backport rancher/ui#4250