### PR TITLE
use verify-auth-azure instead of verify-auth

### DIFF
--- a/lib/global-admin/addon/security/authentication/azuread/controller.js
+++ b/lib/global-admin/addon/security/authentication/azuread/controller.js
@@ -32,7 +32,7 @@ export default Controller.extend(AuthMixin, {
 
       setProperties(model, {
         accessMode: am,
-        rancherUrl: `${ window.location.origin }/verify-auth`
+        rancherUrl: `${ window.location.origin }/verify-auth-azure`
       });
 
       var errors = model.validationErrors();
@@ -73,7 +73,7 @@ export default Controller.extend(AuthMixin, {
   }),
 
   replyUrl: computed(() => {
-    return `${ window.location.origin }/verify-auth`;
+    return `${ window.location.origin }/verify-auth-azure`;
   }),
 
   authenticationApplied(err) {


### PR DESCRIPTION
As part of this https://github.com/rancher/rancher/issues/31562 I changed azure auth to use the same redirect url as other auth types, `/verify-auth`. This works as expected for new setups, but while looking at a different azuread issue I realized it was a poor decision, and will break preexisting  azuread configs that use `/verify-auth-azure`. Both ui's should use `/verify-auth-azure` for azuread, which leverages the same redirect logic as` /verify-auth`. Related Dashboard PR: https://github.com/rancher/dashboard/pull/2564