### PR TITLE
display prefix of node name (drop domain)

### DIFF
--- a/app/models/node.js
+++ b/app/models/node.js
@@ -98,16 +98,7 @@ var Node = Resource.extend(Grafana, StateCounts, ResourceUsage, {
     name = get(this, 'nodeName');
     if ( name ) {
       if ( name.match(/[a-z]/i) ) {
-        name = name.replace(/\..*$/, '');
-
-        const nodesWithSamePrefix = (this.nodes || []).filter((node) => (node.nodeName || '').startsWith(`${ name }.`));
-
-        if ( nodesWithSamePrefix.length > 1 ) {
-          name = this.nodeName.slice(this.nodeName.lastIndexOf('.') + 1, this.nodeName.length)
-          if ( name.match(/^\d+$/) ) {
-            name = this.nodeName;
-          }
-        }
+        name = this.parseNodeName(name);
       }
 
       return name;
@@ -208,6 +199,25 @@ var Node = Resource.extend(Grafana, StateCounts, ResourceUsage, {
 
     return out;
   }),
+
+  parseNodeName(nameIn) {
+    const suffix = nameIn.split('.').slice(1).join('.');
+    const nodesWithSameSuffix = (this.nodes || []).filter((node) => (node.nodeName || '').endsWith(suffix));
+
+    if (nodesWithSameSuffix.length === 1) {
+      return this.nodeName;
+    } else if (nodesWithSameSuffix.length > 1) {
+      const neu = nameIn.replace(/\..*$/, '');
+
+      if ( neu.match(/^\d+$/) ) {
+        return this.nodeName;
+      } else {
+        return neu;
+      }
+    }
+
+    return nameIn;
+  },
 
   engineIcon: computed('info.os.dockerVersion', function() {
     if ( (get(this, 'info.os.dockerVersion') || '').startsWith(CONTAINERD) ) {

--- a/app/models/node.js
+++ b/app/models/node.js
@@ -200,25 +200,6 @@ var Node = Resource.extend(Grafana, StateCounts, ResourceUsage, {
     return out;
   }),
 
-  parseNodeName(nameIn) {
-    const suffix = nameIn.split('.').slice(1).join('.');
-    const nodesWithSameSuffix = (this.nodes || []).filter((node) => (node.nodeName || '').endsWith(suffix));
-
-    if (nodesWithSameSuffix.length === 1) {
-      return this.nodeName;
-    } else if (nodesWithSameSuffix.length > 1) {
-      const neu = nameIn.replace(/\..*$/, '');
-
-      if ( neu.match(/^\d+$/) ) {
-        return this.nodeName;
-      } else {
-        return neu;
-      }
-    }
-
-    return nameIn;
-  },
-
   engineIcon: computed('info.os.dockerVersion', function() {
     if ( (get(this, 'info.os.dockerVersion') || '').startsWith(CONTAINERD) ) {
       return 'icon-container-d';
@@ -278,6 +259,25 @@ var Node = Resource.extend(Grafana, StateCounts, ResourceUsage, {
       .split(/\s*,\s*/)
       .filter((x) => x.length > 0 && x !== C.LABEL.SYSTEM_TYPE);
   }),
+  parseNodeName(nameIn) {
+    const suffix = nameIn.split('.').slice(1).join('.');
+    const nodesWithSameSuffix = (this.nodes || []).filter((node) => (node.nodeName || '').endsWith(suffix));
+
+    if (nodesWithSameSuffix.length === 1) {
+      return this.nodeName;
+    } else if (nodesWithSameSuffix.length > 1) {
+      const neu = nameIn.replace(/\..*$/, '');
+
+      if ( neu.match(/^\d+$/) ) {
+        return this.nodeName;
+      } else {
+        return neu;
+      }
+    }
+
+    return nameIn;
+  },
+
   actions: {
     activate() {
       return this.doAction('activate');


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Change node `displayName` to actually return the prefix (unique data) of a node that has siblings with the same domain in the name.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#27873

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
@deniseschannon @gaktive  A few years back some code was added reduce the size of the node names because users would ask for `requestedHostname: thing-you-asked-for` but then the actual node name would be something like `thing-you-asked-for.us-west-3.aws.compute.internal` after the node was finished creating. In order to reduce the redundant info on the nodes page we added logic to strip the domain off a node name if there are multiple nodes with the same domain. As you can see in my screenshot resolving fixing the code displays the correct unique info (which is what we wanted in the first place) but I still worry this could be confusing to users expecting to see a full name. Because this functionality has been in for so long though I do not want to just change it willy-nilly and cause even more confusion. Thoughts? 

Node Names Used:
etcd -> kmaster01.prep.qdsp.axe.al
controlplane -> kmaster02.prep.qdsp.axe.al
worker -> kube01.prep.qdsp.axe.al 
worker -> kube01.int.qdsp.axe.al

Before Fix:
![Screen Shot 2021-02-03 at 10 13 38 AM](https://user-images.githubusercontent.com/858614/106785156-55325480-660a-11eb-933d-31aa9022e131.png)


After fix: 
![Screen Shot 2021-02-03 at 10 06 59 AM](https://user-images.githubusercontent.com/858614/106785185-5cf1f900-660a-11eb-96d3-5f8fc9557b73.png)

<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
