### PR TITLE
Cluster Reg Commands Not Updating on Edit of Env Vars

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-import/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-import/component.js
@@ -3,6 +3,7 @@ import { computed, get, observer, set } from '@ember/object';
 import { alias, equal } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
+import { resolve } from 'rsvp';
 import ClusterDriver from 'shared/mixins/cluster-driver';
 import layout from './template';
 
@@ -134,4 +135,14 @@ export default Component.extend(ClusterDriver, {
 
     return this._super();
   },
+
+  doneSaving() {
+    return this.loadToken();
+  },
+
+  loadToken() {
+    set(this, 'step', 2);
+
+    return resolve();
+  }
 });

--- a/lib/shared/addon/components/cluster-driver/driver-import/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-import/component.js
@@ -1,10 +1,10 @@
-import Component from '@ember/component'
-import ClusterDriver from 'shared/mixins/cluster-driver';
-import { inject as service } from '@ember/service';
-import { computed, get, set, observer } from '@ember/object';
+import Component from '@ember/component';
+import { computed, get, observer, set } from '@ember/object';
 import { alias, equal } from '@ember/object/computed';
-import layout from './template';
+import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
+import ClusterDriver from 'shared/mixins/cluster-driver';
+import layout from './template';
 
 export default Component.extend(ClusterDriver, {
   globalStore: service(),
@@ -18,6 +18,7 @@ export default Component.extend(ClusterDriver, {
   nodeForInfo:   null,
 
   isEdit:        equal('mode', 'edit'),
+  isView:        equal('mode', 'view'),
   clusterState:  alias('model.originalCluster.state'),
   isK3sCluster:  equal('model.cluster.driver', 'k3s'),
   isRke2Cluster: equal('model.cluster.driver', 'rke2'),
@@ -25,12 +26,6 @@ export default Component.extend(ClusterDriver, {
   nodes: computed.reads('model.cluster.masterNodes'),
 
   didReceiveAttrs() {
-    if ( get(this, 'isEdit') &&
-         get(this, 'clusterState') === 'pending'
-    ) {
-      this.loadToken();
-    }
-
     if ( get(this, 'isEdit') ) {
       if (this.isK3sCluster) {
         set(this, 'configField', 'k3sConfig');
@@ -139,18 +134,4 @@ export default Component.extend(ClusterDriver, {
 
     return this._super();
   },
-
-  doneSaving() {
-    if ( get(this, 'isEdit') ) {
-      if (this.close) {
-        this.close();
-      }
-    } else {
-      return this.loadToken();
-    }
-  },
-
-  loadToken() {
-    set(this, 'step', 2);
-  }
 });

--- a/lib/shared/addon/components/cluster-driver/driver-import/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-import/template.hbs
@@ -26,7 +26,7 @@
 <TopErrors @errors={{otherErrors}} />
 <TopErrors @errors={{clusterErrors}} />
 
-{{#if isView}}
+{{#if (and (eq step 2) (eq originalCluster.state "pending"))}}
   <div class="footer-actions">
     <button class="btn bg-primary" type="button" {{action "close"}}>
       {{t "clusterNew.rke.done"}}

--- a/lib/shared/addon/components/cluster-driver/driver-import/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-import/template.hbs
@@ -18,40 +18,24 @@
       />
     </AccordionListItem>
   </AccordionList>
+{{else if (and (eq step 2) (eq originalCluster.state "pending"))}}
+  <ImportCommand @cluster={{cluster}}/>
+{{/if}}
 
-  <TopErrors @errors={{errors}} />
-  <TopErrors @errors={{otherErrors}} />
-  <TopErrors @errors={{clusterErrors}} />
+<TopErrors @errors={{errors}} />
+<TopErrors @errors={{otherErrors}} />
+<TopErrors @errors={{clusterErrors}} />
+
+{{#if isView}}
+  <div class="footer-actions">
+    <button class="btn bg-primary" type="button" {{action "close"}}>
+      {{t "clusterNew.rke.done"}}
+    </button>
+  </div>
+{{else}}
   <SaveCancel
-    @save={{action "driverSave"}}
+    @save={{"driverSave"}}
     @editing={{isEdit}}
     @cancel={{action "close"}}
   />
-{{else if (and (eq step 2) (eq originalCluster.state "pending"))}}
-  <ImportCommand @cluster={{cluster}}/>
-
-  {{#if isEdit}}
-    {{top-errors errors=otherErrors}}
-    {{top-errors errors=clusterErrors}}
-    {{save-cancel
-      save=(action "driverSave")
-      editing=true
-      cancel=(action "close")
-    }}
-  {{else}}
-    <div class="footer-actions">
-      <button class="btn bg-primary" type="button" {{action "close"}}>
-        {{t "clusterNew.rke.done"}}
-      </button>
-    </div>
-  {{/if}}
-{{else}}
-  {{top-errors errors=errors}}
-  {{top-errors errors=otherErrors}}
-  {{top-errors errors=clusterErrors}}
-  {{save-cancel
-    save=(action "driverSave")
-    editing=isEdit
-    cancel=(action "close")
-  }}
 {{/if}}

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -123,6 +123,8 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
   upgradeStrategy:           null,
   scheduledClusterScan:      null,
 
+  isPostSave: false,
+
   isNew:                        equal('mode', 'new'),
   isEdit:                       equal('mode', 'edit'),
   notView:                      or('isNew', 'isEdit'),

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -515,6 +515,11 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
   agentEnvVars: computed('cluster.agentEnvVars.[]', {
     get() {
+      if (!this.cluster?.agentEnvVars) {
+        // if undefined two way binding doesn't seem to work
+        set(this, 'cluster.agentEnvVars', []);
+      }
+
       return get(this, 'cluster.agentEnvVars') || [];
     },
     set(_key, value) {

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -140,9 +140,6 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       scheduledClusterScan:      { enabled: false },
     })
 
-    this.initAgentEnvVars();
-
-
     this.initNodeCounts();
     if (!this.useClusterTemplate && this.model.cluster.clusterTemplateRevisionId) {
       setProperties(this, {
@@ -200,10 +197,6 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
   },
 
   didReceiveAttrs() {
-    if ( get(this, 'isEdit') && !get(this, 'clusterTemplateCreate')) {
-      this.loadToken();
-    }
-
     if (this.applyClusterTemplate) {
       if (this.useClusterTemplate) {
         this.initTemplateCluster();
@@ -517,6 +510,17 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       });
     }
   })),
+
+  agentEnvVars: computed('cluster.agentEnvVars.[]', {
+    get() {
+      return get(this, 'cluster.agentEnvVars') || [];
+    },
+    set(_key, value) {
+      set(this, 'cluster.agentEnvVars', value);
+
+      return value;
+    },
+  }),
 
   maxUnavailable: computed('upgradeStrategy.maxUnavailableUnit', 'upgradeStrategy.maxUnavailableWorker', function() {
     const value = { value: get(this, 'upgradeStrategy.maxUnavailableWorker') };
@@ -1029,10 +1033,6 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
     this.checkKubernetesVersionSemVer();
 
-    if (get(this, 'agentEnvVars')) {
-      set(this, 'cluster.agentEnvVars', get(this, 'agentEnvVars'));
-    }
-
     if (get(this, 'upgradeStrategy.maxUnavailableUnit') === 'percentage') {
       set(this, 'upgradeStrategy.maxUnavailableWorker', (`${ get(this, 'upgradeStrategy.maxUnavailableWorker')  }%`));
     }
@@ -1238,13 +1238,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     let { close } = this;
 
     if ( get(this, 'isCustom') ) {
-      if ( get(this, 'isEdit') ) {
-        if (close) {
-          close(neu);
-        }
-      } else {
-        this.loadToken();
-      }
+      this.loadToken();
     } else {
       if (close) {
         close(neu);
@@ -1258,10 +1252,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     const cluster = get(this, 'primaryResource');
 
     if (cluster.getOrCreateToken) {
-      setProperties(this, {
-        step:    2,
-        loading: true
-      });
+      set(this, 'loading', true);
 
       return cluster.getOrCreateToken().then((token) => {
         if ( this.isDestroyed || this.isDestroying ) {
@@ -1270,6 +1261,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
         setProperties(this, {
           token,
+          step:    2,
           loading: false
         });
       }).catch((err) => {
@@ -1436,10 +1428,6 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       initialVersion,
       initialNodeCounts: counts,
     })
-  },
-
-  initAgentEnvVars() {
-    set(this, 'agentEnvVars', get(this, 'cluster.agentEnvVars') || []);
   },
 
   initPrivateRegistries() {

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -1370,7 +1370,7 @@
 
 {{top-errors errors=allErrors}}
 
-{{#if (or (and notView (eq step 1)) (and isEdit (eq step 2)))}}
+{{#if (or (and notView (eq step 1)) (and (and (not isPostSave) isEdit) (eq step 2)))}}
   {{#if (and clusterTemplatesEnforced (not clusterTemplateRevisionId) )}}
     <section class="mt-20 mb-20">
       <BannerMessage

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -37,7 +37,7 @@
 </section>
 
 {{#if (and (not clusterTemplateCreate) notView) }}
-  {{#if (or isEdit (eq step 1))}}
+  {{#if (or (and isEdit (not isPostSave)) (eq step 1))}}
     <section class="cluster-template-select mb-5">
       <div class="row">
         {{#if (or (or model.clusterTemplateRevisions model.clusterTemplateRevision) clusterTemplatesEnforced)}}
@@ -95,7 +95,7 @@
 {{/if}}
 
 {{#if (or clusterTemplateCreate (or (not clusterTemplatesEnforced) (and clusterTemplatesEnforced clusterTemplateRevisionId)))}}
-  {{#if (or isEdit (eq step 1))}}
+  {{#if (or (and isEdit (not isPostSave)) (eq step 1))}}
     {{#accordion-list
        expandAll=(mut forceExpandAll)
        showExpandAll=true

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -1253,17 +1253,17 @@
               {{drain-node selection=upgradeStrategy.nodeDrainInput clusterTemplateCreate=clusterTemplateCreate editable=notView applyClusterTemplate=applyClusterTemplate clusterTemplateRevision=model.clusterTemplateRevision.clusterConfig questions=model.clusterTemplateRevision.questions addOverride=(action "addOverride")}}
             </div>
           {{/if}}
-          {{#if (not clusterTemplateCreate)}}
+          {{#unless clusterTemplateCreate}}
             <div class="row mt-10">
               <label class="acc-label">
                 {{t "clusterNew.rke.agentEnvVars.label"}}
               </label>
-              <FormAgentEnvVar 
-                @editable={{notView}} 
-                @value={{agentEnvVars}} 
+              <FormAgentEnvVar
+                @editable={{notView}}
+                @value={{mut agentEnvVars}}
               />
             </div>
-          {{/if}}
+          {{/unless}}
         {{/accordion-list-item}}
 
         {{#accordion-list-item

--- a/lib/shared/addon/components/cru-cluster/component.js
+++ b/lib/shared/addon/components/cru-cluster/component.js
@@ -282,21 +282,19 @@ export default Component.extend(ViewNewEdit, ChildHook, {
         nodeWhich: 'custom',
         nodePool:  true,
         preSave:   true,
-        postSave:    true,
+        postSave:  true,
       });
 
       out.push({
         name:     'import',
         driver:   'import',
         preSave:  true,
-        postSave: true,
       });
 
       out.push({
         name:     'imported',
         driver:   'import',
         preSave:  true,
-        postSave: true,
       });
 
       out.push({
@@ -434,7 +432,7 @@ export default Component.extend(ViewNewEdit, ChildHook, {
   },
 
   doneSaving(saved) {
-    if ( get(this, 'step') === 1 && get(this, 'driverInfo.preSave') ) {
+    if ( get(this, 'step') === 1 && get(this, 'driverInfo.preSave') && !get(this, 'driverInfo.postSave') ) {
       setProperties(this, {
         step:            2,
         initialProvider: get(this, 'provider')

--- a/lib/shared/addon/components/cru-cluster/component.js
+++ b/lib/shared/addon/components/cru-cluster/component.js
@@ -138,6 +138,11 @@ export default Component.extend(ViewNewEdit, ChildHook, {
 
   agentEnvVars: computed('cluster.agentEnvVars.[]', {
     get() {
+      if (!this.cluster?.agentEnvVars) {
+        // if undefined two way binding doesn't seem to work
+        set(this, 'cluster.agentEnvVars', []);
+      }
+
       return get(this, 'cluster.agentEnvVars') || [];
     },
     set(_key, value) {

--- a/lib/shared/addon/components/cru-cluster/component.js
+++ b/lib/shared/addon/components/cru-cluster/component.js
@@ -36,7 +36,6 @@ export default Component.extend(ViewNewEdit, ChildHook, {
   showClassicLauncher:       false,
   nodePoolErrors:            null,
   clusterTemplateRevisionId: null,
-  agentEnvVars:              [],
 
   cluster:                   alias('model.cluster'),
   originalCluster:           alias('model.originalCluster'),
@@ -49,12 +48,6 @@ export default Component.extend(ViewNewEdit, ChildHook, {
 
   init() {
     this._super(...arguments);
-
-    this.initAgentEnvVars();
-
-    if (get(this, 'agentEnvVars')) {
-      set(this, 'cluster.agentEnvVars', get(this, 'agentEnvVars'));
-    }
 
     // On edit pass in initialProvider, for create just set provider directly
     const initialProvider = get(this, 'initialProvider');
@@ -142,6 +135,18 @@ export default Component.extend(ViewNewEdit, ChildHook, {
       });
     }
   }),
+
+  agentEnvVars: computed('cluster.agentEnvVars.[]', {
+    get() {
+      return get(this, 'cluster.agentEnvVars') || [];
+    },
+    set(_key, value) {
+      set(this, 'cluster.agentEnvVars', value);
+
+      return value;
+    },
+  }),
+
 
   isEksClusterPending: computed('clusterState', 'provider', function() {
     const { clusterState, provider } = this;
@@ -276,19 +281,22 @@ export default Component.extend(ViewNewEdit, ChildHook, {
         driver:    'rke',
         nodeWhich: 'custom',
         nodePool:  true,
-        preSave:   true
+        preSave:   true,
+        postSave:    true,
       });
 
       out.push({
-        name:    'import',
-        driver:  'import',
-        preSave: true
+        name:     'import',
+        driver:   'import',
+        preSave:  true,
+        postSave: true,
       });
 
       out.push({
-        name:    'imported',
-        driver:  'import',
-        preSave: true
+        name:     'imported',
+        driver:   'import',
+        preSave:  true,
+        postSave: true,
       });
 
       out.push({
@@ -400,10 +408,6 @@ export default Component.extend(ViewNewEdit, ChildHook, {
 
     return true;
   }),
-
-  initAgentEnvVars() {
-    set(this, 'agentEnvVars', get(this, 'cluster.agentEnvVars') || []);
-  },
 
   doSave(opt) {
     opt = opt || {};

--- a/lib/shared/addon/components/cru-cluster/template.hbs
+++ b/lib/shared/addon/components/cru-cluster/template.hbs
@@ -103,7 +103,7 @@
         </label>
         <FormAgentEnvVar
           @editable={{notView}}
-          @value={{agentEnvVars}}
+          @value={{mut agentEnvVars}}
         />
       {{/accordion-list-item}}
     {{/accordion-list}}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
If a user wants to edit the environment vars on a custom cluster and rerun the registration command they must first save the cluster. EnvVars are not simply appended to the cluster registration command as some of the other params are but are actually apart of the command as fetched from the backend. Rather than try to slice up the command to append our new vars before save I've refactored the logic for both custom and imported clusters to not show the command on edit until the cluster has been saved. This breaks the previous UX pattern of displaying the command on initialization of the edit view but I think this is a better UX regardless. This explicitly requires action from the user before just fetching the command, which if that is all they want can be done from the action menu for the cluster. 

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Breaking Change
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#31529
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
