### PR TITLE
[2.5.x] Expose rotate encryption keys action and modal

### DIFF
--- a/app/components/modal-rotate-encryption-key/component.js
+++ b/app/components/modal-rotate-encryption-key/component.js
@@ -20,7 +20,7 @@ export default Component.extend(ModalBase, {
       const { cluster } = this;
 
       try {
-        await cluster.doAction('rotateEncryptionKeys');
+        await cluster.doAction('rotateEncryptionKey');
 
         cb(true);
 

--- a/app/components/modal-rotate-encryption-key/component.js
+++ b/app/components/modal-rotate-encryption-key/component.js
@@ -1,0 +1,51 @@
+import Component from '@ember/component';
+import ModalBase from 'shared/mixins/modal-base';
+import layout from './template';
+import { inject as service } from '@ember/service';
+import { get, computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import moment from 'moment';
+
+export default Component.extend(ModalBase, {
+  growl: service(),
+
+  layout,
+  classNames: ['large-modal'],
+
+  etcdBackups: alias('modalOpts.model.etcdbackups'),
+  cluster:     alias('modalOpts.model'),
+
+  actions: {
+    async rotate(cb) {
+      const { cluster } = this;
+
+      try {
+        await cluster.doAction('rotateEncryptionKeys');
+
+        cb(true);
+
+        this.send('cancel');
+      } catch (error) {
+        cb(false);
+      }
+    }
+  },
+
+  lastBackup: computed('etcdBackups.@each.created', function() {
+    const { etcdBackups } = this;
+    const latest = get(etcdBackups, 'firstObject');
+
+    if (!latest) {
+      return null;
+    }
+
+    const backupName = get(latest, 'displayName');
+    const created = moment(get(latest, 'created'));
+    const backupTime = created ? created.format('MMMM Do YYYY, HH:mm:ss') : 'N/A';
+
+    return {
+      backupName,
+      backupTime,
+    }
+  }),
+});

--- a/app/components/modal-rotate-encryption-key/template.hbs
+++ b/app/components/modal-rotate-encryption-key/template.hbs
@@ -1,0 +1,26 @@
+<div class="container-header-text">
+  <h3>
+    {{t "modalRotateEncryption.title"}}
+  </h3>
+</div>
+{{banner-message
+  color="bg-warning"
+  message=(t "modalRotateEncryption.backupWarning")
+}}
+<div class="row">
+  <div class="col span-12">
+    <p>
+      {{t "modalRotateEncryption.lastBackup" backupName=lastBackup.backupName backupTime=lastBackup.backupTime}}
+    </p>
+  </div>
+</div>
+<TopErrors @errors={{errors}} />
+<div class="footer-actions">
+  {{save-cancel
+    class="pt-0"
+    cancel=(action "cancel")
+    editLabel="generic.confirm"
+    editing=true
+    save=(action "rotate")
+  }}
+</div>

--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -692,9 +692,7 @@ export default Resource.extend(Grafana, ResourceUsage, {
     rotateEncryptionKeys() {
       const model = this;
 
-      get(this, 'modalService').toggleModal('modal-rotate-encryption-key', {
-        model,
-      });
+      get(this, 'modalService').toggleModal('modal-rotate-encryption-key', { model, });
     },
 
     showCommandModal() {

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -1480,9 +1480,12 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       services: globalStore.createRecord({
         type:    'rkeConfigServices',
         kubeApi: globalStore.createRecord({
-          type:                  'kubeAPIService',
-          podSecurityPolicy:     false,
-          serviceNodePortRange: '30000-32767',
+          type:                    'kubeAPIService',
+          podSecurityPolicy:       false,
+          serviceNodePortRange:    '30000-32767',
+          secretsEncryptionConfig: globalStore.createRecord({
+            type: 'secretsEncryptionConfig'
+          })
         }),
         etcd: globalStore.createRecord({
           type:         'etcdService',

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -1483,9 +1483,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
           type:                    'kubeAPIService',
           podSecurityPolicy:       false,
           serviceNodePortRange:    '30000-32767',
-          secretsEncryptionConfig: globalStore.createRecord({
-            type: 'secretsEncryptionConfig'
-          })
+          secretsEncryptionConfig: globalStore.createRecord({ type: 'secretsEncryptionConfig' })
         }),
         etcd: globalStore.createRecord({
           type:         'etcdService',

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -566,7 +566,45 @@
           </div>
           <div class="row">
             <div class="col span-12">
-
+              <label class="acc-label">
+                {{t "clusterNew.rke.secretsEncryption.label"}}
+                {{#if clusterTemplateCreate}}
+                  <ClusterTemplateOverrideToggle
+                    @path="rancherKubernetesEngineConfig.services.kubeApi.secretsEncryptionConfig.enabled"
+                    @configVariable={{config.services.kubeApi.secretsEncryptionConfig.enabled}}
+                    @addOverride={{action "addOverride"}}
+                    @questions={{model.clusterTemplateRevision.questions}}
+                  />
+                {{/if}}
+              </label>
+              <CheckOverrideAllowed
+                @paramName="rancherKubernetesEngineConfig.services.kubeApi.secretsEncryptionConfig.enabled"
+                @applyClusterTemplate={{applyClusterTemplate}}
+                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                @questions={{model.clusterTemplateRevision.questions}}
+              >
+                {{#input-or-display
+                   editable=notView
+                   value=config.services.kubeApi.secretsEncryptionConfig.enabled
+                }}
+                  <div>
+                    <label class="radio mt-0">
+                      {{radio-button selection=config.services.kubeApi.secretsEncryptionConfig.enabled value=true}}
+                      {{t "generic.enabled"}}
+                    </label>
+                  </div>
+                  <div>
+                    <label class="radio">
+                      {{radio-button selection=config.services.kubeApi.secretsEncryptionConfig.enabled value=false}}
+                      {{t "generic.disabled"}}
+                    </label>
+                  </div>
+                {{/input-or-display}}
+              </CheckOverrideAllowed>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col span-12">
               <label class="acc-label">
                 {{t "clusterNew.rke.etcd.location.label"}}
                 {{#if clusterTemplateCreate}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4196,6 +4196,8 @@ clusterNew:
   rancherd:
     shortLabel: RancherD
   rke:
+    secretsEncryption:
+      label: Secrets Encryption
     upgradeStrategy:
       maximumWorkersDown:
         view:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -8169,6 +8169,11 @@ modalRotateCertificates:
     until: '{ cert } (expires { expiresIn })'
     from: '{ cert } (expired { expiresIn })'
 
+modalRotateEncryption:
+  title: Rotate Encryption Keys
+  backupWarning: Before proceeding, ensure a successful ETCD backup of the cluster has been completed.
+  lastBackup: The last backup {backupName} was performed on {backupTime}
+
 modalRollbackService:
   title: 'Rollback "{instanceName}"'
   titleWithSidekicks: 'Rollback "{instanceName}" & {count, plural, =1 {# sidecar} other {# sidecar}}'
@@ -9974,6 +9979,7 @@ action:
   revision: New Revision from Default
   rollback: Rollback
   rotate: Rotate Certificates
+  rotateEncryption: Rotate Encryption Keys
   run: Run
   runCISScan: Run CIS Scan
   saveAsTemplate: Save As RKE Template


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This PR exposes the `rotateEncryptionKey` action on RKE clusters. Adds a new modal and warning about taking a backup before proceeding.
Additionally, I have added some logic around when we show the action in the UI. We explicitly do not expose the action until the cluster has at least one backup, and that backup is within the last 6 hours (or 360 min). Six hours is an arbitrary time frame, and one could argue the 'time since last backup' check should be in the backend, but the implementation was minimal and I think the UX is improved since we want users to make a backup. The backups can take a while depending on the size of the cluster and six hours seems sufficient. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
New Feature
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#30077

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
![Screen Shot 2020-12-16 at 4 13 37 PM](https://user-images.githubusercontent.com/858614/102419690-8b196c00-3fbd-11eb-81fa-2d20af8ae55f.png)
![Screen Shot 2020-12-16 at 4 17 42 PM](https://user-images.githubusercontent.com/858614/102419698-8e145c80-3fbd-11eb-8fcc-c3b1edd727e0.png)

<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
