### PR TITLE
[2.5.x] custom cluster command set etcd/cp false if windows

### DIFF
--- a/lib/shared/addon/components/custom-command/component.js
+++ b/lib/shared/addon/components/custom-command/component.js
@@ -7,6 +7,7 @@ import { validateHostname } from '@rancher/ember-api-store/utils/validate';
 import { validateEndpoint, } from 'shared/utils/util';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
+import { next } from '@ember/runloop';
 
 export default Component.extend(ManageLabels, {
   intl: service(),
@@ -101,6 +102,13 @@ export default Component.extend(ManageLabels, {
     const windowsCmdPostfix = ` | iex}"`;
 
     if (windowsSelected) {
+      next(() => {
+        setProperties(this, {
+          etcd:         false,
+          controlplane: false,
+        });
+      })
+
       out = (get(this, 'token.windowsNodeCommand') || '').replace('--isolation hyperv ', '').replace(windowsCmdPostfix, '')
     }
 


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
windows nodes can only be workers, if a user switches to windows and has cp or etcd set we need to set it to false

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#30903

<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
