### PR TITLE
Update Windows Server version to refer to docs

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4401,7 +4401,7 @@ clusterNew:
       text: Editing node options will update the command you will run on your existing machines
     command:
       instructions: 'Run this command on one or more existing machines already running a supported version of Docker.'
-      winInstructions: 'Run this command in <code>CMD</code> on one or more existing machines already running a supported version of Docker and Windows Server version <code class="code-version">{version}</code> and above.'
+      winInstructions: 'Run this command in <code>CMD</code> on one or more existing machines already running <a href="https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/windows-clusters/" target="_blank" rel="nofollow noopener noreferrer">supported versions of Docker and Windows Server</a>.'
     auth:
       label: Auth Provider
       x509: x509


### PR DESCRIPTION
Proposed changes
======
Update `en-us` translation for Docker version and Windows Server version to refer to docs rather than give a concrete number. **Reasoning**: Windows Server 1903 SAC has reached EOM. The current wording suggests that all Windows Server versions at and above 1809 are valid, when that is not the case. In fact, Windows Server SAC releases reach EOM after ~1 year and release about ~6 months. Referring to the docs would provide one source of truth that's easier to maintain and would provide consistent messaging (note: the docs should be updated as well to reflect 1903 SAC EOM, but that is a separate issue).

Types of changes
======
Updating `yaml` file(s) to change the text that appears on screen. This is a non-breaking, "text-only" change.

Linked Issues
======
https://github.com/rancher/rancher/issues/31055

Further comments
======
n/a