### PR TITLE
[backport] Disabling all reference types on rke create for agentenvvar and marking variable name field as required

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -1261,6 +1261,7 @@
               <FormAgentEnvVar 
                 @editable={{notView}} 
                 @value={{agentEnvVars}} 
+                @disableReferenceTypes={{isNew}}
                 @showCustomConfigMaps={{showCustomConfigMaps}} 
                 @showCustomSecrets={{showCustomSecrets}} 
                 @configMaps={{model.configMaps}} 

--- a/lib/shared/addon/components/form-agent-env-var/component.js
+++ b/lib/shared/addon/components/form-agent-env-var/component.js
@@ -11,21 +11,27 @@ export default Component.extend({
   model:    null,
   editable: true,
 
-  statusClass:          null,
-  status:               null,
-  editing:              true,
-  showCustomConfigMaps: false,
-  showCustomSecrets:    false,
-  typeChoices:          [],
-  configMaps:           [],
-  secrets:              [],
-  value:                [],
-  resourceKeyChoices:   [],
+  statusClass:           null,
+  status:                null,
+  editing:               true,
+  showCustomConfigMaps:  false,
+  showCustomSecrets:     false,
+  disableReferenceTypes: false,
+  typeChoices:           [],
+  configMaps:            [],
+  secrets:               [],
+  value:                 [],
+  resourceKeyChoices:    [],
   init() {
     this._super(...arguments);
 
     const configMapsEnabled = this.showCustomConfigMaps || this.configMaps?.length > 0;
     const secretsEnabled = this.showCustomSecrets || this.secrets?.length > 0;
+
+    const configMapString = this.intl.t('formAgentEnvVar.typeChoices.configMap');
+    const secretString = this.intl.t('formAgentEnvVar.typeChoices.secret');
+    const resourceString = this.intl.t('formAgentEnvVar.typeChoices.resource');
+    const podFieldString = this.intl.t('formAgentEnvVar.typeChoices.podField');
 
     const typeChoices = [
       {
@@ -33,22 +39,24 @@ export default Component.extend({
         value: 'keyValue'
       },
       {
-        label: this.intl.t('formAgentEnvVar.typeChoices.resource'),
-        value: 'resource'
+        label:    this.disableReferenceTypes ? this.intl.t('formAgentEnvVar.typeChoices.notAvailable', { type: resourceString }) : resourceString,
+        disabled: this.disableReferenceTypes,
+        value:    'resource'
       },
       {
-        label:    configMapsEnabled ? this.intl.t('formAgentEnvVar.typeChoices.configMap') : this.intl.t('formAgentEnvVar.typeChoices.configMapNone'),
-        disabled: !configMapsEnabled,
+        label:    configMapsEnabled ? configMapString : this.intl.t('formAgentEnvVar.typeChoices.notAvailable', { type: configMapString }),
+        disabled: this.disableReferenceTypes || !configMapsEnabled,
         value:    'configMap'
       },
       {
-        label:    secretsEnabled ? this.intl.t('formAgentEnvVar.typeChoices.secret') : this.intl.t('formAgentEnvVar.typeChoices.secretNone'),
-        disabled: !secretsEnabled,
+        label:    secretsEnabled ? secretString : this.intl.t('formAgentEnvVar.typeChoices.notAvailable', { type: secretString }),
+        disabled: this.disableReferenceTypes || !secretsEnabled,
         value:    'secret'
       },
       {
-        label: this.intl.t('formAgentEnvVar.typeChoices.podField'),
-        value: 'podfield'
+        label:    this.disableReferenceTypes ? this.intl.t('formAgentEnvVar.typeChoices.notAvailable', { type: podFieldString }) : podFieldString,
+        disabled: this.disableReferenceTypes,
+        value:    'podfield'
       }
     ];
 

--- a/lib/shared/addon/components/form-agent-env-var/template.hbs
+++ b/lib/shared/addon/components/form-agent-env-var/template.hbs
@@ -18,7 +18,12 @@
           {{/input-or-display}}
         </td>
         <td class="pl-10">
-          <label class="text-small">{{t 'formAgentEnvVar.headers.variableName'}}</label>
+          <label class="text-small">
+            {{t 'formAgentEnvVar.headers.variableName'}}
+            {{#if editing}}
+              {{field-required}}
+            {{/if}}
+          </label>
           {{#input-or-display
               editable=editable
               value=envVar.name

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -6444,14 +6444,12 @@ formAgentEnvVar:
     bar: e.g. bar
     container: e.g. my-container
     key: e.g. metadata.labels['KEY']
-
   typeChoices:
+    notAvailable: "{type} (Not Available)"
     keyValue: Key/Value Pair
     resource: Resource
     configMap: ConfigMap Key 
-    configMapNone: ConfigMap Key (None Available)
     secret: Secret Key
-    secretNone: Secret Key (None Available)
     podField: Pod Field
 
   addActionLabel: Add Environment Variable


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Since the reference types can't exist until the cluster is created I added an option to disable all reference types and use it during RKE create

Even though the backend doesn't indicate the variable name is required we're marking it as such because it casues cluster to fail. No validation will be done at this time.


Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
rancher/rancher#31528

![image](https://user-images.githubusercontent.com/55104481/109550631-c8ee4280-7a8c-11eb-969c-c46e74dee91c.png)

![image](https://user-images.githubusercontent.com/55104481/109550708-df949980-7a8c-11eb-944b-36dc53fed11c.png)

