### PR TITLE
[2.5.x] fix url-safe base64 regex

### DIFF
--- a/lib/shared/addon/oauth/service.js
+++ b/lib/shared/addon/oauth/service.js
@@ -45,7 +45,7 @@ export default Service.extend({
       '=': ''
     }
 
-    return AWS.util.base64.encode(state).replace(/[+/]|=$/g, (char) => m[char])
+    return AWS.util.base64.encode(state).replace(/[+/]|=+$/g, (char) => m[char])
   },
 
   decodeState(state){


### PR DESCRIPTION
See https://github.com/rancher/dashboard/pull/2631  azureAD and googleoauth state params happen to encode without more than 1 `=` here, so no bug to reproduce on this side, but the same flaw in encoding is present here. 