### PR TITLE
Migrating environment variables over to new format

### DIFF
--- a/app/components/container/form-sources/component.js
+++ b/app/components/container/form-sources/component.js
@@ -44,19 +44,10 @@ export default Component.extend({
     if (!get(this, 'sources') ) {
       set(this, 'sources', [])
     }
-
-    get(this, 'sources').forEach((source) => {
-      if ( source.sourceKey === undefined ) {
-        set(source, 'sourceKey', null);
-      }
-    });
   },
   actions: {
     addSource() {
-      let source = {
-        source:    'secret',
-        sourceKey: null
-      };
+      let source = { source: null };
 
       get(this, 'sources').addObject(source);
     },

--- a/app/components/container/form-sources/template.hbs
+++ b/app/components/container/form-sources/template.hbs
@@ -1,19 +1,19 @@
 {{#if editing}}
   <div class="clearfix">
-    <label class="acc-label">{{t 'newContainer.environment.from'}}</label>
+    <label class="acc-label">{{t 'newContainer.environment.label'}}</label>
   </div>
   <div>
     {{#if sources.length}}
       <table class="table fixed no-lines small mb-10">
         <thead>
           <tr class="hidden-sm">
-            <th width="140">{{t 'formSources.type.label'}}{{field-required}}</th>
+            <th width="25%">{{t 'formSources.type.label'}}{{field-required}}</th>
             <th width="10"></th>
-            <th width="220">{{t 'formSources.source.label'}}{{field-required}}</th>
+            <th width="25%">{{t 'formSources.prefixOrKey.label'}}{{field-required}}</th>
+            <th width="20"></th>
+            <th width="25%">{{t 'formSources.value.label'}}{{field-required}}</th>
             <th width="10"></th>
-            <th>{{t 'formSources.prefixOrKey.label'}}{{field-required}}</th>
-            <th width="70"></th>
-            <th>{{t 'formSources.prefix.label'}}</th>
+            <th width="25%">{{t 'formSources.key.label'}}{{field-required}}</th>
             <th width="40">&nbsp;</th>
           </tr>
         </thead>
@@ -30,7 +30,7 @@
     {{/if}}
     <button type="button" class="btn bg-link icon-btn" {{action "addSource"}}>
       <span class="darken"><i class="icon icon-plus icon-small"></i></span>
-      <span>{{t 'newContainer.environment.addFrom'}}</span>
+      <span>{{t 'newContainer.environment.addAction'}}</span>
     </button>
   </div>
 {{else}}

--- a/app/components/container/new-edit/component.js
+++ b/app/components/container/new-edit/component.js
@@ -67,8 +67,8 @@ export default Component.extend(NewOrEdit, ChildHook, {
     window.nec = this;
     this._super(...arguments);
 
-    if (get(this, 'launchConfig') && !get(this, 'launchConfig.environmentFrom')) {
-      set(this, 'launchConfig.environmentFrom', []);
+    if (get(this, 'launchConfig') && !get(this, 'launchConfig.environment')) {
+      set(this, 'launchConfig.environment', []);
     }
 
     const service = get(this, 'service');

--- a/app/components/container/new-edit/template.hbs
+++ b/app/components/container/new-edit/template.hbs
@@ -137,23 +137,10 @@
      expandAll=al.expandAll
      expand=(action expandFn)
   }}
-    {{form-key-value
-      initialMap=launchConfig.environment
-      changed=(action (mut launchConfig.environment))
-      allowEmptyValue=true
-      editing=true
-      header=(t "newContainer.environment.label")
-      addActionLabel="newContainer.environment.addAction"
-      keyLabel="newContainer.environment.keyLabel"
-      keyPlaceholder="newContainer.environment.keyPlaceholder"
-      valueLabel="newContainer.environment.valueLabel"
-      valuePlaceholder="newContainer.environment.valuePlaceholder"
-    }}
-    <hr class="mt-30 mb-30" />
     {{container/form-sources
       namespace=namespace
       classNames="accordion-wrapper"
-      sources=launchConfig.environmentFrom
+      sources=launchConfig.environment
       errors=secretErrors
       editing=true
     }}

--- a/app/components/form-sources-row/component.js
+++ b/app/components/form-sources-row/component.js
@@ -1,8 +1,12 @@
 import Component from '@ember/component';
 import layout from './template';
-import { get, set, computed } from '@ember/object';
+import { get, set, computed, observer } from '@ember/object';
 
 const SOURCES = [
+  {
+    id:       null,
+    label:    'Key/Value Pair'
+  },
   {
     id:       'configMap',
     label:    'Config Map',
@@ -21,6 +25,33 @@ const SOURCES = [
   }
 ];
 
+const RESOURCE_KEY_OPTS = [
+  {
+    id:    'limits.cpu',
+    label: 'limits.cpu'
+  },
+  {
+    id:    'limits.ephemeral-storage',
+    label: 'limits.ephemeral-storage'
+  },
+  {
+    id:    'limits.memory',
+    label: 'limits.memory'
+  },
+  {
+    id:    'requests.cpu',
+    label: 'requests.cpu'
+  },
+  {
+    id:    'requests.ephemeral-storage',
+    label: 'requests.ephemeral-storage'
+  },
+  {
+    id:    'requests.memory',
+    label: 'requests.memory'
+  },
+]
+
 export default Component.extend({
   layout,
   tagName:         'tr',
@@ -29,33 +60,23 @@ export default Component.extend({
   secretOnly:      false,
   specificKeyOnly: false,
 
-  selectedSecret: null,
-  sources:        SOURCES,
+  selectedSecret:  null,
+  sources:         SOURCES,
+  resourceKeyOpts: RESOURCE_KEY_OPTS,
 
-  prefixOrTarget: computed('source.{prefix,source,sourceKey,targetKey}', {
-    get() {
-      if ( get(this, 'source.source') !== 'field' && (get(this, 'source.sourceKey') === null || get(this, 'source.sourceKey') === undefined) ) {
-        return get(this, 'source.prefix');
-      } else {
-        return get(this, 'source.targetKey');
-      }
-    },
-    set(key, value) {
-      if ( get(this, 'source.source') !== 'field' && (get(this, 'source.sourceKey') === null || get(this, 'source.sourceKey') === undefined) ) {
-        return set(this, 'source.prefix', value);
-      } else {
-        return set(this, 'source.targetKey', value);
-      }
-    }
+  onSourceChange: observer('source.source', function() {
+    set(this, 'source.value', null);
+    set(this, 'source.valueFrom', null);
+    set(this, 'source.name', null);
   }),
 
-  prefixOrKeys: computed('selectedConfigMap', 'selectedSecret', 'source.{source,sourceName}', 'specificKeyOnly', function() {
+  prefixOrKeys: computed('selectedConfigMap', 'selectedSecret', 'source.{source,name,valueFrom}', 'specificKeyOnly', function() {
     let prefix = {
       id:    null,
       label: 'All'
     };
     let sourceType = get(this, 'source.source');
-    let sourceName = get(this, 'source.sourceName');
+    let valueFrom = get(this, 'source.valueFrom');
     let out = get(this, 'specificKeyOnly') ? [] : [prefix];
     let selected;
 
@@ -68,7 +89,7 @@ export default Component.extend({
       break;
     }
 
-    if (sourceName) {
+    if (valueFrom) {
       if (selected && get(selected, 'data')) {
         let keys = Object.keys(get(selected, 'data'));
 

--- a/app/components/form-sources-row/template.hbs
+++ b/app/components/form-sources-row/template.hbs
@@ -17,30 +17,32 @@
   </td>
   <td>&nbsp;</td>
 {{/unless }}
+<td>
+  {{input type="text" value=source.name classNames="form-control" placeholder=(t "formSources.fooPlaceholder")}}
+</td>
+<td>&nbsp;</td>
 <td data-title="{{t "formSources.kind.label"}}">
-  {{#if (and editing (eq source.source "secret"))}}
-    {{schema/input-secret
-      namespace=namespace
-      value=source.sourceName
-      valueKey="name"
-      selectedSecret=selectedSecret
-    }}
-  {{else if (and editing (eq source.source "configMap"))}}
-    {{schema/input-config-map
-      namespace=namespace
-      value=source.sourceName
-      valueKey="name"
-      selectedConfigMap=selectedConfigMap
-    }}
-  {{else if (and editing (eq source.source "field"))}}
-    {{input type="text" value=source.sourceName classNames="form-control" placeholder=(t "formSources.field.placeholder")}}
-  {{else if (and editing (eq source.source "resource"))}}
-    {{input type="text" value=source.sourceName classNames="form-control" placeholder=(t "formSources.container.placeholder")}}
-  {{else}}
-    {{#if source}}
-      {{source.sourceName}}
+  {{#if editing}}
+    {{#if (eq source.source "secret")}}
+      {{schema/input-secret
+        namespace=namespace
+        value=source.valueFrom
+        valueKey="name"
+        selectedSecret=selectedSecret
+      }}
+    {{else if (eq source.source "configMap")}}
+      {{schema/input-config-map
+        namespace=namespace
+        value=source.valueFrom
+        valueKey="name"
+        selectedConfigMap=selectedConfigMap
+      }}
+    {{else if (eq source.source "resource")}}
+      {{input type="text" value=source.valueFrom classNames="form-control" placeholder=(t "formSources.containerPlaceholder")}}
+    {{else if (eq source.source null)}}
+      {{input type="text" value=source.value classNames="form-control" placeholder=(t "formSources.barPlaceholder")}}
     {{else}}
-      <span class="text-muted">{{t "generic.na"}}</span>
+      <span class="text-muted">&ndash;</span>
     {{/if}}
   {{/if}}
 </td>
@@ -48,35 +50,26 @@
 <td data-title="{{t "formSources.prefixOrKey.label"}}">
   {{#if (or (eq source.source "secret") (eq source.source "configMap"))}}
     {{searchable-select
+      placeholder=valuePlaceholder
       classNames="form-control"
       optionValuePath="id"
       optionLabelPath="label"
       content=prefixOrKeys
-      value=source.sourceKey
-      readOnly=(or (not source.sourceName) (not editing))
+      value=source.value
+      readOnly=(or (not source.valueFrom) (not editing))
     }}
   {{else if (eq source.source "resource")}}
-    {{input type="text" value=source.sourceKey classNames="form-control" placeholder=(t "formSources.resource.placeholder")}}
+    {{new-select
+      classNames="form-control"
+      optionValuePath="id"
+      content=resourceKeyOpts
+      value=valueFrom
+    }}
+  {{else if (eq source.source "field")}}
+    {{input type="text" value=source.value classNames="form-control" placeholder=(t "formSources.labelsKeyPlaceholder")}}
   {{else}}
-    <span class="text-muted">{{t "generic.na"}}</span>
+    <span class="text-muted">&ndash;</span>
   {{/if}}
-</td>
-<td>
-  <div class="text-center">
-    {{#if (or specificKeyOnly (eq source.source "field") (eq source.source "resource"))}}
-      {{t "generic.as"}}
-    {{else if (eq source.sourceKey null)}}
-      {{t "generic.prefix"}}
-    {{else}}
-      {{t "generic.as"}}
-    {{/if}}
-  </div>
-</td>
-
-<td data-title="{{t "formSources.prefix.label"}}">
-  {{#input-or-display editable=editing value=prefixOrTarget classesForDisplay="text-muted form-control-static"}}
-    {{input type="text" value=prefixOrTarget classNames="form-control" disabled=(and (not source.sourceName) (not-eq source.source "resource") (not-eq source.source "field"))}}
-  {{/input-or-display}}
 </td>
 <td>
   {{#if editing}}

--- a/app/workload/template.hbs
+++ b/app/workload/template.hbs
@@ -170,13 +170,9 @@
        expandAll=al.expandAll
        expand=(action expandFn)
     }}
-      {{form-env-var
-        model=displayEnvironmentVars
-      }}
-      <hr class="mt-30 mb-30" />
       {{container/form-sources
         namespace=service.namespace
-        sources=launchConfig.environmentFrom
+        sources=launchConfig.environment
         editing=false
       }}
     {{/accordion-list-item}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -6861,18 +6861,19 @@ formSources:
   addLabel: Add Source
   type:
     label: Type
-  source:
-    label: Source
-  prefixOrKey:
+  value:
+    label: Value/Value From
+  key:
     label: Key
+  prefixOrKey:
+    label: Variable Name
   prefix:
     label: Prefix or Alias
-  field:
-    placeholder: e.g. spec.nodeName
-  resource:
-    placeholder: e.g. requests.cpu
-  container:
-    placeholder: e.g. my-container
+  fieldPlaceholder: e.g. spec.nodeName
+  containerPlaceholder: e.g. my-container
+  fooPlaceholder: e.g. foo
+  barPlaceholder: e.g. bar
+  labelsKeyPlaceholder: e.g. e.g. metadata.labels['<KEY>']
 
 formSecurity:
   title: Security & Host Config
@@ -8479,12 +8480,10 @@ newContainer:
     placeholder: e.g. My Application
   environment:
     label: Environment Variables
-    from: Inject Values From Another Resource
     detail: Set the environment that will be visible to the container, including injecting values from other resources like Secrets.
     addAction: Add Variable
-    addFrom: Add From Source
     keyLabel: Variable
-    keyPlaceholder: e.g. FOO
+    keyPlaceholder: e.g. foo
     valueLabel: Value
     valuePlaceholder: e.g. bar
   sidekick:
@@ -10567,9 +10566,7 @@ fromSecret:
   prefix:
     label: Alias
   keyLabel: Variable
-  keyPlaceholder: e.g. FOO
   valueLabel: Value
-  valuePlaceholder: e.g. bar
 
 pipelineNotification:
   header: Notification


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Migrating environment variables over to new format

Types of changes
======
- New feature (non-breaking change which adds functionality)


Linked Issues
======
rancher/rancher#30683

Further comments
======
The new format looks like

```
[
  {
      name: "variableName",
      valueFrom: "secret or config if used",
      value: "value for key value pairs or the name of the key within the secret, configMap or resource to reference"
  }
]
```

![Screen Shot 2021-01-07 at 12 57 32 PM](https://user-images.githubusercontent.com/55104481/103942599-e4247d80-50ed-11eb-85c7-d0c9c6e9163e.png)
![Screen Shot 2021-01-07 at 12 57 26 PM](https://user-images.githubusercontent.com/55104481/103942605-e4bd1400-50ed-11eb-9cee-1d8404b27259.png)
![Screen Shot 2021-01-07 at 12 57 09 PM](https://user-images.githubusercontent.com/55104481/103942609-e555aa80-50ed-11eb-8e75-20d409524723.png)
![Screen Shot 2021-01-07 at 12 57 01 PM](https://user-images.githubusercontent.com/55104481/103942610-e5ee4100-50ed-11eb-800d-294be0ab122d.png)
![Screen Shot 2021-01-07 at 12 56 38 PM](https://user-images.githubusercontent.com/55104481/103942611-e5ee4100-50ed-11eb-8a23-81201ca6cc1c.png)
