### PR TITLE
fix languageName of Vietnamese

### DIFF
--- a/translations/vi-vn.yaml
+++ b/translations/vi-vn.yaml
@@ -1,5 +1,5 @@
 ---
-languageName: "Tiếng Anh"
+languageName: "Tiếng Việt"
 languageContribute: "Hỗ trợ dịch Rancher bởi namhbnam"
 ##############################
 #Really generic things used in multiple places (use sparingly)


### PR DESCRIPTION
Vietnamese Language should be written in
Tiếng Việt (vi-vn)

Tiếng Anh (vi-vn) means English