### PR TITLE
[2.5.x] GKE V2 Edit Sync Upstream Config

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -1023,8 +1023,8 @@ export default Resource.extend(Grafana, ResourceUsage, {
 
       set(options, 'data.gkeConfig', this.diffUpstreamSpec(upstreamSpec, config));
 
-      if (!isEmpty(get(options, 'data.gkeConfig.nodeGroups'))) {
-        get(options, 'data.gkeConfig.nodeGroups').forEach((ng) => {
+      if (!isEmpty(get(options, 'data.gkeConfig.nodePools'))) {
+        get(options, 'data.gkeConfig.nodePools').forEach((ng) => {
           this.replaceNullWithEmptyDefaults(ng, get(gkeNodePoolConfigSpec, 'resourceFields'));
         });
       }

--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -138,10 +138,10 @@ export const DEFAULT_GKE_CONFIG = {
     masterIpv4CidrBlock:   null,
   },
   projectID:  null,
-  region:     'us-west2',
+  region:     null,
   subnetwork: null,
   type:       'gkeclusterconfigspec',
-  zone:       null,
+  zone:       'us-central1-c',
 };
 
 

--- a/lib/shared/addon/components/cluster-driver/driver-gke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/component.js
@@ -32,6 +32,8 @@ export default Component.extend(ClusterDriver, {
   monitoringServiceChoices: null,
   loggingServiceChoices:    null,
   sharedSubnets:            null,
+  clusterLocationSaved:     false,
+  clusterLocationSaving:    false,
 
   allErrors: union('errors', 'otherErrors', 'clusterErrors'),
   isNew:     equal('mode', 'new'),
@@ -76,6 +78,16 @@ export default Component.extend(ClusterDriver, {
       config = this.globalStore.createRecord(this.defaultConfig());
 
       set(this, 'cluster.gkeConfig', config);
+    } else {
+      if ( this.editing && this.clusterIsPending ) {
+        set(this, 'step', 5);
+      } else {
+        this.syncUpstreamConfig();
+
+        const initalTags = { ...( config.tags || {} ) };
+
+        set(this, 'initalTags', initalTags);
+      }
     }
 
     setProperties(this, {
@@ -107,11 +119,11 @@ export default Component.extend(ClusterDriver, {
         nodePools = [];
       }
 
-      const nodeGroup = this.globalStore.createRecord(npConfig);
+      const nodePool = this.globalStore.createRecord(npConfig);
 
-      set(nodeGroup, 'version', kubernetesVersion);
+      set(nodePool, 'version', kubernetesVersion);
 
-      nodePools.pushObject(nodeGroup);
+      nodePools.pushObject(nodePool);
 
       set(this, 'config.nodePools', nodePools);
     },
@@ -139,7 +151,17 @@ export default Component.extend(ClusterDriver, {
         setProperties(this, {
           step: 2,
           zones,
-        })
+        });
+
+        if (this.editing) {
+          set(this, 'clusterLocationSaving', true);
+          this.send('checkServiceAccount', () => {
+            setProperties(this, {
+              clusterLocationSaving: false,
+              clusterLocationSaved:  true,
+            });
+          });
+        }
 
         cb(true);
       }).catch((err) => {
@@ -149,7 +171,7 @@ export default Component.extend(ClusterDriver, {
       });
     },
 
-    checkServiceAccount(cb) {
+    checkServiceAccount(cb = () => {}) {
       set(this, 'errors', []);
 
       const config = get(this, `cluster.${ this.configField }`);
@@ -659,5 +681,19 @@ export default Component.extend(ClusterDriver, {
     set(this, 'errors', errors);
 
     return errors.length >= 1 ? true : null;
+  },
+
+  syncUpstreamConfig() {
+    const originalCluster = get(this, 'model.originalCluster').clone();
+    const ourClusterSpec = get(originalCluster, 'gkeConfig');
+    const upstreamSpec = get(originalCluster, 'gkeStatus.upstreamSpec');
+
+    if (!isEmpty(upstreamSpec)) {
+      Object.keys(upstreamSpec).forEach((k) => {
+        if (isEmpty(get(ourClusterSpec, k)) && !isEmpty(get(upstreamSpec, k))) {
+          set(this, `config.${ k }`, get(upstreamSpec, k));
+        }
+      });
+    }
   },
 });

--- a/lib/shared/addon/components/cluster-driver/driver-gke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/template.hbs
@@ -161,6 +161,8 @@
           <SaveCancel
             @createLabel="clusterNew.googlegke.clusterLocation.createLabel"
             @savingLabel="clusterNew.googlegke.clusterLocation.savingLabel"
+            @saving={{mut clusterLocationSaving}}
+            @saved={{mut clusterLocationSaved}}
             @save={{action "checkServiceAccount"}}
             @cancel={{close}}
           />

--- a/lib/shared/addon/components/gke-node-pool-row/component.js
+++ b/lib/shared/addon/components/gke-node-pool-row/component.js
@@ -28,7 +28,6 @@ export default Component.extend({
   nodeVersions:                    null,
   controlPlaneVersion:             null,
   upgradeVersion:                  false,
-  showNodeUpgradePreventionReason: false,
 
   init() {
     this._super(...arguments);
@@ -154,7 +153,7 @@ export default Component.extend({
     return '';
   }),
 
-  upgradeAvailable: computed('controlPlaneVersion', 'mode', 'model.version', 'originalClusterVersion', 'showNodeUpgradePreventionReason', function() {
+  upgradeAvailable: computed('controlPlaneVersion', 'mode', 'model.version', 'originalClusterVersion', function() {
     const originalClusterVersion = get(this, 'originalClusterVersion');
     const clusterVersion         = get(this, 'controlPlaneVersion');
     const nodeVersion            = get(this, 'model.version');
@@ -167,14 +166,8 @@ export default Component.extend({
     if (mode === 'edit') {
       // we must upgrade the cluster first
       if (originalClusterVersion !== clusterVersion) {
-        set(this, 'showNodeUpgradePreventionReason', true);
-
         return false;
       }
-    }
-
-    if (diff === 0 && get(this, 'showNodeUpgradePreventionReason')) {
-      set(this, 'showNodeUpgradePreventionReason', false);
     }
 
     return diff === 1;

--- a/lib/shared/addon/components/gke-node-pool-row/template.hbs
+++ b/lib/shared/addon/components/gke-node-pool-row/template.hbs
@@ -42,11 +42,6 @@
       {{else}}
         <div>
           {{model.version}}
-          {{#if showNodeUpgradePreventionReason}}
-            <div class="help-block">
-              {{t "nodeGroupRow.version.warning"}}
-            </div>
-          {{/if}}
         </div>
       {{/if}}
     </div>


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This was my bad, I accidentally left the edit syncing out because I had so much trouble getting clusters launched when I was working on it. Added in the sync, which is slightly different then EKS where we loop over the config keys and grab items off the upstreamspec. But for GKE the config doesn't always contain all the keys (not values) of the upstream spec so we miss some data when looping over it. This loops over the keys on the upstream spec and writes them to the config to sync. 
Change an accidental ref from nodeGroup to nodePool
Adds logic to move to the correct step automatically after user selects cloud credentials on the edit flow.
Changes the default location type to zonal instead of regional.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#32059
rancher/rancher#32060
rancher/rancher#32068
rancher/rancher#32098
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
