### PR TITLE
[backport 2.5] Ensuring the initial values are set on vsphere template when switching credentials

### DIFF
--- a/lib/nodes/addon/components/driver-vmwarevsphere/component.js
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/component.js
@@ -203,6 +203,10 @@ export default Component.extend(NodeDriver, {
   datacenterContent: computed('model.cloudCredentialId', async function() {
     const options = await this.requestOptions('data-centers', get(this, 'model.cloudCredentialId'));
 
+    set(this, 'config.datacenter', options[0]);
+    set(this, 'config.cloneFrom', undefined);
+    set(this, 'config.useDataStoreCluster', false);
+
     return this.mapPathOptionsToContent(options);
   }),
 
@@ -210,6 +214,8 @@ export default Component.extend(NodeDriver, {
     const categoriesPromise = this.requestOptions('tag-categories', get(this, 'model.cloudCredentialId'));
     const optionsPromise = this.requestOptions('tags', get(this, 'model.cloudCredentialId'));
     const [categories, options] = await Promise.all([categoriesPromise, optionsPromise]);
+
+    set(this, 'config.tag', []);
 
     return this.mapTagsToContent(options).map((option) => ({
       ...option,
@@ -229,6 +235,8 @@ export default Component.extend(NodeDriver, {
       get(this, 'config.datacenter')
     );
 
+    set(this, 'config.hostsystem', options[0])
+
     return this.mapHostOptionsToContent(options);
   }),
 
@@ -239,6 +247,8 @@ export default Component.extend(NodeDriver, {
       get(this, 'config.datacenter')
     );
 
+    set(this, 'config.pool', options[0]);
+
     return this.mapPoolOptionsToContent(options);
   }),
 
@@ -248,6 +258,8 @@ export default Component.extend(NodeDriver, {
       get(this, 'model.cloudCredentialId'),
       get(this, 'config.datacenter')
     );
+
+    set(this, 'config.datastore', options[0]);
 
     return this.mapPathOptionsToContent(options);
   }),
@@ -269,6 +281,8 @@ export default Component.extend(NodeDriver, {
       get(this, 'config.datacenter')
     );
 
+    set(this, 'config.folder', options[0]);
+
     return this.mapFolderOptionsToContent(options);
   }),
 
@@ -279,6 +293,8 @@ export default Component.extend(NodeDriver, {
       get(this, 'config.datacenter')
     );
 
+    set(this, 'config.network', []);
+
     return this.mapPathOptionsToContent(options);
   }),
 
@@ -288,6 +304,8 @@ export default Component.extend(NodeDriver, {
       get(this, 'model.cloudCredentialId'),
       get(this, 'config.datacenter')
     );
+
+    set(this, 'config.contentLibrary', options[0]);
 
     return this.mapPathOptionsToContent(options);
   }),


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
For props that have options which depend on the selected credentials or datacenter this ensures that the props are reinitialized to one of the options.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#30074

Further comments
======
This one was a little difficult to verify since I only have access to one vsphere datacenter. I ended up mocking the responses in a way that I think will be sufficient but we may encounter more edge cases.
