### PR TITLE
[2.5.x] Show istio hidden answers

### DIFF
--- a/lib/istio/addon/components/istio-catalog/component.js
+++ b/lib/istio/addon/components/istio-catalog/component.js
@@ -139,6 +139,7 @@ const ISTIO_CLUSTER_MEMORY = 500;
 const ISTIO_BREAKING_VERSION = '1.4.2';
 
 export default Component.extend(CrudCatalog, ReservationCheck, CatalogUpgrade, {
+  settings:     service(),
   scope:        service(),
   intl:         service(),
   grafana:      service(),
@@ -164,6 +165,8 @@ export default Component.extend(CrudCatalog, ReservationCheck, CatalogUpgrade, {
 
     if ( get(this, 'enabled') ) {
       this.initAnswers();
+    } else {
+      set(this, 'customAnswers', { ...HIDDEN_KEYS });
     }
   },
 
@@ -184,7 +187,6 @@ export default Component.extend(CrudCatalog, ReservationCheck, CatalogUpgrade, {
       }
 
       let answers = {
-        ...HIDDEN_KEYS,
         'global.rancher.domain':    window.location.host,
         'global.rancher.clusterId': get(this, 'cluster.id'),
       };
@@ -819,10 +821,6 @@ export default Component.extend(CrudCatalog, ReservationCheck, CatalogUpgrade, {
           || key.startsWith(`${ GATEWAY_TOLERATION }`)
           || key.startsWith(`${ TRACING_TOLERATION }`)
       ) {
-        return
-      }
-
-      if (Object.keys(HIDDEN_KEYS).includes(key)) {
         return
       }
 

--- a/lib/istio/addon/components/istio-catalog/template.hbs
+++ b/lib/istio/addon/components/istio-catalog/template.hbs
@@ -455,6 +455,11 @@
        expand=(action expandFn)
        expandOnInit=false
     }}
+      <BannerMessage
+        @color="bg-warning"
+        @icon="icon-alert"
+        @message={{t "clusterIstioPage.customAnswers.warning" appName=settings.appName htmlSafe=true}}
+      />
       {{form-key-value
         initialMap=customAnswers
         changed=(action (mut customAnswers))

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1138,6 +1138,7 @@ clusterIstioPage:
   customAnswers:
     title: Custom Answers
     detail: Configure custom answers.
+    warning: "Custom Answers are an advanced configuration option. {appName} pre-configures custom answers to ensure that specific <a href='https://istio.io/latest/docs/setup/additional-setup/cni/#prerequisites' target='_blank' rel='nofollow noreferrer'>prerequisites</a> are met for the default Istio configuration. Adding or removing custom answers may result in a non-functional Istio configuration. Please ensure you fully understand the changes you are making before you save."
   links:
     kiali:
       label: Kiali UI
@@ -6448,7 +6449,7 @@ formAgentEnvVar:
     notAvailable: "{type} (Not Available)"
     keyValue: Key/Value Pair
     resource: Resource
-    configMap: ConfigMap Key 
+    configMap: ConfigMap Key
     secret: Secret Key
     podField: Pod Field
 


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
During istio configuration we previously hide a collection of keys with static answers we set to ensure the default setup would work correctly. This created  a case when a user made could make an edit to one of those hidden keys on initial configuration but when editing or upgrading the key would be hidden. 

I've removed the logic that hides those keys from the custom answers section on edit. 
Updated the create case to populate the custom answers object with the hidden keys on init.
Added a warning banner informing the user that changing these keys is an advanced use case.

Warning: 
`Custom Answers are an advanced configuration option. Rancher pre-configures custom answers to ensure that specific prerequisites are met for the default Istio configuration. Adding or removing custom answers may result in a non-functional Istio configuration. Please ensure you fully understand the changes you are making before you save.`

![Screen Shot 2021-03-15 at 10 10 49 AM](https://user-images.githubusercontent.com/858614/111193855-dd940580-8577-11eb-98f6-58c873e6d7c7.png)

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Enhancement
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#29247
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
