### PR TITLE
enable save on edit if cluster is generic import

### DIFF
--- a/lib/shared/addon/components/cru-cluster/template.hbs
+++ b/lib/shared/addon/components/cru-cluster/template.hbs
@@ -108,13 +108,13 @@
         <label class="acc-label">
           {{t "clusterNew.rke.agentEnvVars.label"}}
         </label>
-        <FormAgentEnvVar 
-          @editable={{notView}} 
-          @value={{agentEnvVars}} 
-          @showCustomConfigMaps={{true}} 
-          @showCustomSecrets={{true}} 
-          @configMaps={{model.configMaps}} 
-          @secrets={{model.secrets}} 
+        <FormAgentEnvVar
+          @editable={{notView}}
+          @value={{agentEnvVars}}
+          @showCustomConfigMaps={{true}}
+          @showCustomSecrets={{true}}
+          @configMaps={{model.configMaps}}
+          @secrets={{model.secrets}}
         />
       {{/accordion-list-item}}
     {{/accordion-list}}
@@ -142,7 +142,9 @@
   }}
 {{/if}}
 
-{{#if (and isEdit (not provider))}}
+{{!-- in older ver of rancher no provider was import but we only want to show this save if is generic (non eks) import --}}
+{{!-- otherwise save is handled by the cluster driver component --}}
+{{#if (and isEdit (or (not provider) isImportedOther))}}
   {{top-errors errors=errors}}
   {{save-cancel
     editing=isEdit
@@ -150,6 +152,7 @@
     cancel=(action "close")
   }}
 {{else if (not showDriverComponent)}}
+  {{!-- something is super wrong because your not import or custom or any driver in general so we're not letting you save --}}
   {{save-cancel
     saveDisabled=true
     cancel=(action "close")


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Regression introduced with Eks Imported clusters that prevented generic imported clusters from getting saved. Added some comments to clarify the branches logic as well. Didn't want to refactor because we're so close to release. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#31547
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
