### PR TITLE
[2.5.x] LDAP auth provider encryption options and bugs

### DIFF
--- a/lib/global-admin/addon/mixins/ldap-auth.js
+++ b/lib/global-admin/addon/mixins/ldap-auth.js
@@ -1,0 +1,52 @@
+import Mixin from '@ember/object/mixin';
+import { computed, setProperties } from '@ember/object';
+import { isEmpty } from '@ember/utils';
+
+const NONE = 'none';
+const TLS = 'tls';
+const STARTTLS = 'starttls';
+
+export default Mixin.create({
+  encryption: computed('authConfig.{tls,starttls}', {
+    get() {
+      const { authConfig } = this;
+
+      if (isEmpty(authConfig)) {
+        return NONE;
+      } else {
+        if (authConfig.tls && !authConfig.starttls) {
+          return TLS;
+        } else if (!authConfig.tls && authConfig.starttls) {
+          return STARTTLS;
+        } else {
+          return NONE;
+        }
+      }
+    },
+    set(key, value) {
+      switch (value) {
+      case TLS:
+        setProperties(this.authConfig, {
+          tls:      true,
+          starttls: false,
+        });
+        break;
+      case STARTTLS:
+        setProperties(this.authConfig, {
+          tls:      false,
+          starttls: true,
+        });
+        break;
+      default:
+        setProperties(this.authConfig, {
+          tls:      false,
+          starttls: false,
+        });
+        break;
+      }
+
+      return value;
+    },
+  }),
+
+});

--- a/lib/global-admin/addon/security/authentication/activedirectory/controller.js
+++ b/lib/global-admin/addon/security/authentication/activedirectory/controller.js
@@ -6,11 +6,12 @@ import {
   get, set, computed, observer, setProperties
 } from '@ember/object';
 import AuthMixin from 'global-admin/mixins/authentication';
+import LDAPAuthMixin from 'global-admin/mixins/ldap-auth';
 
 var PLAIN_PORT = 389;
 var TLS_PORT = 636;
 
-export default Controller.extend(AuthMixin, {
+export default Controller.extend(AuthMixin, LDAPAuthMixin, {
   access:            service(),
   settings:          service(),
 

--- a/lib/global-admin/addon/security/authentication/freeipa/controller.js
+++ b/lib/global-admin/addon/security/authentication/freeipa/controller.js
@@ -6,11 +6,12 @@ import {
   get, set, computed, observer, setProperties
 } from '@ember/object';
 import AuthMixin from 'global-admin/mixins/authentication';
+import LDAPAuthMixin from 'global-admin/mixins/ldap-auth';
 
 const PLAIN_PORT = 389;
 const TLS_PORT = 636;
 
-export default Controller.extend(AuthMixin, {
+export default Controller.extend(AuthMixin, LDAPAuthMixin, {
   access:            service(),
   settings:          service(),
 
@@ -27,7 +28,7 @@ export default Controller.extend(AuthMixin, {
   password:          '',
   providerName:      'ldap.providerName.freeipa',
   providerSaveLabel: 'ldap.providerName.saveLabels.freeipa',
-  authConfig:          alias('model.freeipaConfig'),
+  authConfig:        alias('model.freeipaConfig'),
 
   init() {
     this._super(...arguments);

--- a/lib/global-admin/addon/security/authentication/openldap/controller.js
+++ b/lib/global-admin/addon/security/authentication/openldap/controller.js
@@ -6,11 +6,12 @@ import {
   get, set, computed, observer, setProperties
 } from '@ember/object';
 import AuthMixin from 'global-admin/mixins/authentication';
+import LDAPAuthMixin from 'global-admin/mixins/ldap-auth';
 
 const PLAIN_PORT = 389;
 const TLS_PORT = 636;
 
-export default Controller.extend(AuthMixin, {
+export default Controller.extend(AuthMixin, LDAPAuthMixin, {
   access:            service(),
   settings:          service(),
 

--- a/lib/global-admin/addon/templates/-ldap-config.hbs
+++ b/lib/global-admin/addon/templates/-ldap-config.hbs
@@ -59,29 +59,17 @@
                 {{t "ldap.accessEnabled.general.server"}}
               </b>
               <span class="text-muted">
-                {{authConfig.servers.firstObject}}
-                :
-                {{authConfig.port}}
+                {{authConfig.servers.firstObject}} : {{authConfig.port}}
               </span>
             </div>
             <div>
               <b>
-                {{t "ldap.accessEnabled.general.tls"}}
+                {{t "ldap.accessEnabled.general.encryption"}}
               </b>
               <span class="text-muted">
-                {{if authConfig.tls "Yes" "No"}}
+                {{upper-case encryption}}
               </span>
             </div>
-            {{#if (eq authConfig.name "openldap")}}
-              <div>
-                <b>
-                  {{t "ldap.accessConfig.starttls.label"}}
-                </b>
-                <span class="text-muted">
-                  {{if authConfig.starttls "Yes" "No"}}
-                </span>
-              </div>
-            {{/if}}
             {{#if authConfig.serviceAccountUsername}}
               <div>
                 <b>
@@ -267,7 +255,7 @@
               {{input value=configServers classNames="form-control"}}
             </div>
           </div>
-          <div class="col span-6 mb-0">
+          <div class="col span-2 mb-0">
             <label class="acc-label pb-5">
               {{t "ldap.accessConfig.port.labelText"}}
             </label>
@@ -278,23 +266,36 @@
                 max=65535
                 classNames="form-control"
               }}
-              <span class="input-group-addon bg-default">
-                <label>
-                  {{t "ldap.accessConfig.port.checkbox"}}
-                  {{input
-                    type="checkbox"
-                    checked=authConfig.tls
-                    disabled=(and
-                      (eq authConfig.name "openldap") authConfig.starttls
-                    )
-                  }}
-                </label>
-              </span>
+            </div>
+          </div>
+          <div class="col span-4 mb-0">
+            <label class="acc-label pb-5">
+              {{t "ldap.accessConfig.port.radioGroup.label"}}
+            </label>
+            <div class="radio">
+              <label>
+                {{radio-button selection=encryption value="none"}}
+                {{t "ldap.accessConfig.port.radioGroup.none"}}
+              </label>
+            </div>
+            <div class="radio">
+              <label>
+                {{radio-button selection=encryption value="tls"}}
+                {{t "ldap.accessConfig.port.radioGroup.tls"}}
+              </label>
+            </div>
+            <div class="radio">
+              <label>
+                {{radio-button selection=encryption value="starttls"}}
+                {{t "ldap.accessConfig.port.radioGroup.starttls"}}
+              </label>
+              <p class="help-block">
+                {{t "ldap.accessConfig.starttls.helpText"}}
+              </p>
             </div>
           </div>
         </div>
-        {{#if authConfig.tls}}
-          <hr />
+        {{#if (or authConfig.tls authConfig.starttls)}}
           <div class="row pt-10">
             <div class="col span-12 input-group mt-0">
               {{input-text-file
@@ -311,6 +312,7 @@
               </p>
             </div>
           </div>
+          <hr/>
         {{/if}}
         <div class="row">
           <div class="col span-6 mb-0">
@@ -331,23 +333,6 @@
               </span>
             </div>
           </div>
-          {{#if (eq authConfig.name "openldap")}}
-            <div class="col span-6 mb-0 pt-25">
-              <div class="radio">
-                <label class="acc-label">
-                  {{input
-                    type="checkbox"
-                    checked=authConfig.starttls
-                    disabled=authConfig.tls
-                  }}
-                  {{t "ldap.accessConfig.starttls.label"}}
-                </label>
-              </div>
-              <span class="help-block">
-                {{t "ldap.accessConfig.starttls.helpText"}}
-              </span>
-            </div>
-          {{/if}}
         </div>
         <hr class="mt-30 mb-30" />
         <p class="text-info mb-0">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -2952,136 +2952,141 @@ notifierPage:
 # Partials
 ##############################
 ldap:
-  providerName:
-    openldap: OpenLDAP
-    ad: Active Directory
-    freeipa: FreeIPA
-    saveLabels:
-      openldap: Authenticate with OpenLDAP
-      ad: Authenticate with Active Directory
-      freeipa: Authenticate with FreeIPA
-  header:
-    disabled:
-      label: "{providerName} is not configured"
-  accessEnabled:
-    header: Authentication
-    subtext: "To change the server configuration, disable access control below and then set it up again."
-    serviceAccountDistinguishedName:
-      labelText: "Service Account Distinguished Name:"
+  accessConfig:
     connectionTimeout:
-      labelText: "Server Connection Timeout:"
-    general:
-      header: General
-      server: "Server:"
-      tls: "TLS:"
-      serviceAccount: "Service Account Username:"
-      searchBase: "Search Base:"
-      defaultDomain: "Default Domain:"
-    users:
-      header: Users
-      objectClass: "Object Class:"
-      login: "Login Attribute:"
-      name: "Username Attribute:"
-      search: "Search Attribute:"
-      searchFilter: "Search Filter:"
-      enabled: "Status Attribute:"
-      disabledBitMask: "Disabled BitMask:"
-    group:
-      header: Group
-      objectClass: "Object Class:"
-      name: "Name Attribute:"
-      search: "Search Attribute:"
-      searchFilter: "Search Filter:"
+      labelText: Server Connection Timeout
+    defaultDomain:
+      helpText: This domain will be used if a user logs in without specifying one.
+      labelText: Default Login Domain
+      placeholder: e.g. mycompany
+    groupSearchBase:
+      helpText: 'If set, groups will be searched for only under this base instead of under the User Search Base.'
+      labelText: Group Search Base
+      placeholder: 'e.g. ou=Groups,dc=mycompany,dc=com'
+    header: '1. Configure an {providerName} server'
+    port:
+      labelText: Port
+      radioGroup:
+        label: Encryption
+        none: None
+        starttls: STARTTLS
+        tls: TLS
+    serviceAccountDistinguishedName:
+      labelText: Service Account Distinguished Name
+    starttls:
+      helpText: Upgrades non-encrypted connections by wrapping with TLS during the connection process. Can not be used in conjunction with TLS.
+      label: Start TLS
+    subtext1: 'Enter the address, port, and protocol to connect to your {providerName} server.  <code>389</code> is the standard port for insecure, <code>636</code> for TLS.'
+    subtext2: '{appName} needs a service account that has (read-only) access to all of the domains that will be able to login, so that we can determine what groups a user is a member of when they make a request with an API key.'
+    userSearchBase:
+      labelText: User Search Base
+      placeholder: 'e.g. ou=users,dc=mycompany,dc=com'
+  accessEnabled:
+    connectionTimeout:
+      labelText: 'Server Connection Timeout:'
     disable:
       confirmDisable:
         pre: Disable access control
-  accessConfig:
-    header: "1. Configure an {providerName} server"
-    subtext1: "Enter the address, port, and protocol to connect to your {providerName} server.  <code>389</code> is the standard port for insecure, <code>636</code> for TLS."
-    subtext2: "{appName} needs a service account that has (read-only) access to all of the domains that will be able to login, so that we can determine what groups a user is a member of when they make a request with an API key."
-    port:
-      labelText: Port
-      checkbox: TLS
-    groupSearchBase:
-      labelText: Group Search Base
-      placeholder: "e.g. ou=Groups,dc=mycompany,dc=com"
-      helpText: "If set, groups will be searched for only under this base instead of under the User Search Base."
-    userSearchBase:
-      labelText: User Search Base
-      placeholder: "e.g. ou=users,dc=mycompany,dc=com"
-    defaultDomain:
-      helpText: "This domain will be used if a user logs in without specifying one."
-      labelText: Default Login Domain
-      placeholder: "e.g. mycompany"
+    general:
+      defaultDomain: 'Default Domain:'
+      header: General
+      searchBase: 'Search Base:'
+      server: 'Server:'
+      serviceAccount: 'Service Account Username:'
+      tls: 'TLS:'
+      encryption: Encryption
+    group:
+      header: Group
+      name: 'Name Attribute:'
+      objectClass: 'Object Class:'
+      search: 'Search Attribute:'
+      searchFilter: 'Search Filter:'
+    header: Authentication
     serviceAccountDistinguishedName:
-      labelText: Service Account Distinguished Name
-    connectionTimeout:
-      labelText: Server Connection Timeout
-    starttls:
-      label: Start TLS
-      helpText: "Upgrades non-encrypted connections by wrapping with TLS during the connection process. Can not be used in conjunction with TLS."
-  customizeSchema:
-    header: "2. Customize Schema"
-    helpText: "If your schema does not match the standard ActiveDirectory format, you can customize it here."
-    cert:
-      labelText: CA Certificate
-      helpText: If needed, enter a CA certificate
-      placeholder: "Paste in the certificate, starting with -----BEGIN CERTIFICATE-----"
+      labelText: 'Service Account Distinguished Name:'
+    subtext: 'To change the server configuration, disable access control below and then set it up again.'
     users:
+      disabledBitMask: 'Disabled BitMask:'
+      enabled: 'Status Attribute:'
       header: Users
+      login: 'Login Attribute:'
+      name: 'Username Attribute:'
+      objectClass: 'Object Class:'
+      search: 'Search Attribute:'
+      searchFilter: 'Search Filter:'
+  customizeSchema:
+    cert:
+      helpText: 'If needed, enter a CA certificate'
+      labelText: CA Certificate
+      placeholder: 'Paste in the certificate, starting with -----BEGIN CERTIFICATE-----'
+    groups:
+      groupDN:
+        labelText: Group DN Attribute
+        placeholder: distinguishedName
+      groupMemberMapping:
+        labelText: Group Member Mapping Attribute
+      groupMemberUser:
+        labelText: Group Member User Attribute
+        placeholder: uid
+      header: Groups
+      name:
+        labelText: Name Attribute
+      nestedGroup:
+        disabled:
+          labelText: Search only direct group memberships
+        enabled:
+          helpText: Nested search may be slower in large directories
+          labelText: Search direct and nested group memberships
+        title: Nested Group Membership
       objectClass:
         labelText: Object Class
+      search:
+        labelText: Search Attribute
+      searchFilter:
+        labelText: Search Filter
+    header: 2. Customize Schema
+    helpText: 'If your schema does not match the standard ActiveDirectory format, you can customize it here.'
+    users:
+      disabledBitMask:
+        labelText: Disabled Status Bitmask
+      enabledAttribute:
+        labelText: User Enabled Attribute
+      header: Users
       login:
         labelText: Login Attribute
       name:
         labelText: Username Attribute
-      search:
-        labelText: Search Attribute
-      searchFilter:
-        labelText: Search Filter
-      searchBase:
-        labelText: User Search Base
-      enabledAttribute:
-        labelText: User Enabled Attribute
-      disabledBitMask:
-        labelText: Disabled Status Bitmask
-      userMemberAttribute:
-        labelText: User Member Attribute
-    groups:
-      header: Groups
       objectClass:
         labelText: Object Class
-      name:
-        labelText: Name Attribute
       search:
         labelText: Search Attribute
+      searchBase:
+        labelText: User Search Base
       searchFilter:
         labelText: Search Filter
-      groupMemberUser:
-        labelText: Group Member User Attribute
-        placeholder: uid
-      groupMemberMapping:
-        labelText: Group Member Mapping Attribute
-      groupDN:
-        labelText: Group DN Attribute
-        placeholder: distinguishedName
-      nestedGroup:
-        title: Nested Group Membership
-        enabled:
-          labelText: Search direct and nested group memberships
-          helpText: Nested search may be slower in large directories
-        disabled:
-          labelText: Search only direct group memberships
+      userMemberAttribute:
+        labelText: User Member Attribute
+  header:
+    disabled:
+      label: '{providerName} is not configured'
+  providerName:
+    ad: Active Directory
+    freeipa: FreeIPA
+    openldap: OpenLDAP
+    saveLabels:
+      ad: Authenticate with Active Directory
+      freeipa: Authenticate with FreeIPA
+      openldap: Authenticate with OpenLDAP
   testAuth:
-    header: "3. Test and enable authentication"
-    helpText: "Check that everything is configured correctly by testing authentication with your {providerName} account:"
-    userName:
-      labelText: Your Username
+    authenticate:
+      post: Testing...
+      pre: Authenticate
+    header: 3. Test and enable authentication
+    helpText: 'Check that everything is configured correctly by testing authentication with your {providerName} account:'
     password:
       labelText: Your Password
-    authenticate:
-      pre: Authenticate
-      post: "Testing..."
+    userName:
+      labelText: Your Username
 
 servicePartial:
   noContainers:


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
refactor ldap auth provider encryption to a radio group and mixin for
all auth providers. exposes the option on all ldap providers as well.
expose CA cert input when user selects STARTTLS

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#30348
rancher/rancher#30783
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
Sorted ldap yaml keys
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
