### PR TITLE
[2.5.x] explicitly pass import provider for edit import

### DIFF
--- a/app/authenticated/cluster/edit/controller.js
+++ b/app/authenticated/cluster/edit/controller.js
@@ -6,9 +6,10 @@ import { inject as service } from '@ember/service';
 export default Controller.extend({
   settings: service(),
 
-  queryParams:             ['provider', 'clusterTemplateRevision', 'scrollTo'],
+  queryParams:             ['provider', 'importProvider', 'clusterTemplateRevision', 'scrollTo'],
   provider:                null,
   clusterTemplateRevision: null,
+  importProvider:          null,
 
   cluster: alias('model.cluster'),
 

--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -700,6 +700,10 @@ export default Resource.extend(Grafana, ResourceUsage, {
         }
       };
 
+      if (provider === 'import' && isEmpty(get(this, 'eksConfig'))) {
+        set(queryParams, 'queryParams.importProvider', 'other');
+      }
+
       if (provider === 'amazoneks' && !isEmpty(get(this, 'eksConfig'))) {
         set(queryParams, 'queryParams.provider', 'amazoneksv2');
       }

--- a/lib/shared/addon/components/cru-cluster/template.hbs
+++ b/lib/shared/addon/components/cru-cluster/template.hbs
@@ -142,9 +142,8 @@
   }}
 {{/if}}
 
-{{!-- in older ver of rancher no provider was import but we only want to show this save if is generic (non eks) import --}}
 {{!-- otherwise save is handled by the cluster driver component --}}
-{{#if (and isEdit (or (not provider) isImportedOther))}}
+{{#if (and isEdit (not provider))}}
   {{top-errors errors=errors}}
   {{save-cancel
     editing=isEdit


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
In a prior PR I put in a dependency on a computed property to show the correct save. While reviewing another PR I saw that this was actually incorrect. The change technically worked but in the case of `K3s` clusters which are technically an import, we would show a second save button. This ensures that when selecting edit, we send the importProvider (added for eks imports) which will ensure the DriverImport component is shown with the correct save button and no double buttons will be produced for `K3s` edits.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#31547
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
