### PR TITLE
EKS V2 Node Group Refactor

### DIFF
--- a/lib/shared/addon/components/node-group-row/component.js
+++ b/lib/shared/addon/components/node-group-row/component.js
@@ -19,7 +19,8 @@ export default Component.extend({
   layout,
   classNames:  ['row', 'mb-20'],
 
-  instanceTypes: INSTANCE_TYPES,
+  instanceTypes:          INSTANCE_TYPES,
+  defaultNodeGroupConfig: DEFAULT_NODE_GROUP_CONFIG,
 
   clusterConfig:               null,
   keyPairs:                    null,
@@ -75,97 +76,194 @@ export default Component.extend({
         return;
       }
 
-      set(this, 'model.resourceTags', section);
+      set(this, 'resourceTags', section);
     },
   },
 
-  loadTemplateVersionInfo: observer('model.launchTemplate.{id,version}', async function() {
-    if (!this.clusterSaving && !this.clusterSaved) {
-      const { launchTemplate = {} } = this.model;
-      let defaults = { ...DEFAULT_NODE_GROUP_CONFIG };
+  instanceType: computed('defaultNodeGroupConfig.instanceType', 'isNoLaunchTemplate', 'model.instanceType', 'selectedTemplateVersionInfo.LaunchTemplateData.InstanceType', {
+    get() {
+      let instanceType = this?.model?.instanceType;
+      const { selectedTemplateVersionInfo, isNoLaunchTemplate } = this;
 
-      // in this case we dont want the defaults for nodegroup items
-      delete defaults.nodegroupName;
-      delete defaults.maxSize;
-      delete defaults.minSize;
-      delete defaults.desiredSize;
+      if (isNoLaunchTemplate) {
+        return instanceType;
+      } else if (selectedTemplateVersionInfo) {
+        const { LaunchTemplateData: { InstanceType = this.defaultNodeGroupConfig.instanceType } } = selectedTemplateVersionInfo;
 
-
-      if (isEmpty(launchTemplate)) {
-        set(this, 'refreshResourceInstanceTags', false);
-
-        next(() => {
-          setProperties(this.model, defaults);
-          set(this, 'refreshResourceInstanceTags', true)
-        });
-      } else if ( !isEmpty(get(launchTemplate, 'id')) ) {
-        try {
-          const versions = await this.listTemplateVersions();
-          const match = versions.findBy('VersionNumber', parseInt(launchTemplate.version, 10)); // newselect doesn't handle numbers as values very well
-          const { LaunchTemplateData: launchTemplateData } = match;
-
-          const overrides = {
-            imageId:      get(launchTemplateData, 'ImageId') ?? null,
-            instanceType: get(launchTemplateData, 'InstanceType') ?? 't3.medium',
-            volumeSize:   get(launchTemplateData, 'BlockDeviceMappings.Ebs.VolumeSize') ?? 20,
-            ec2SshKey:    get(launchTemplateData, 'KeyName') ?? null,
-            userData:     isEmpty(get(launchTemplateData, 'UserData')) ? null : atob(get(launchTemplateData, 'UserData')),
-          };
-
-
-          defaults = Object.assign({}, defaults, overrides);
-
-          if (get(launchTemplateData, 'InstanceMarketOptions.MarketType') && get(launchTemplateData, 'InstanceMarketOptions.MarketType') === 'spot') {
-            set(defaults, 'requestSpotInstances', true);
-          }
-
-          if ( !isEmpty(get(launchTemplateData, 'TagSpecifications')) ) {
-            const resourceInstanceTags = get(launchTemplateData, 'TagSpecifications').findBy('ResourceType', 'instance');
-
-            if (!isEmpty(resourceInstanceTags) && !isEmpty(get(resourceInstanceTags, 'Tags'))) {
-              set(defaults, 'resourceTags', {});
-
-              resourceInstanceTags.Tags.forEach((tag) => set(defaults.resourceTags, get(tag, 'Key'), get(tag, 'Value')));
-            }
-          }
-
-          // if ( !isEmpty(get(launchTemplateData, 'NetworkInterfaces')) ) {
-          //   const subnets = [];
-          //   const interfaces = get(launchTemplateData, 'NetworkInterfaces');
-
-          //   interfaces.forEach((enterface) => subnets.push(get(enterface, 'SubnetId')))
-          // }
-
-          set(this, 'refreshResourceInstanceTags', false);
-
-          next(() =>  {
-            setProperties(this.model, defaults);
-
-            set(this, 'allSelectedTemplateVersions', versions);
-            set(this, 'refreshResourceInstanceTags', true)
-          } );
-        } catch (err) { }
+        return InstanceType ?? this.defaultNodeGroupConfig.instanceType;
       }
+
+      return instanceType;
+    },
+    set(_key, instanceType) {
+      const { selectedTemplateVersionInfo, isNoLaunchTemplate } = this;
+
+      if (isNoLaunchTemplate) {
+        set(this, 'model.instanceType', instanceType)
+      } else if (selectedTemplateVersionInfo) {
+        // dont set because it will be discarded
+      }
+
+      return instanceType;
     }
   }),
 
-  selectedLaunchTemplateVersion: computed('model.launchTemplate.version', 'model.launchTemplate.id', {
+  imageId: computed('defaultNodeGroupConfig.imageId', 'isNoLaunchTemplate', 'model.imageId', 'selectedTemplateVersionInfo.LaunchTemplateData.ImageId', {
     get() {
-      return get(this, 'model.launchTemplate.version') ? get(this, 'model.launchTemplate.version').toString() : null;
-    },
-    set(_key, value) {
-      set(this, 'model.launchTemplate.version', parseInt(value, 10));
+      let imageId = this?.model?.imageId;
+      const { selectedTemplateVersionInfo, isNoLaunchTemplate } = this;
 
-      return value;
+      if (isNoLaunchTemplate) {
+        return imageId;
+      } else if (selectedTemplateVersionInfo) {
+        const { LaunchTemplateData: { ImageId = this.defaultNodeGroupConfig.imageId } } = selectedTemplateVersionInfo;
+
+        return ImageId ?? this.defaultNodeGroupConfig.imageId;
+      }
+
+      return imageId;
     },
+    set(_key, imageId) {
+      const { selectedTemplateVersionInfo, isNoLaunchTemplate } = this;
+
+      if (isNoLaunchTemplate) {
+        set(this, 'model.imageId', imageId)
+      } else if (selectedTemplateVersionInfo) {
+        // dont set because it will be discarded
+      }
+
+      return imageId;
+    }
   }),
+
+  diskSize: computed('defaultNodeGroupConfig.diskSize', 'isNoLaunchTemplate', 'model.diskSize', 'selectedTemplateVersionInfo.LaunchTemplateData.BlockDeviceMappings.[]', {
+    get() {
+      let diskSize = this?.model?.diskSize;
+      const { selectedTemplateVersionInfo, isNoLaunchTemplate } = this;
+
+      if (isNoLaunchTemplate) {
+        return diskSize;
+      } else if (selectedTemplateVersionInfo) {
+        const blockDeviceMappings = selectedTemplateVersionInfo?.LaunchTemplateData?.BlockDeviceMappings?.firstObject ?? {};
+        const DiskSize = blockDeviceMappings?.Ebs?.VolumeSize ?? this.defaultNodeGroupConfig.diskSize;
+
+        return DiskSize ?? this.defaultNodeGroupConfig.diskSize;
+      }
+
+      return diskSize;
+    },
+    set(_key, diskSize) {
+      const { selectedTemplateVersionInfo, isNoLaunchTemplate } = this;
+
+      if (isNoLaunchTemplate) {
+        set(this, 'model.diskSize', diskSize)
+      } else if (selectedTemplateVersionInfo) {
+        // dont set because it will be discarded
+      }
+
+      return diskSize;
+    }
+  }),
+
+  ec2SshKey: computed('defaultNodeGroupConfig.ec2SshKey', 'isNoLaunchTemplate', 'model.ec2SshKey', 'selectedTemplateVersionInfo.LaunchTemplateData.KeyName', {
+    get() {
+      let ec2SshKey = this?.model?.ec2SshKey;
+      const { selectedTemplateVersionInfo, isNoLaunchTemplate } = this;
+
+      if (isNoLaunchTemplate) {
+        return ec2SshKey;
+      } else if (selectedTemplateVersionInfo) {
+        const { LaunchTemplateData: { KeyName = this.defaultNodeGroupConfig.ec2SshKey } } = selectedTemplateVersionInfo;
+
+        return KeyName ?? this.defaultNodeGroupConfig.ec2SshKey;
+      }
+
+      return ec2SshKey;
+    },
+    set(_key, ec2SshKey) {
+      const { selectedTemplateVersionInfo, isNoLaunchTemplate } = this;
+
+      if (isNoLaunchTemplate) {
+        set(this, 'model.ec2SshKey', ec2SshKey)
+      } else if (selectedTemplateVersionInfo) {
+        // dont set because it will be discarded
+      }
+
+      return ec2SshKey;
+    }
+  }),
+
+  userData: computed('defaultNodeGroupConfig.userData', 'isNoLaunchTemplate', 'model.userData', 'selectedTemplateVersionInfo.LaunchTemplateData.UserData', {
+    get() {
+      let userData = this?.model?.userData;
+      const { selectedTemplateVersionInfo, isNoLaunchTemplate } = this;
+
+      if (isNoLaunchTemplate) {
+        return userData;
+      } else if (selectedTemplateVersionInfo) {
+        let { LaunchTemplateData: { UserData = this.defaultNodeGroupConfig.userData } } = selectedTemplateVersionInfo;
+
+        try {
+          UserData = atob(UserData);
+        } catch (_err) {
+        }
+
+        return UserData ?? this.defaultNodeGroupConfig.userData;
+      }
+
+      return userData;
+    },
+    set(_key, userData) {
+      const { selectedTemplateVersionInfo, isNoLaunchTemplate } = this;
+
+      if (isNoLaunchTemplate) {
+        set(this, 'model.userData', userData)
+      } else if (selectedTemplateVersionInfo) {
+        // dont set because it will be discarded
+      }
+
+      return userData;
+    }
+  }),
+
+  resourceTags: computed('defaultNodeGroupConfig.resourceTags', 'isNoLaunchTemplate', 'model.resourceTags', 'selectedTemplateVersionInfo.LaunchTemplateData.TagSpecifications.[]', {
+    get() {
+      let resourceTags = this?.model?.resourceTags;
+      const { selectedTemplateVersionInfo, isNoLaunchTemplate } = this;
+
+      if (isNoLaunchTemplate) {
+        return resourceTags;
+      } else if (selectedTemplateVersionInfo) {
+        const resourceInstanceTags = ( selectedTemplateVersionInfo?.LaunchTemplateData?.TagSpecifications ?? []).findBy('ResourceType', 'instance');
+        const resourceTags = {};
+
+        (resourceInstanceTags?.Tags ?? []).forEach((tag) => set(resourceTags, get(tag, 'Key'), get(tag, 'Value')));
+
+        return resourceTags;
+      }
+
+      return resourceTags;
+    },
+    set(_key, resourceTags) {
+      const { selectedTemplateVersionInfo, isNoLaunchTemplate } = this;
+
+      if (isNoLaunchTemplate) {
+        set(this, 'model.resourceTags', resourceTags)
+      } else if (selectedTemplateVersionInfo) {
+        // dont set because it will be discarded
+      }
+
+      return resourceTags;
+    }
+  }),
+
 
   isRancherLaunchTemplate: computed('model.{launchTemplate,nodegroupName}', 'originalCluster.eksStatus.managedLaunchTemplateID', function() {
     const { originalCluster, model } = this;
     const { launchTemplate } = model;
     const eksStatus = get((originalCluster ?? {}), 'eksStatus') || {};
     const { managedLaunchTemplateID = null, managedLaunchTemplateVersions = {} } = eksStatus;
-    const matchedManagedVersion = get(managedLaunchTemplateVersions, this.model.nodegroupName);
+    const matchedManagedVersion = get(( managedLaunchTemplateVersions ?? {} ), this.model.nodegroupName);
 
     if (isEmpty(launchTemplate) && !isEmpty(managedLaunchTemplateID) && !isEmpty(matchedManagedVersion)) {
       return true;
@@ -175,10 +273,10 @@ export default Component.extend({
   }),
 
   isUserLaunchTemplate: computed('model.launchTemplate', 'originalCluster.eksStatus.managedLaunchTemplateID', function() {
-    const { model } = this;
-    const { launchTemplate }        = model;
+    const { model }         = this;
+    const { launchTemplate } = model;
 
-    if (!isEmpty(launchTemplate)) {
+    if (!isEmpty(launchTemplate) && !isEmpty(launchTemplate?.id) && !isEmpty(launchTemplate?.version)) {
       return true;
     }
 
@@ -199,7 +297,7 @@ export default Component.extend({
     return launchTemplates.filter(({ LaunchTemplateName }) =>  !LaunchTemplateName.includes('rancher-managed-lt') ).sortBy('LaunchTemplateName');
   }),
 
-  selectedTemplateVersion: computed('model.launchTemplate.{id,version}', 'allSelectedTemplateVersions.[]', function() {
+  selectedTemplateVersionInfo: computed('model.launchTemplate.{id,version}', 'allSelectedTemplateVersions.[]', function() {
     const { model, allSelectedTemplateVersions } = this;
     const version = get(model, 'launchTemplate.version');
 
@@ -215,6 +313,20 @@ export default Component.extend({
 
     return null;
   }),
+
+  selectedLaunchTemplateVersion: computed('model.launchTemplate.version', 'model.launchTemplate.id', {
+    get() {
+      return get(this, 'model.launchTemplate.version') ? get(this, 'model.launchTemplate.version').toString() : null;
+    },
+    set(_key, value) {
+      set(this, 'model.launchTemplate.version', parseInt(value, 10));
+
+      this.loadTemplateVersionInfo();
+
+      return value;
+    },
+  }),
+
 
   selectedLaunchTemplateVersions: computed('model.launchTemplate.{id,name,version}', 'launchTemplates', function() {
     const { model, launchTemplates } = this;
@@ -248,7 +360,7 @@ export default Component.extend({
       return null;
     },
 
-    set(key, launchTemplateId) {
+    set(_key, launchTemplateId) {
       const launchTemplate = this.filteredLaunchTemplates.findBy('LaunchTemplateId', launchTemplateId);
       const  {
         LaunchTemplateId: id, LaunchTemplateName: name, DefaultVersionNumber: version
@@ -256,12 +368,22 @@ export default Component.extend({
 
       if (isEmpty(launchTemplate)) {
         set(this, 'model.launchTemplate', null);
+
+        setProperties(this, {
+          diskSize:             this.defaultNodeGroupConfig.diskSize,
+          ec2SshKey:            this.defaultNodeGroupConfig.ec2SshKey,
+          imageId:              this.defaultNodeGroupConfig.imageId,
+          instanceType:         this.defaultNodeGroupConfig.instanceType,
+          requestSpotInstances: this.defaultNodeGroupConfig.requestSpotInstances,
+          resourceTags:         this.defaultNodeGroupConfig.resourceTags,
+          userData:             this.defaultNodeGroupConfig.userData,
+        });
       } else {
         set(this, 'model.launchTemplate', {
           id,
           name,
-          version
         });
+        set(this, 'selectedLaunchTemplateVersion', version);
       }
 
       return launchTemplateId;
@@ -327,22 +449,22 @@ export default Component.extend({
     return diff === 1;
   }),
 
-  showGPUWarning: computed('model.launchTemplate.{id,version}', 'selectedTemplateVersion', function() {
-    const { model, selectedTemplateVersion } = this;
+  showGPUWarning: computed('model.launchTemplate.{id,version}', 'selectedTemplateVersionInfo', function() {
+    const { model, selectedTemplateVersionInfo } = this;
     const ltId = get(model, 'launchTemplate.id');
     const ltVersion = get(model, 'launchTemplate.version');
-    const imageId = selectedTemplateVersion ? get(selectedTemplateVersion, 'LaunchTemplateData.ImageId') : undefined;
+    const imageId = selectedTemplateVersionInfo ? get(selectedTemplateVersionInfo, 'LaunchTemplateData.ImageId') : undefined;
 
-    return ltId && ltVersion && selectedTemplateVersion && imageId;
+    return ltId && ltVersion && selectedTemplateVersionInfo && imageId;
   }),
 
   requestedSpotInstances: on('init', observer('model.requestSpotInstances', function() {
     const { model } = this;
 
     if (get(model, 'requestSpotInstances')) {
-      set(this, 'model.instanceType', null);
+      set(this, 'instanceType', null);
     } else if (!get(model, 'requestSpotInstances') && get(model, 'instanceType') === null) {
-      set(this, 'model.instanceType', 't3.medium');
+      set(this, 'instanceType', 't3.medium');
     }
   })),
 
@@ -363,6 +485,69 @@ export default Component.extend({
       set(this, 'model.version', clusterVersion);
     }
   })),
+
+  async loadTemplateVersionInfo() {
+    if (!this.clusterSaving && !this.clusterSaved) {
+      const { launchTemplate = {} } = this.model;
+      let defaults = { ...this.defaultNodeGroupConfig };
+
+      // in this case we dont want the defaults for nodegroup items
+      delete defaults.nodegroupName;
+      delete defaults.maxSize;
+      delete defaults.minSize;
+      delete defaults.desiredSize;
+
+
+      if (isEmpty(launchTemplate)) {
+        set(this, 'refreshResourceInstanceTags', false);
+
+        next(() => {
+          setProperties(this.model, defaults);
+          set(this, 'refreshResourceInstanceTags', true)
+        });
+      } else if ( !isEmpty(get(launchTemplate, 'id')) ) {
+        try {
+          const versions = await this.listTemplateVersions();
+          const match = versions.findBy('VersionNumber', parseInt(launchTemplate.version, 10)); // newselect doesn't handle numbers as values very well
+          const { LaunchTemplateData: launchTemplateData } = match;
+
+          const overrides = {
+            imageId:      get(launchTemplateData, 'ImageId') ?? null,
+            instanceType: get(launchTemplateData, 'InstanceType') ?? this.defaultNodeGroupConfig.instanceType,
+            diskSize:     get(launchTemplateData, 'BlockDeviceMappings.firstObject.Ebs.VolumeSize') ?? this.defaultNodeGroupConfig.diskSize,
+            ec2SshKey:    get(launchTemplateData, 'KeyName') ?? null,
+            userData:     isEmpty(get(launchTemplateData, 'UserData')) ? null : atob(get(launchTemplateData, 'UserData')),
+          };
+
+
+          defaults = Object.assign({}, defaults, overrides);
+
+          if (get(launchTemplateData, 'InstanceMarketOptions.MarketType') && get(launchTemplateData, 'InstanceMarketOptions.MarketType') === 'spot') {
+            set(defaults, 'requestSpotInstances', true);
+          }
+
+          if ( !isEmpty(get(launchTemplateData, 'TagSpecifications')) ) {
+            const resourceInstanceTags = get(launchTemplateData, 'TagSpecifications').findBy('ResourceType', 'instance');
+
+            if (!isEmpty(resourceInstanceTags) && !isEmpty(get(resourceInstanceTags, 'Tags'))) {
+              set(defaults, 'resourceTags', {});
+
+              resourceInstanceTags.Tags.forEach((tag) => set(defaults.resourceTags, get(tag, 'Key'), get(tag, 'Value')));
+            }
+          }
+
+          set(this, 'refreshResourceInstanceTags', false);
+
+          next(() =>  {
+            setProperties(this.model, defaults);
+
+            set(this, 'allSelectedTemplateVersions', versions);
+            set(this, 'refreshResourceInstanceTags', true)
+          } );
+        } catch (err) { }
+      }
+    }
+  },
 
   listTemplateVersions() {
     const { launchTemplate } = this.model;

--- a/lib/shared/addon/components/node-group-row/component.js
+++ b/lib/shared/addon/components/node-group-row/component.js
@@ -354,7 +354,7 @@ export default Component.extend({
       if (launchTemplate) {
         const out = this.filteredLaunchTemplates.findBy('LaunchTemplateId', launchTemplate.id);
 
-        return isEmpty(out) ? null : get(out, 'value');
+        return isEmpty(out) ? null : out;
       }
 
       return null;

--- a/lib/shared/addon/components/node-group-row/component.js
+++ b/lib/shared/addon/components/node-group-row/component.js
@@ -196,18 +196,7 @@ export default Component.extend({
       return [];
     }
 
-    return launchTemplates.filter(({ LaunchTemplateName }) =>  !LaunchTemplateName.includes('rancher-managed-lt') ).map(({
-      LaunchTemplateName, LaunchTemplateId, DefaultVersionNumber
-    }) => {
-      return {
-        label: LaunchTemplateName,
-        value:    {
-          id:             LaunchTemplateId,
-          name:           LaunchTemplateName,
-          defaultVersion: DefaultVersionNumber,
-        },
-      };
-    }).sortBy('label');
+    return launchTemplates.filter(({ LaunchTemplateName }) =>  !LaunchTemplateName.includes('rancher-managed-lt') ).sortBy('LaunchTemplateName');
   }),
 
   selectedTemplateVersion: computed('model.launchTemplate.{id,version}', 'allSelectedTemplateVersions.[]', function() {
@@ -251,7 +240,7 @@ export default Component.extend({
       const launchTemplate = get(this, 'model.launchTemplate') ?? false;
 
       if (launchTemplate) {
-        const out = this.filteredLaunchTemplates.findBy('value.id', launchTemplate.id);
+        const out = this.filteredLaunchTemplates.findBy('LaunchTemplateId', launchTemplate.id);
 
         return isEmpty(out) ? null : get(out, 'value');
       }
@@ -259,12 +248,13 @@ export default Component.extend({
       return null;
     },
 
-    set(key, value) {
+    set(key, launchTemplateId) {
+      const launchTemplate = this.filteredLaunchTemplates.findBy('LaunchTemplateId', launchTemplateId);
       const  {
-        id, name, defaultVersion: version
-      }  = value ?? {};
+        LaunchTemplateId: id, LaunchTemplateName: name, DefaultVersionNumber: version
+      }  = launchTemplate ?? {};
 
-      if (isEmpty(value)) {
+      if (isEmpty(launchTemplate)) {
         set(this, 'model.launchTemplate', null);
       } else {
         set(this, 'model.launchTemplate', {
@@ -274,7 +264,7 @@ export default Component.extend({
         });
       }
 
-      return value;
+      return launchTemplateId;
     }
   }),
 

--- a/lib/shared/addon/components/node-group-row/template.hbs
+++ b/lib/shared/addon/components/node-group-row/template.hbs
@@ -37,16 +37,7 @@
               {{#if isRancherLaunchTemplate}}
                 {{t "nodeGroupRow.launchTemplates.managed"}}
               {{else if isUserLaunchTemplate}}
-                {{searchable-select
-                  classNames="form-control"
-                  value=selectedLaunchTemplate
-                  content=filteredLaunchTemplates
-                  optionValuePath="LaunchTemplateId"
-                  optionLabelPath="LaunchTemplateName"
-                  prompt="nodeGroupRow.launchTemplates.label"
-                  localizedPrompt=true
-                  readOnly=(and (not isRancherLaunchTemplate) editing)
-                }}
+                {{selectedLaunchTemplate.LaunchTemplateName}}
               {{else}}
                 <div>
                   {{t "generic.na"}}
@@ -303,7 +294,11 @@
             @removeButtonClass="btn bg-primary btn-remove"
             @valueLabelEnabled={{false}} as |fva fvaRow|
           >
-            {{#input-or-display editable=creating value=fvaRow.value class="input-or-display"}}
+            {{#input-or-display
+              editable=creating
+              value=fvaRow.value
+              class="input-or-display"
+            }}
               <NewSelect
                 @value={{fvaRow.value}}
                 @content={{instanceTypes}}
@@ -352,7 +347,10 @@
             @initialMap={{resourceTags}}
             @changed={{action "setResourceTags"}}
             @addActionLabel="clusterNew.amazoneks.tags.addActionLabel"
-            @editing={{not model.launchTemplate.version}}
+            @editing={{or
+                (and creating isNoLaunchTemplate)
+                (and editing isRancherLaunchTemplate)
+            }}
           />
         {{/if}}
       </div>

--- a/lib/shared/addon/components/node-group-row/template.hbs
+++ b/lib/shared/addon/components/node-group-row/template.hbs
@@ -139,11 +139,11 @@
         {{else}}
           {{#input-or-display
             editable=(or creating (and isRancherLaunchTemplate editing))
-            value=model.instanceType
+            value=instanceType
           }}
             <NewSelect
               class="form-control"
-              @value={{mut model.instanceType}}
+              @value={{mut instanceType}}
               @content={{instanceTypes}}
               @optionValuePath="name"
               @optionLabelPath="name"
@@ -162,11 +162,11 @@
         </label>
         {{#input-or-display
           editable=(or creating (and isRancherLaunchTemplate editing))
-          value=model.imageId
+          value=imageId
         }}
           <Input
             @type="text"
-            @value={{mut model.imageId}}
+            @value={{mut imageId}}
             @classNames="form-control"
             @disabled={{model.launchTemplate.version}}
           />
@@ -181,12 +181,12 @@
         </label>
         {{#input-or-display
           editable=(or creating (and isRancherLaunchTemplate editing))
-          value=(concat model.diskSize (t "generic.gigabyte"))
+          value=(concat diskSize (t "generic.gigabyte"))
         }}
           <div class="input-group">
             <InputInteger
               @min={{0}}
-              @value={{mut model.diskSize}}
+              @value={{mut diskSize}}
               @classNames="form-control"
               @placeholder={{t "nodeGroupRow.nodeVolumeSize.placeholder"}}
               @disabled={{model.launchTemplate.version}}
@@ -205,12 +205,12 @@
         </label>
         {{#input-or-display
           editable=(or creating (and isRancherLaunchTemplate editing))
-          value=model.ec2SshKey
+          value=ec2SshKey
         }}
           {{#if keyPairs}}
             {{searchable-select
               classNames="form-control"
-              value=model.ec2SshKey
+              value=ec2SshKey
               content=keyPairs
               optionValuePath="KeyName"
               optionLabelPath="KeyName"
@@ -220,7 +220,7 @@
           {{else}}
             <Input
               @type="text"
-              @value={{mut model.ec2SshKey}}
+              @value={{mut ec2SshKey}}
               @classNames="form-control"
               @disabled={{model.launchTemplate.version}}
             />
@@ -326,7 +326,7 @@
           canChangeName=false
           classNames="box"
           placeholder="nodeGroupRow.userData.placeholder"
-          value=model.userData
+          value=userData
           minHeight=150
           disabled=(or
             (or
@@ -349,7 +349,7 @@
         </label>
         {{#if refreshResourceInstanceTags}}
           <FormKeyValue
-            @initialMap={{model.resourceTags}}
+            @initialMap={{resourceTags}}
             @changed={{action "setResourceTags"}}
             @addActionLabel="clusterNew.amazoneks.tags.addActionLabel"
             @editing={{not model.launchTemplate.version}}

--- a/lib/shared/addon/components/node-group-row/template.hbs
+++ b/lib/shared/addon/components/node-group-row/template.hbs
@@ -26,8 +26,8 @@
               classNames="form-control"
               value=selectedLaunchTemplate
               content=filteredLaunchTemplates
-              optionValuePath="value"
-              optionLabelPath="label"
+              optionValuePath="LaunchTemplateId"
+              optionLabelPath="LaunchTemplateName"
               prompt="nodeGroupRow.launchTemplates.label"
               localizedPrompt=true
               readOnly=isRancherLaunchTemplate
@@ -41,8 +41,8 @@
                   classNames="form-control"
                   value=selectedLaunchTemplate
                   content=filteredLaunchTemplates
-                  optionValuePath="value"
-                  optionLabelPath="label"
+                  optionValuePath="LaunchTemplateId"
+                  optionLabelPath="LaunchTemplateName"
                   prompt="nodeGroupRow.launchTemplates.label"
                   localizedPrompt=true
                   readOnly=(and (not isRancherLaunchTemplate) editing)
@@ -55,7 +55,7 @@
             </div>
           {{else if selectedLaunchTemplate}}
             <div>
-              {{selectedLaunchTemplate.name}}
+              {{selectedLaunchTemplate.LaunchTemplateName}}
             </div>
           {{else}}
             <div>


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
While investigating another issue that was reopened I discovered an assumption that the UI was making was incorrect leading to the refactor. When using a launch template the UI parses the data for various fields onto the model from the launch template version info after it is loaded. This has never presented an issue so my assumption that this data would always be present was incorrect. There is a 5 min window after the cluster has provision where in a sync between the upstream and rancher versions of the cluster happens, if the node group is using a launch template then any data from the managed fields is dropped. I did not see this because while developing I apparently never waiting 5 min between when a cluster came up and when I edited it.

This PR addresses the following:
Refactor how we load the selected launch template version info. Change observer to a method explicitly called when version is set or changed.
Swap access to raw data on the model for managed fields to computed properties which allows us to return the info from the selected launch template because the node group wont have this info. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
https://github.com/rancher/rancher/issues/31277
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
