### PR TITLE
[2.5] fix base64 encode

### DIFF
--- a/lib/shared/addon/oauth/service.js
+++ b/lib/shared/addon/oauth/service.js
@@ -42,10 +42,9 @@ export default Service.extend({
     const m = {
       '+': '-',
       '/': '_',
-      '=': ''
     }
 
-    return AWS.util.base64.encode(state).replace(/[+/]|=+$/g, (char) => m[char])
+    return AWS.util.base64.encode(state).replace(/[+/]|=+$/g, (char) => m[char] || '')
   },
 
   decodeState(state){


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/2116 - this issue is not visible in Ember but this url-safe base64 code is the same, so same flaw exists; when `char = '==' m[char] = undefined` and the returned string isn't valid base64
related dashboard pr: https://github.com/rancher/dashboard/pull/2692