### PR TITLE
[2.4.10] Send exit to container exec on close of container-shell

### DIFF
--- a/lib/shared/addon/components/container-shell/component.js
+++ b/lib/shared/addon/components/container-shell/component.js
@@ -235,6 +235,7 @@ export default Component.extend(ThrottledResize, {
     const socket = get(this, 'socket');
 
     if (socket) {
+      socket.send(`0${ AWS.util.base64.encode('exit\r\n') }`);
       socket.close();
 
       set(this, 'socket', null);


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Rather than add a warning the user needs to exit I've added a send to the socket for `exit\r\n` to disconnect the process before the socket closes


<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#16192
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
