### PR TITLE
[2.5.3] 2 ETCD Node Delete Warning

### DIFF
--- a/lib/shared/addon/components/confirm-delete/component.js
+++ b/lib/shared/addon/components/confirm-delete/component.js
@@ -106,6 +106,27 @@ export default Component.extend(ModalBase, {
     return app && C.SYSTEM_CHART_APPS.includes(get(app, 'displayName'))
   }),
 
+  isRke2NodeEtcd: computed('resources', function() {
+    const nodes = get(this, 'resources');
+    const atLeastOneEtcdBeingDeleted = nodes.filterBy('etcd').length >= 1;
+
+    if (atLeastOneEtcdBeingDeleted) {
+      const cluster = nodes.length >= 1 ? get(nodes.firstObject, 'cluster') : false;
+
+      if (cluster) {
+        const filteredEtcdNodes = (get(cluster, 'nodes') || []).filterBy('etcd');
+
+        if (filteredEtcdNodes.length === 2) {
+          return true;
+        } else {
+          return false;
+        }
+      }
+    }
+
+    return false;
+  }),
+
   hasSystemProjectNamespace: computed('resources', function() {
     const namespaces = get(this, 'resources').filter((resource) => get(resource, 'type') === 'namespace' && get(resource, 'project.isSystemProject'));
 

--- a/lib/shared/addon/components/confirm-delete/template.hbs
+++ b/lib/shared/addon/components/confirm-delete/template.hbs
@@ -38,6 +38,11 @@
       {{/banner-message}}
     </div>
   {{/if}}
+  {{#if isRke2NodeEtcd}}
+    <div class="mb-20 mt-20">
+      <BannerMessage @color="bg-warning" @message={{t "confirmDelete.twoNodeEtcd"}} />
+    </div>
+  {{/if}}
   <div class="display-name">
     {{#if (lte resources.length 10)}}
       {{#each resources as |resource|}}

--- a/lib/shared/addon/components/confirm-delete/template.hbs
+++ b/lib/shared/addon/components/confirm-delete/template.hbs
@@ -10,37 +10,34 @@
       {{t "confirmDelete.titleWithoutResourceType"}}
     {{/if}}
   </h3>
-  <hr/>
+  <hr />
   {{#if isSystemProject}}
     <div class="mb-20 mt-20">
-      {{#banner-message
-        color="bg-warning m-0"
-      }}
+      {{#banner-message color="bg-warning m-0"}}
         {{t "confirmDelete.systemProjectNote"}}
       {{/banner-message}}
     </div>
   {{/if}}
   {{#if hasSystemProjectNamespace}}
     <div class="mb-20 mt-20">
-      {{#banner-message
-        color="bg-warning m-0"
-      }}
+      {{#banner-message color="bg-warning m-0"}}
         {{t "confirmDelete.systemProjectNamespaceNote"}}
       {{/banner-message}}
     </div>
   {{/if}}
   {{#if isSystemChart}}
     <div class="mb-20 mt-20">
-      {{#banner-message
-        color="bg-warning m-0"
-      }}
+      {{#banner-message color="bg-warning m-0"}}
         {{t "confirmDelete.systemChartNote"}}
       {{/banner-message}}
     </div>
   {{/if}}
   {{#if isRke2NodeEtcd}}
     <div class="mb-20 mt-20">
-      <BannerMessage @color="bg-warning" @message={{t "confirmDelete.twoNodeEtcd"}} />
+      <BannerMessage
+        @color="bg-warning"
+        @message={{t "confirmDelete.twoNodeEtcd"}}
+      />
     </div>
   {{/if}}
   <div class="display-name">
@@ -52,12 +49,15 @@
       {{/each}}
     {{else}}
       <div>
-        {{t "confirmDelete.largeDeleteText" key=resources.firstObject.displayName othersCount=(sub resources.length 1)}}
+        {{t
+          "confirmDelete.largeDeleteText"
+          key=resources.firstObject.displayName
+          othersCount=(sub resources.length 1)
+        }}
       </div>
     {{/if}}
   </div>
 </div>
-
 {{#if (and isEnvironment (not isSystemProject))}}
   <div class="mb-15">
     {{t "confirmDelete.environmentNote" appName=settings.appName}}
@@ -71,35 +71,35 @@
 {{#if isPod}}
   <div class="checkbox pt-10">
     <label>
-      {{input
-        type="checkbox"
-        checked=forceDelete
-      }}
+      {{input type="checkbox" checked=forceDelete}}
       {{t "confirmDelete.forceDelete.label"}}
     </label>
   </div>
 {{/if}}
-  {{#if forceDelete}}
-    <div class="mb-20 mt-20">
-      {{banner-message
-        icon="icon-alert"
-        color="bg-warning m-0"
-        message=(t "confirmDelete.forceDelete.warning" htmlSafe=true)
-      }}
-    </div>
-  {{/if}}
+{{#if forceDelete}}
+  <div class="mb-20 mt-20">
+    {{banner-message
+      icon="icon-alert"
+      color="bg-warning m-0"
+      message=(t "confirmDelete.forceDelete.warning" htmlSafe=true)
+    }}
+  </div>
+{{/if}}
 {{#if isClusterRoleTemplateBinding}}
   <div class="mb-15">
     {{t "confirmDelete.clusterRoleTemplateBindingNote"}}
   </div>
 {{/if}}
-
-{{#if (and isGlobalRole (gte resources.firstObject.globalRoleAssociatedUserCount 0))}}
+{{#if
+  (and isGlobalRole (gte resources.firstObject.globalRoleAssociatedUserCount 0))
+}}
   <div class="mb-15 text-center">
-    {{t "confirmDelete.globalRoleNote" count=resources.firstObject.globalRoleAssociatedUserCount }}
+    {{t
+      "confirmDelete.globalRoleNote"
+      count=resources.firstObject.globalRoleAssociatedUserCount
+    }}
   </div>
 {{/if}}
-
 <div class="footer-actions">
   <button class="btn bg-error" type="button" {{action "confirm"}}>
     {{t "confirmDelete.confirmAction"}}
@@ -108,7 +108,6 @@
     {{t "confirmDelete.cancelAction"}}
   </button>
 </div>
-
 {{#if showProtip}}
   <div class="protip mt-10">
     {{t "confirmDelete.protip" key=alternateLabel}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4734,6 +4734,7 @@ confirmDelete:
   forceDelete:
     label: Force Delete
     warning: "IMPORTANT: Force deleting pods does not wait for confirmation that the pod's processes have been terminated. This may result in <b>data corruption or inconsistencies</b>."
+  twoNodeEtcd: Removing an ETCD node from a two-node cluster is considered unsafe! We highly recommended that you increase the ETCD node count to three or more nodes before deleting one.
 
 containerLogs:
   download: Download Logs


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Rancher UI does not allow a user to create a 2 node etcd cluster but that is not a hard requirement on the ETCD side so they can exist. If a user is running a 2 node etcd cluster the UI will show a warning when removing an etcd node from a 2 node cluster. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
New Feature
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#29665
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
Since the UI does not allow a user to create this type of cluster (you can only have 1, 3, 5, etc etcd nodes) the 2 node cluster has to be created via the RKE CLI or some other manner outside of Rancher UI.
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
