### PR TITLE
Provide more context around in-tree and out-of-tree cloud providers

### DIFF
--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -178,6 +178,20 @@ export default Component.extend({
     return out;
   }),
 
+  showVsphereHelperText: computed('selectedCloudProvider', 'driver', function() {
+    const driver = get(this, 'driver');
+    const selectedCloudProvider = get(this, 'selectedCloudProvider');
+
+    return (driver === 'custom' || driver === 'vmwarevsphere') &&
+           (selectedCloudProvider === 'external')
+  }),
+
+  isInTree: computed('selectedCloudProvider', function() {
+    const selectedCloudProvider = get(this, 'selectedCloudProvider');
+
+    return selectedCloudProvider !== 'external' && selectedCloudProvider !== 'none';
+  }),
+
   checkDefaults(record) {
     get(this, 'azureDefaults').forEach((def) => {
       if (isEmpty(record[def])) {

--- a/lib/shared/addon/components/cru-cloud-provider/template.hbs
+++ b/lib/shared/addon/components/cru-cloud-provider/template.hbs
@@ -100,7 +100,7 @@
           {{#if (and applyClusterTemplate (eq selectedCloudProvider "generic"))}}
             <div class="radio">
               <label>
-                {{t "generic.custom"}}
+                {{t "cloudProvider.custom.label"}}
               </label>
             </div>
           {{else if isCreateClusterOrClusterTemplate}}
@@ -109,7 +109,7 @@
                 {{radio-button
                   selection=selectedCloudProvider
                   value="generic"
-                }} {{t "generic.custom"}}
+                }} {{t "cloudProvider.custom.label"}}
               </label>
             </div>
           {{/if}}
@@ -136,6 +136,13 @@
   </CheckComputedOverride>
   {{#if (and (not-eq selectedCloudProvider "none") (eq mode "new"))}}
     <div class="col span-6">
+      {{#if isInTree}}
+        <BannerMessage
+          @color="bg-warning mt-0"
+          @icon="icon-alert"
+          @message={{t "cloudProvider.inTreeDeprecated"}}
+        />
+      {{/if}}
       <BannerMessage
         @color="bg-info mt-0 mb-0"
         @icon="icon-alert"
@@ -200,8 +207,18 @@
   <p class="text-info">
     {{#if (eq selectedCloudProvider "generic")}}
       {{t "cloudProvider.custom.helpText" htmlSafe=true}}
-    {{else if (eq selectedCloudProvider "external")}}
+    {{else if (and (eq selectedCloudProvider "external") (not (eq driver "vmwarevsphere")) )}}
       {{t "cloudProvider.external.helpText" htmlSafe=true}}
     {{/if}}
   </p>
+  {{#if showVsphereHelperText}}
+    <p class="text-info">
+      {{t 
+        "cloudProvider.external.vsphereHelpText" 
+        csi=(href-to 'global-admin.multi-cluster-apps.catalog.launch' 'cattle-global-data:helm3-library-vsphere-csi') 
+        cpi=(href-to 'global-admin.multi-cluster-apps.catalog.launch' 'cattle-global-data:helm3-library-vsphere-cpi')
+        htmlSafe=true
+      }}
+    </p>
+  {{/if}}
 {{/if}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3152,14 +3152,16 @@ billingInfo:
       actions: Actions
 
 cloudProvider:
-  title: In-Tree Cloud Provider
-  amazon: Amazon
-  azure: Azure
+  title: Cloud Provider
+  amazon: Amazon (In-Tree)
+  azure: Azure (In-Tree)
   external:
     label: External
     helpText: 'Please edit the YAML to specify the required addon for cloud controller manager.'
+    vsphereHelpText: 'Out-of-tree cloud provider for vsphere is available through the <a href="{csi}" target="_blank" rel="nofollow noopener noreferrer">vsphere-csi</a> and <a href="{cpi}" target="_blank" rel="nofollow noopener noreferrer">vsphere-cpi</a> helm charts.'
   name: Cloud Provider Name
   custom:
+    label: Custom (In-Tree)
     notInList: 'If your cloud provider is not listed, please use the <b>Custom</b> option.'
     helpText: 'Please edit the YAML to add in any other <a href="http://rancher.com/docs/rke/v0.1.x/en/config-options/cloud-providers/" target="_blank" rel="nofollow noopener noreferrer">cloud providers</a>'
 
@@ -3167,6 +3169,8 @@ cloudProvider:
      Read more about the state of the <a href="https://kubernetes.io/blog/2019/04/17/the-future-of-cloud-providers-in-kubernetes/" target="_blank" rel="nofollow noopener noreferrer">Kubernetes in-tree cloud providers</a>
   warning:
     Configuring a Cloud Provider in your cluster without configuring the prerequisites will cause your cluster to not provision correctly. Prerequisites needed for supported cloud providers can be found in the documentation.
+  inTreeDeprecated:
+    In-tree cloud providers are deprecated
   azureCloudConfig:
     cloudProviderBackoff:
       description: "Enable exponential backoff to manage resource request retries"


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Provide more context around in-tree and out-of-tree cloud providers

- Add helper text to help people find the out-of-tree providers for vsphere
- Label each in-tree provider with (In-tree) label
- Show a deprecated message for each in-tree option


Types of changes
======
- New feature (non-breaking change which adds functionality)

Linked Issues
======
rancher/rancher#31162

![image](https://user-images.githubusercontent.com/55104481/107831714-ef517580-6d4b-11eb-8b02-7dd23c02bb07.png)
![image](https://user-images.githubusercontent.com/55104481/107831725-f7a9b080-6d4b-11eb-918d-c80088978600.png)
![image](https://user-images.githubusercontent.com/55104481/107831734-fc6e6480-6d4b-11eb-8040-7de176fab88e.png)
![image](https://user-images.githubusercontent.com/55104481/107831766-1019cb00-6d4c-11eb-916c-bb36a6cf4e08.png)

