### PR TITLE
[2.5.3] Global User Create Error Handling 

### DIFF
--- a/lib/global-admin/addon/components/form-global-roles/component.js
+++ b/lib/global-admin/addon/components/form-global-roles/component.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component'
-import { all as PromiseAll } from 'rsvp';
+import { all as PromiseAll, reject } from 'rsvp';
 import { inject as service } from '@ember/service';
 import { get, set, setProperties } from '@ember/object';
 import layout from './template';
@@ -103,7 +103,19 @@ export default Component.extend({
     return PromiseAll(add.map((x) => x.save())).then(() => {
       return PromiseAll(remove.map((x) => x.delete())).then(() => {
         return true;
+      }).catch((err) => {
+        if (this.setGRError) {
+          this.setGRError(err)
+        }
+
+        return reject(err);
       });
+    }).catch((err) => {
+      if (this.setGRError) {
+        this.setGRError(err)
+      }
+
+      return reject(err);
     });
   },
 

--- a/lib/global-admin/addon/security/accounts/new/controller.js
+++ b/lib/global-admin/addon/security/accounts/new/controller.js
@@ -5,6 +5,7 @@ import Controller from '@ember/controller';
 import NewOrEdit from 'ui/mixins/new-or-edit';
 import C from 'ui/utils/constants';
 import { get, set } from '@ember/object';
+import { resolve } from 'rsvp';
 
 const HEADERS = [
   {
@@ -27,16 +28,29 @@ export default Controller.extend(NewOrEdit, {
 
   sortBy: 'name',
 
-  globalRoleSave:  null,
-  canUserLogIn:    null,
+  globalRoleSave:      null,
+  canUserLogIn:        null,
+  globalRoleSaveError: false,
+
+  password: '',
 
   headers: HEADERS,
 
   primaryResource: alias('model.account'),
 
+  init() {
+    this._super(...arguments);
+
+    set(this, 'doSave', this._doSave.bind(this));
+  },
+
   actions:         {
     cancel() {
       this.transitionToRoute('security.accounts.users');
+    },
+
+    setGRError() {
+      set(this, 'globalRoleSaveError', true);
     },
 
     setGlobalRoleSave(fn) {
@@ -52,6 +66,12 @@ export default Controller.extend(NewOrEdit, {
     return get(this, 'settings').get(C.SETTING.AUTH_LOCAL_VALIDATE_DESC) || null;
   }),
 
+  users: computed('model.users.@each.{id,state}', function() {
+    const users = get(this, 'model.users');
+
+    return users;
+  }),
+
   roles: computed('model.globalRoles.[]', function() {
     return get(this, 'model.globalRoles').map((grb) => {
       return {
@@ -62,8 +82,8 @@ export default Controller.extend(NewOrEdit, {
     });
   }),
 
-  doesExist() {
-    let users = get(this, 'model.users');
+  doesExist: computed('users.@each.{username,id,state}', 'model.account.username', function() {
+    let users = get(this, 'users');
     let account = get(this, 'model.account');
 
     if (users.findBy('username', account.get('username'))) {
@@ -71,7 +91,7 @@ export default Controller.extend(NewOrEdit, {
     }
 
     return false;
-  },
+  }),
 
   validate() {
     var errors = [];
@@ -84,11 +104,11 @@ export default Controller.extend(NewOrEdit, {
       errors.push(get(this, 'intl').t('accountsPage.new.errors.usernameReq'));
     }
 
-    if (this.doesExist()) {
+    if (this.doesExist && !this.globalRoleSaveError) {
       errors.push(get(this, 'intl').t('accountsPage.new.errors.usernameInExists'));
     }
 
-    if ((get(this, 'model.account.password') || '').trim().length === 0) {
+    if ((get(this, 'password') || '').trim().length === 0 && !this.globalRoleSaveError) {
       errors.push(get(this, 'intl').t('accountsPage.new.errors.pwReq'));
     }
 
@@ -103,11 +123,41 @@ export default Controller.extend(NewOrEdit, {
     return true;
   },
 
+  willSave() {
+    set(this, 'model.account.password', get(this, 'password'));
+
+    set(this, 'errors', null);
+    var ok = this.validate();
+
+    return ok;
+  },
+
   didSave() {
     return this.globalRoleSave();
   },
 
   doneSaving() {
     this.transitionToRoute('security.accounts.users');
-  }
+  },
+
+  _doSave(opt) {
+    if (get(this, 'doesExist') && this.globalRoleSaveError) {
+      // we shouldn't hit this since I changed the password to be a static var instead of directly on th model.account.password and set it on save BUT if the password was cleared we don't have to reset it
+      if ((get(this, 'password') || '').trim().length === 0) {
+        return resolve(get(this, 'primaryResource'));
+      } else {
+        // else we should make sure there password is ALWAYS set to what they expect
+        return get(this, 'primaryResource').save(opt).then((newData) => {
+          this.mergeResult(newData);
+
+          return this.primaryResource.doAction('setpassword', { newPassword: this.password });
+        });
+      }
+    } else {
+      return get(this, 'primaryResource').save(opt).then((newData) => {
+        return this.mergeResult(newData);
+      });
+    }
+  },
+
 });

--- a/lib/global-admin/addon/security/accounts/new/route.js
+++ b/lib/global-admin/addon/security/accounts/new/route.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
-import { get } from '@ember/object';
+import { get, setProperties } from '@ember/object';
 
 export default Route.extend({
   globalStore: service(),
@@ -24,7 +24,12 @@ export default Route.extend({
 
   resetController(controller, isExisting /* , transition*/ ) {
     if (isExisting) {
-      controller.set('errors', null);
+      setProperties(controller, {
+        canUserLogIn:        null,
+        errors:              null,
+        globalRoleSaveError: false,
+        password:            '',
+      })
     }
   }
 });

--- a/lib/global-admin/addon/security/accounts/new/template.hbs
+++ b/lib/global-admin/addon/security/accounts/new/template.hbs
@@ -22,7 +22,7 @@
     <label class="pb-5 acc-label">
       {{t "accountsPage.new.form.password.labelText"}}{{field-required}}
     </label>
-    {{schema/input-password value=model.account.password}}
+    {{schema/input-password value=password}}
     <div class="text-info">
       {{validateDescription}}
     </div>
@@ -59,6 +59,7 @@
     @errors={{errors}}
     @mode="new"
     @setGRValidator={{action "setValidateGlobalRoles"}}
+    @setGRError={{action "setGRError"}}
     @setSave={{action "setGlobalRoleSave"}}
     @user={{model.account}}
   />


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
If a user was created and the subsequent global role calls failed there was no way to re-save the roles from the create page.
Now if a user creates but the roles fail the creator may select different roles and re-save to create the roles with out creating the new user.

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#29315
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
