### PR TITLE
[2.5.4] Edit As Yaml Resources Key Name Bug

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -1313,6 +1313,11 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     let resourceFields;
     const out = {};
 
+    if (type === 'map[json]' && get(( field || {} ), 'Resources') && get(( field || {} ), 'kind') === 'EncryptionConfiguration') {
+      // this is a one off change to handle rancherKubernetesEngineConfig.services.kubeAPI.secretsEncryptionConfig.customConfig arbitrary JSON problem seeing in #30555.
+      return field;
+    }
+
     if ( type.startsWith('map[') ) {
       type = type.slice(4, type.length - 1);
 


### PR DESCRIPTION



<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Adds in one off check for secretsEncryption.customConfig. The custom config has a type of `map[json]` and when we process this for the edit yaml view we can goof some of the keys in the arbitrary JSON.
Specifically the `Resources` key gets dasherized and lower cased which borks  the cluster on save.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#30555

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
