### PR TITLE
[2.5.4] Missing Save/Cancel Buttons Imported Cluster

### DIFF
--- a/lib/shared/addon/components/cru-cluster/component.js
+++ b/lib/shared/addon/components/cru-cluster/component.js
@@ -262,6 +262,12 @@ export default Component.extend(ViewNewEdit, ChildHook, {
       });
 
       out.push({
+        name:    'imported',
+        driver:  'import',
+        preSave: true
+      });
+
+      out.push({
         name:     'importeks',
         driver:   'import-eks',
         preSave:  false,


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
When we changed up how the cluster selection and creation was done to account for the provider param there was a bug in HA local clusters that prevented the save and cancel buttons from showing up. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#30354
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
