### PR TITLE
[2.5.2] Logout Bug - CSFR not being refetched

### DIFF
--- a/lib/shared/addon/mixins/store-tweaks.js
+++ b/lib/shared/addon/mixins/store-tweaks.js
@@ -1,7 +1,6 @@
 import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
 import C from 'ui/utils/constants';
-import { computed } from '@ember/object';
 
 export default Mixin.create({
   cookies: service(),
@@ -9,7 +8,7 @@ export default Mixin.create({
   defaultPageSize:   -1,
   removeAfterDelete: false,
 
-  headers: computed('cookies.CSRF', function() {
+  get headers() {
     let out = {
       [C.HEADER.ACTIONS]:      C.HEADER.ACTIONS_VALUE,
       [C.HEADER.NO_CHALLENGE]: C.HEADER.NO_CHALLENGE_VALUE
@@ -22,5 +21,5 @@ export default Mixin.create({
     }
 
     return out;
-  }),
+  }
 });


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
volatile was deprecated, during the ember 3.12 -> 3.20 upgrade the headers computed property was incorrectly changed to a regular computed property when it should have actually been converted to a native getter as this property is not intended to be tracked.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#29751
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
