### PR TITLE
[2.5.4] Rotate Secrets Encryption Bugs

### DIFF
--- a/app/authenticated/cluster/route.js
+++ b/app/authenticated/cluster/route.js
@@ -29,12 +29,18 @@ export default Route.extend(Preload, {
 
         return get(this, 'scope').startSwitchToCluster(cluster).then(() => {
           if ( get(cluster, 'isReady') ) {
-            return this.loadSchemas('clusterStore').then(() => PromiseAll([
+            const preloads = [
               this.preload('clusterScan', 'globalStore'),
               this.preload('namespace', 'clusterStore'),
-              this.preload('storageClass', 'clusterStore'),
               this.preload('persistentVolume', 'clusterStore'),
-            ]).then(() => cluster));
+              this.preload('storageClass', 'clusterStore'),
+            ];
+
+            if (get(cluster, 'isRKE')) {
+              preloads.push(this.preload('etcdBackup', 'globalStore'));
+            }
+
+            return this.loadSchemas('clusterStore').then(() => PromiseAll(preloads).then(() => cluster));
           } else {
             return cluster;
           }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Adds isActive to computed check for canRotateEncryptionKey. Originally I only keyed on Transition doesn't always update as often or as fast and isActive. I dont see a downside in checking both though its unlikely we'd ever get into a state where they are both not true or false.
Add `etcdBackup` to the list of preloads for RKE cluster to ensure rotate encryption keys works from a fresh load of the ui at the cluster level.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#30552
rancher/rancher#30553
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
