### PR TITLE
Add static region list for (bootstrap) authentication to a subscribed…

### DIFF
--- a/lib/global-admin/addon/components/cru-cloud-credential/component.js
+++ b/lib/global-admin/addon/components/cru-cloud-credential/component.js
@@ -5,6 +5,7 @@ import layout from './template';
 import { get, set, computed, setProperties } from '@ember/object';
 import { next } from '@ember/runloop';
 import { REGIONS } from 'shared/utils/amazon';
+import { OCI_REGIONS } from 'shared/utils/oci';
 import { Promise } from 'rsvp';
 
 const CRED_CONFIG_CHOICES = [
@@ -63,6 +64,7 @@ export default Component.extend(ViewNewEdit, {
   region:                    null,
   sinlgeCloudKeyChoice:      null,
   regionChoices:             REGIONS,
+  ociRegionChoices:          OCI_REGIONS,
   mode:                      'new',
 
   init() {
@@ -239,7 +241,7 @@ export default Component.extend(ViewNewEdit, {
 
       if (cloudCredentialType === 'oci') {
         let authConfig = {
-          region:               'us-phoenix-1',
+          region:               this.config.region,
           tenancyOCID:          this.config.tenancyId,
           userOCID:             this.config.userId,
           fingerprint:          this.config.fingerprint,

--- a/lib/global-admin/addon/components/cru-cloud-credential/template.hbs
+++ b/lib/global-admin/addon/components/cru-cloud-credential/template.hbs
@@ -179,6 +179,18 @@
             id="oci-tenancy"
           }}
         </div>
+
+        <div class="col span-6">
+          <label class="acc-label">
+            {{t "modalAddCloudKey.oci.authRegion.label"}}{{field-required}}
+          </label>
+          <select class="form-control" onchange={{action (mut config.region) value="target.value"}}>
+            <option value="" selected={{eq config.region choice}}>Select a region to authenticate credentials</option>
+            {{#each ociRegionChoices as |choice|}}
+              <option value={{choice}} selected={{eq config.region choice}}>{{choice}}</option>
+            {{/each}}
+          </select>
+        </div>
       </div>
 
       <div class="row">
@@ -213,6 +225,21 @@
 
       <div class="row">
         <div class="col span-6">
+          <label class="acc-label" for="oci-privateKeyPassphrase">
+            {{t "modalAddCloudKey.oci.secretKeyPassphrase.label"}}
+          </label>
+          {{input
+            type="password"
+            classNames="form-control"
+            placeholder=(t "modalAddCloudKey.oci.secretKeyPassphrase.placeholder")
+            value=config.privateKeyPassphrase
+            id="oci-privateKeyPassphrase"
+          }}
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col span-6">
           <label class="acc-label" for="oci-privateKeyContents">
             {{t "modalAddCloudKey.oci.secretKey.label"}}{{field-required}}
           </label>
@@ -229,18 +256,6 @@
           }}
         </div>
 
-        <div class="col span-6">
-          <label class="acc-label" for="oci-privateKeyPassphrase">
-            {{t "modalAddCloudKey.oci.secretKeyPassphrase.label"}}
-          </label>
-          {{input
-            type="password"
-            classNames="form-control"
-            placeholder=(t "modalAddCloudKey.oci.secretKeyPassphrase.placeholder")
-            value=config.privateKeyPassphrase
-            id="oci-privateKeyPassphrase"
-          }}
-        </div>
       </div>
 
     {{else if (eq cloudCredentialType "vmware")}}

--- a/lib/nodes/addon/components/driver-oci/component.js
+++ b/lib/nodes/addon/components/driver-oci/component.js
@@ -4,6 +4,7 @@ import Component from '@ember/component';
 import NodeDriver from 'shared/mixins/node-driver';
 import layout from './template';
 import { inject as service } from '@ember/service';
+import { OCI_REGIONS } from 'shared/utils/oci';
 
 export default Component.extend(NodeDriver, {
   intl:     service(),
@@ -17,6 +18,7 @@ export default Component.extend(NodeDriver, {
   nodeAvailabilityDomain: '',
   nodeImage:              '',
   step:                    1,
+  regionChoices:          OCI_REGIONS,
 
   config: alias('model.ociConfig'),
 
@@ -30,25 +32,6 @@ export default Component.extend(NodeDriver, {
     },
   },
 
-  regionChoices: computed('model.cloudCredentialId', 'primaryResource.cloudCredentialId', async function() {
-    let token = get(this, 'primaryResource.cloudCredentialId');
-
-    if ( token !== null && token !== '') {
-      const auth = {
-        type: 'cloud',
-        token
-      };
-
-      const options = await this.oci.request(auth, 'regions');
-
-      return this.mapToContent(options);
-    }
-
-    return {
-      value: '',
-      label: '',
-    };
-  }),
   adChoices: computed('config.region', 'model.cloudCredentialId', 'primaryResource.cloudCredentialId', async function() {
     let token = get(this, 'primaryResource.cloudCredentialId');
     let region = get(this, 'config.region');

--- a/lib/nodes/addon/components/driver-oci/template.hbs
+++ b/lib/nodes/addon/components/driver-oci/template.hbs
@@ -35,14 +35,13 @@
     <div class="row">
 
       <div class="col span-6">
-        <label class="acc-label">{{t 'nodeDriver.oci.region.label'}}{{field-required}}</label>
-        {{#input-or-display value=selectedRegion}}
-          {{searchable-select class="form-control"
-                              content=regionChoices
-                              value=config.region
-                              placeholder=(t "nodeDriver.oci.region.placeholder")
-          }}
-        {{/input-or-display}}
+        <label class="acc-label">{{t "nodeDriver.oci.region.label"}}{{field-required}}</label>
+        <select class="form-control" onchange={{action (mut config.region) value="target.value"}}>
+          <option value="" selected={{eq config.region choice}}>Select a region</option>
+          {{#each regionChoices as |choice|}}
+            <option value={{choice}} selected={{eq config.region choice}}>{{choice}}</option>
+          {{/each}}
+        </select>
       </div>
 
       <div class="col span-6">

--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
@@ -5,6 +5,7 @@ import { equal } from '@ember/object/computed'
 import { get, set, computed, setProperties } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
+import { OCI_REGIONS } from 'shared/utils/oci';
 
 
 const vcnIdMap = { quick: 'Quick Create', }
@@ -15,23 +16,23 @@ const subnetAccessMap = {
 }
 
 export default Component.extend(ClusterDriver, {
-  intl:            service(),
+  intl:              service(),
   layout,
-  configField:     'okeEngineConfig',
-  instanceConfig:  '',
-  step:            1,
-  lanChanged:      null,
-  refresh:         false,
-  vcnCreationMode: 'none',
-  vpcs:                    null,
-  subnets:                 null,
-  eipIds:                  null,
-  nodeFlavors:             null,
-  keypairs:                null,
-  availableZones:          null,
-
-  isNew:                   equal('mode', 'new'),
-  editing:                 equal('mode', 'edit'),
+  configField:       'okeEngineConfig',
+  instanceConfig:    '',
+  step:              1,
+  lanChanged:        null,
+  refresh:           false,
+  vcnCreationMode:   'none',
+  vpcs:              null,
+  subnets:           null,
+  eipIds:            null,
+  nodeFlavors:       null,
+  keypairs:          null,
+  availableZones:    null,
+  authRegionChoices: OCI_REGIONS,
+  isNew:             equal('mode', 'new'),
+  editing:           equal('mode', 'edit'),
 
   init() {
     this._super(...arguments);
@@ -91,20 +92,14 @@ export default Component.extend(ClusterDriver, {
           url:    '/meta/oci/okeVersions',
           method: 'POST',
           data
-        }),
-        regions: store.rawRequest({
-          url:    '/meta/oci/regions',
-          method: 'POST',
-          data
         })
       }
 
       return hash(ociRequest).then((resp) => {
-        const { okeVersions, regions } = resp;
+        const { okeVersions } = resp;
 
         setProperties(this, {
           okeVersions:  (get( okeVersions, 'body') || []),
-          regions:      (get( regions, 'body') || []),
           errors:       [],
         });
 
@@ -272,11 +267,11 @@ export default Component.extend(ClusterDriver, {
 
     return subnetAccess && subnetAccessMap[subnetAccess];
   }),
-  canAuthenticate: computed('config.tenancyId', 'config.compartmentId', 'config.userOcid', 'config.fingerprint', 'config.privateKeyContents', function() {
-    return get(this, 'config.tenancyId') && get(this, 'config.compartmentId') && get(this, 'config.userOcid') && get(this, 'config.fingerprint') && get(this, 'config.privateKeyContents') ? false : true;
+  canAuthenticate: computed('config.tenancyId', 'config.region', 'config.userOcid', 'config.fingerprint', 'config.privateKeyContents', function() {
+    return get(this, 'config.tenancyId') && get(this, 'config.region') && get(this, 'config.userOcid') && get(this, 'config.fingerprint') && get(this, 'config.privateKeyContents') ? false : true;
   }),
-  canAddK8sVersion: computed('config.region', 'config.kubernetesVersion', function() {
-    return !(get(this, 'config.region') && get(this, 'config.kubernetesVersion'));
+  canAddK8sVersion: computed('config.kubernetesVersion', 'config.compartmentId', function() {
+    return !(get(this, 'config.compartmentId') && get(this, 'config.kubernetesVersion'));
   }),
 
   canSaveVCN: computed('vcnCreationMode', 'config.vcnName', 'config.loadBalancerSubnetName1', 'config.loadBalancerSubnetName2', 'config.subnetAccess', 'config.vcnCidr', function() {

--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/template.hbs
@@ -19,14 +19,22 @@
         {{/input-or-display}}
       </div>
 
-
       <div class="col span-6">
         <label class="acc-label">
-          {{t 'clusterNew.oracleoke.compartmentOCID.label'}}{{field-required}}
+          {{t 'clusterNew.oracleoke.region.label'}}{{field-required}}
         </label>
-        {{#input-or-display editable=isNew value=config.compartmentId}}
-          {{input type="text" name="compartment" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.compartmentOCID.placeholder') value=config.compartmentId}}
-        {{/input-or-display}}
+        {{#if (and (eq step 1) isNew)}}
+          <select class="form-control" onchange={{action (mut config.region) value="target.value"}}>
+            {{#each authRegionChoices as |choice|}}
+              <option value={{choice}} selected={{eq config.region choice}}>{{choice}}</option>
+            {{/each}}
+          </select>
+          <p class="help-block">
+            {{t 'clusterNew.oracleoke.region.help'}}
+          </p>
+        {{else}}
+          <div>{{config.region}}</div>
+        {{/if}}
       </div>
 
     </div>
@@ -51,6 +59,9 @@
           {{input type="text" name="fingerprint" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.userFingerprint.placeholder') value=config.fingerprint}}
         {{/input-or-display}}
       </div>
+
+    </div>
+    <div class="row">
 
       <div class="col span-6">
         <label class="acc-label">
@@ -102,18 +113,6 @@
                            expandAll=al.expandAll
                            expand=(action expandFn)
     }}
-      <div class="row">
-        <div class="col span-6">
-          <label class="acc-label">
-            {{t 'clusterNew.oracleoke.region.label'}}{{field-required}}
-          </label>
-          {{#if (eq step 2)}}
-            {{#input-or-display editable=isNew value=config.region}}
-              {{input type="text" name="region" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.region.placeholder') value=config.region}}
-            {{/input-or-display}}
-          {{/if}}
-        </div>
-      </div>
       <div class="row">
 
         <div class="col span-4">
@@ -173,20 +172,6 @@
         <div class="row">
           <div class="col span-4 mb-0">
             <label class="acc-label">
-              {{t 'clusterNew.oracleoke.region.label'}}
-            </label>
-            {{#if (eq step 2)}}
-              <select class="form-control" onchange={{action (mut config.region) value="target.value"}}>
-                {{#each regions as |choice|}}
-                  <option value={{choice}} selected={{eq config.region choice}}>{{choice}}</option>
-                {{/each}}
-              </select>
-            {{else}}
-              <div>{{config.region}}</div>
-            {{/if}}
-          </div>
-          <div class="col span-4 mb-0">
-            <label class="acc-label">
               {{t 'clusterNew.oracleoke.version.label'}}
             </label>
             {{#if (eq step 2)}}
@@ -210,6 +195,17 @@
               <p class="help-block">
                 {{t 'clusterNew.oracleoke.quantityPerSubnet.help'}}
               </p>
+            {{/input-or-display}}
+          </div>
+
+        </div>
+        <div class="row">
+          <div class="col span-4">
+            <label class="acc-label">
+              {{t 'clusterNew.oracleoke.compartmentOCID.label'}}{{field-required}}
+            </label>
+            {{#input-or-display editable=(and (eq step 2) isNew) value=config.compartmentId}}
+              {{input type="text" name="compartment" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.compartmentOCID.placeholder') value=config.compartmentId}}
             {{/input-or-display}}
           </div>
 

--- a/lib/shared/addon/utils/oci.js
+++ b/lib/shared/addon/utils/oci.js
@@ -1,0 +1,37 @@
+// Copyright 2020 Oracle and/or its affiliates.
+
+// See:
+//   https://docs.cloud.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
+//   https://docs.cloud.oracle.com/en-us/iaas/Content/General/Concepts/govfeddod.htm
+//   https://docs.cloud.oracle.com/en-us/iaas/Content/General/Concepts/govuksouth.htm
+export const OCI_REGIONS = [
+  'ap-chuncheon-1',
+  'ap-hyderabad-1',
+  'ap-mumbai-1',
+  'ap-melbourne-1',
+  'ap-osaka-1',
+  'ap-seoul-1',
+  'ap-sydney-1',
+  'ap-tokyo-1',
+  'ca-montreal-1',
+  'ca-toronto-1',
+  'eu-amsterdam-1',
+  'eu-frankfurt-1',
+  'eu-zurich-1',
+  'me-dubai-1',
+  'me-jeddah-1',
+  'sa-saopaulo-1',
+  'uk-cardiff-1',
+  'uk-london-1',
+  'us-phoenix-1',
+  'us-ashburn-1',
+  'us-sanjose-1',
+  'us-langley-1',
+  'us-luke-1',
+  'us-gov-ashburn-1',
+  'us-gov-phoenix-1',
+  'us-gov-chicago-1',
+  'uk-gov-london-1',
+  'uk-gov-cardiff-1',
+];
+

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4088,10 +4088,11 @@ clusterNew:
     access:
       next: "Next: Authenticate & Configure Cluster"
       loading: Loading values from Oracle Cloud Infrastructure
-      title: Choose the region and API Key that will be used to authenticate and configure Oracle Container Engine.
+      title: OCI Cloud Credentials
       detail: Choose the region and API Key that will be used to authenticate and configure Oracle Container Engine.
     region:
       label: Region
+      help: The geographic region in which the cluster will run
     tenancyOCID:
       label: Tenancy OCID
       placeholder: The OCID of the tenancy in which to create resources
@@ -4100,9 +4101,10 @@ clusterNew:
       label: Compartment OCID
       placeholder: The OCID of the compartment in which to create the resources
       required: Compartment OCID is required
+      help: The compartment in which the cluster will reside
     userOcid:
       label: User OCID
-      placeholder: The OCID of a user who has access to the specified tenancy/compartment
+      placeholder: The OCID of a user who has access to the specified tenancy
       required: Tenancy OCID is required
     userFingerprint:
       label: User fingerprint
@@ -4115,11 +4117,11 @@ clusterNew:
       required: User Private API Key is required
     secretKeyPassphrase:
       label: User Private Key Passphrase
-      placeholder: The passphrase (if any) that protects private key file the specified OCI user
+      placeholder: The passphrase (if any) that protects private key file of the specified OCI user
       provided: Provided
     cluster:
       title: Cluster Configuration
-      detail: Choose the Kubernetes version and the number of nodes per availability-domain for the cluster.
+      detail: Choose the Kubernetes version, the number of nodes, and the target compartment for the cluster.
       next: "Next: Configure Virtual Cloud Network"
       loading: Loading VCNs from Oracle Cloud Infrastructure
     vcn:
@@ -7947,7 +7949,7 @@ modalAddCloudKey:
   oci:
     userOcid:
       label: User OCID
-      placeholder: The OCID of a user
+      placeholder: The OCID of a user who has access to the specified tenancy
     userFingerprint:
       label: User fingerprint
       placeholder: The fingerprint corresponding to the specified user's private API Key
@@ -7956,10 +7958,14 @@ modalAddCloudKey:
       placeholder: The private API key contents for the specified OCI user, in PEM format
     secretKeyPassphrase:
       label: User Private Key Passphrase
-      placeholder: The passphrase (if any) that protects private key file the specified OCI user
+      placeholder: The passphrase (if any) that protects private key file of the specified OCI user
     tenancyOcid:
       label: Tenancy OCID
-      placeholder: The OCID of the tenancy in the user account exists
+      placeholder: The OCID of the tenancy containing the user
+    authRegion:
+      label: Region
+      help: Any region your tenancy is subscribed to authenticate your credentials.
+
 
   vmwarevsphere:
     password:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

This PR resolves a "chicken-and-egg" problem in the OCI node and OKE cluster drivers where a user is required to authenticate against a [region](https://docs.cloud.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm) they are _subscribed to_ to in order to access the OCI API, but retrieving that list of available regions itself requires authentication. 

We had previously worked around this issue by defaulting to `us-phoenix-1` region. However, this does not work [if the user is not subscribed to this region](https://github.com/rancher-plugins/kontainer-engine-driver-oke/issues/20). The fix here is to add and maintain a static _baootstrap_ list of available regions that the two drivers can share - everything else will continue to be fetched dynamically from the API.

Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Bugfix, New feature

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

https://github.com/rancher-plugins/kontainer-engine-driver-oke/issues/20

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->

This should probably be [back-ported to 2.4](https://github.com/rancher/ui/pull/4325) as well.

![CC OCI Node](https://user-images.githubusercontent.com/13613687/100945867-fa1f9c80-34b6-11eb-8495-21f2a128988d.png)
![OKE Cluster](https://user-images.githubusercontent.com/13613687/100945875-fee45080-34b6-11eb-9cf4-592c7a2bc8b9.png)

