### PR TITLE
Gray out scheduler status for linode lke

### DIFF
--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -643,7 +643,8 @@ C.GRAY_OUT_ETCD_STATUS_PROVIDERS = [
 
 C.GRAY_OUT_SCHEDULER_STATUS_PROVIDERS = [
   'azureaks',
-  'tencenttke'
+  'tencenttke',
+  'linodelke'
 ];
 
 C.SYSTEM_LABELS_WITH_CONTROL = [


### PR DESCRIPTION
Proposed changes
======

![image](https://user-images.githubusercontent.com/15082/104736099-750fe000-5710-11eb-90dd-cc45e841b989.png)


Types of changes
======

LKE does not report component status. Adding LKE to this constant appears to hide false alerts.

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
