### PR TITLE
Fixing azure k8s version dropdown from breaking when selecing uae-central

### DIFF
--- a/lib/shared/addon/version-choices/service.js
+++ b/lib/shared/addon/version-choices/service.js
@@ -37,6 +37,6 @@ export default Service.extend({
 
         return out;
       }
-    });
+    }).filter((version) => version);
   }
 });


### PR DESCRIPTION
When selecting UAE central parseCloudProviderVersionChoices was returning 2 undefined elements which then broke the dropdown. It seemed that parseCloudProviderVersionChoices should only return valid choices so I filtered out falsey values.


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#28341
