### PR TITLE
Edit Yaml Comments Nesting Level

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -807,30 +807,25 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
       lines.forEach((line, idx) => {
         if ( line.trim() ) {
-          let key          = '';
-          let commentLines = '';
+          if (!this.isEdit) {
+            let key          = '';
+            let commentLines = '';
 
-          if (idx === 0) {
-            commentLines = intl.t('').split('\n');
-            key = `rkeConfigComment.clusterConfig`
-          } else {
-            key = `rkeConfigComment.${ line.split(':')[0].trim() }`
+            if (idx === 0) {
+              commentLines = intl.t('').split('\n');
+              key = `rkeConfigComment.clusterConfig`
+            } else {
+              key = `rkeConfigComment.${ line.split(':')[0].trim() }`
+            }
+
+            if ( intl.exists(key) ) {
+              commentLines = intl.t(key).split('\n');
+
+              commentLines.forEach((commentLine) => {
+                out += `# ${ commentLine.slice(1, commentLine.length - 1) }\n`;
+              });
+            }
           }
-
-          if ( intl.exists(key) ) {
-            // We can face problems when embedding comments into the YAML, e.g. placing comments under a multi-line string -> addons: |-↵
-            // ---↵apiVersion: networking.k8s.io/v1↵kind: NetworkPolicy↵metadata:↵  name: test-network-policy↵  namespace: default↵spec:↵  podSelector:↵    matchLabels:↵      role: db↵  policyTypes:↵  - Ingress↵  - Egress↵  ingress:↵  - {}"
-            // Adding the whitespace at least nests the comments to the right level. We will strip the comments off later before we dump it because of the possability of multiline strings
-            const whitespaceIndex = line.search(/\S|$/);
-            const whitespace = whitespaceIndex > 0 ? line.slice(0, whitespaceIndex) : '';
-
-            commentLines = intl.t(key).split('\n');
-
-            commentLines.forEach((commentLine) => {
-              out += `${ whitespace }# ${ commentLine.slice(1, commentLine.length - 1) }\n`;
-            });
-          }
-
           out += `${ line.trimEnd() }\n`;
         }
       });
@@ -968,10 +963,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     let yamlConfig;
 
     try {
-      // strip comments from the yaml, including any in multi-line strings
-      const newYaml = yamlValue.split('\n').filter((line) => !line.trim().startsWith('#')).join('\n');
-
-      yamlConfig = jsyaml.safeLoad(newYaml);
+      yamlConfig = jsyaml.safeLoad(yamlValue);
     } catch ( err ) {
       set(this, 'clusterOptErrors', [`Cluster Options Parse Error: ${ err.snippet } - ${ err.message }`]);
 

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -818,10 +818,16 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
           }
 
           if ( intl.exists(key) ) {
+            // We can face problems when embedding comments into the YAML, e.g. placing comments under a multi-line string -> addons: |-↵
+            // ---↵apiVersion: networking.k8s.io/v1↵kind: NetworkPolicy↵metadata:↵  name: test-network-policy↵  namespace: default↵spec:↵  podSelector:↵    matchLabels:↵      role: db↵  policyTypes:↵  - Ingress↵  - Egress↵  ingress:↵  - {}"
+            // Adding the whitespace at least nests the comments to the right level. We will strip the comments off later before we dump it because of the possability of multiline strings
+            const whitespaceIndex = line.search(/\S|$/);
+            const whitespace = whitespaceIndex > 0 ? line.slice(0, whitespaceIndex) : '';
+
             commentLines = intl.t(key).split('\n');
 
             commentLines.forEach((commentLine) => {
-              out += `# ${ commentLine.slice(1, commentLine.length - 1) }\n`;
+              out += `${ whitespace }# ${ commentLine.slice(1, commentLine.length - 1) }\n`;
             });
           }
 
@@ -962,7 +968,10 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     let yamlConfig;
 
     try {
-      yamlConfig = jsyaml.safeLoad(yamlValue);
+      // strip comments from the yaml, including any in multi-line strings
+      const newYaml = yamlValue.split('\n').filter((line) => !line.trim().startsWith('#')).join('\n');
+
+      yamlConfig = jsyaml.safeLoad(newYaml);
     } catch ( err ) {
       set(this, 'clusterOptErrors', [`Cluster Options Parse Error: ${ err.snippet } - ${ err.message }`]);
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
~When we embed comments into the yaml on Cluster Edit if the comment is embedded in a multi-line string the yaml editor breaks and users have to remove the comments (or nest them correctly) to save the cluster. AFAICT without implementing some pretty complex logic it would be pretty hard to detect if we are in a mulit-line string while looping over the yaml lines to build the content for the editor.~

~I am proposing the following solution:
While looping, keep track of the lines whitespace. If we embed comments, prepend tracked whitespace to the comment line. 
Before dumping the yaml to an object, so it can be parsed over the cluster config (clusters dont take a yaml file), strip all comment lines. Normally we dont have to do this because js-yaml will drop comments when converting yaml to object, but in the case where we embedded comments into ML strings, we must also strip manually. I dont think its useful to send our comments with the string so this made sense to me.~

After some discussion this original change was reverted. Going forward we will not embed rancher comments in the cluster yaml on edit. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#28532

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
@vincent99 @deniseschannon Would this be acceptable? We hit the particular issue mentioned because of the `addons: |-` multi-line string param in the customers cluster yaml. Because it contained the word `ingress` which [matched our comments translation map](https://github.com/rancher/ui/blob/master/lib/shared/addon/components/cluster-driver/driver-rke/component.js#L820) we push the ingress comments. But that also means that we have the ingress comments at the normal ingress level. Not the most desirable result. The other option would be disabling embedding of the comments on edit. Thats even easier to do but thought it may raise more confusion. 
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
