### PR TITLE
[2.5.4] EKS prevent users from changing vpc/sub net choice after selected

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-eks/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-eks/template.hbs
@@ -295,26 +295,36 @@
               <label class="acc-label">
                 {{t "clusterNew.amazoneks.subnet.title"}}
               </label>
-              <div class="radio">
-                <label>
-                  <RadioButton
-                    @selection={{vpcSubnetMode}}
-                    @value="default"
-                    @disabled={{editing}}
-                  />
-                  {{t "clusterNew.amazoneks.vpc.radio.default"}}
-                </label>
-              </div>
-              <div class="radio">
-                <label>
-                  <RadioButton
-                    @selection={{vpcSubnetMode}}
-                    @value="custom"
-                    @disabled={{editing}}
-                  />
-                  {{t "clusterNew.amazoneks.vpc.radio.custom"}}
-                </label>
-              </div>
+              {{#if (eq step 3)}}
+                <div class="radio">
+                  <label>
+                    <RadioButton
+                      @selection={{vpcSubnetMode}}
+                      @value="default"
+                      @disabled={{editing}}
+                    />
+                    {{t "clusterNew.amazoneks.vpc.radio.default"}}
+                  </label>
+                </div>
+                <div class="radio">
+                  <label>
+                    <RadioButton
+                      @selection={{vpcSubnetMode}}
+                      @value="custom"
+                      @disabled={{editing}}
+                    />
+                    {{t "clusterNew.amazoneks.vpc.radio.custom"}}
+                  </label>
+                </div>
+              {{else}}
+                <div>
+                  {{#if (eq vpcSubnetMode "default")}}
+                    {{t "clusterNew.amazoneks.vpc.radio.default"}}
+                  {{else}}
+                    {{t "clusterNew.amazoneks.vpc.radio.custom"}}
+                  {{/if}}
+                </div>
+              {{/if}}
               {{#unless (eq vpcSubnetMode "default")}}
                 <select
                   class="form-control existing-subnet-groups"


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
previously we prevented users from changing the choice of standard or custom vpc which also loads the security groups, this adds the same logic back in for eks v2

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#30301

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
