### PR TITLE
Updating the principal logicalType to account for okta

### DIFF
--- a/app/models/principal.js
+++ b/app/models/principal.js
@@ -52,6 +52,7 @@ var Principal = Resource.extend({
     case C.PROJECT.TYPE_PING_USER:
     case C.PROJECT.TYPE_RANCHER:
     case C.PROJECT.TYPE_SHIBBOLETH_USER:
+    case C.PROJECT.TYPE_OKTA_USER:
     default:
       return C.PROJECT.PERSON;
     case C.PROJECT.TYPE_GITHUB_TEAM:
@@ -67,6 +68,7 @@ var Principal = Resource.extend({
     case C.PROJECT.TYPE_PING_GROUP:
     case C.PROJECT.TYPE_SHIBBOLETH_GROUP:
     case C.PROJECT.TYPE_GOOGLE_GROUP:
+    case C.PROJECT.TYPE_OKTA_GROUP:
       return C.PROJECT.ORG;
     }
   }),


### PR DESCRIPTION
Proposed changes
======
Updating the principal logicalType to account for okta

This will allow the group principals to be displays on the project members section.

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#30401

![image](https://user-images.githubusercontent.com/55104481/114946680-7da3af80-9e00-11eb-9f76-ee5d5e6f7a3d.png)



