### PR TITLE
Revert "Filter out OL-8.x images until it is supported by OCI machine…

### DIFF
--- a/lib/nodes/addon/components/driver-oci/component.js
+++ b/lib/nodes/addon/components/driver-oci/component.js
@@ -94,7 +94,7 @@ export default Component.extend(NodeDriver, {
         }
       });
 
-      return this.mapToContent(this.filterOut(options, 'Oracle-Linux-8'));
+      return this.mapToContent(options);
     }
 
     return {
@@ -136,11 +136,6 @@ export default Component.extend(NodeDriver, {
         label: option,
         value: option
       }));
-    }
-  },
-  filterOut(folderOptions, filter) {
-    if (folderOptions && typeof folderOptions.map === 'function') {
-      return folderOptions.filter((entry) => !entry.includes(filter));
     }
   },
   validate() {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

This PR reverts the [temporary filtering](https://github.com/rancher/ui/pull/4250) of Oracle-Linux 8.x images from the OCI node template UI now that OL-8 is working for Docker machine. 

I have personally verified the driver is working with the currently available Oracle Linux images including OL-7.8, OL-7.9, and OL-8.2.


<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-->



Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

- https://github.com/rancher/ui/pull/4250
- rancher/rancher#23045
- rancher/rancher#29253

Further comments
======



<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->





