### PR TITLE
Add support for Embedding in the Dashboard UI

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -11,10 +11,24 @@ export default class App extends Application {
   Resolver = Resolver;
 
   ready = function() {
-    // Notify outer window that the app has loaded when we are embedded
     const isEmbedded = window.top !== window;
 
     if (isEmbedded) {
+      // Add a class 'hide-when-embedded' which can be used to hide elements
+      // that we don't want to show up when embedded
+      const head = document.getElementsByTagName('head')[0];
+      const styl = document.createElement('style');
+      const css = '.hide-when-embedded { display: none; }';
+
+      styl.setAttribute('type', 'text/css');
+      if (styl.styleSheet) {
+        styl.styleSheet.cssText = css;
+      } else {
+        styl.appendChild(document.createTextNode(css));
+      }
+      head.appendChild(styl);
+
+      // Notify outer window that the app has loaded when we are embedded
       window.top.postMessage({ action: 'ready' });
     }
   };

--- a/app/app.js
+++ b/app/app.js
@@ -10,6 +10,15 @@ export default class App extends Application {
 
   Resolver = Resolver;
 
+  ready = function() {
+    // Notify outer window that the app has loaded when we are embedded
+    const isEmbedded = window.top !== window;
+
+    if (isEmbedded) {
+      window.top.postMessage({ action: 'ready' });
+    }
+  };
+
   engines = {
     login: {
       dependencies: {

--- a/app/application/route.js
+++ b/app/application/route.js
@@ -1,8 +1,8 @@
+import { get, observer, set } from '@ember/object';
+import Route from '@ember/routing/route';
 import { cancel, next, schedule } from '@ember/runloop';
 import { inject as service } from '@ember/service';
-import Route from '@ember/routing/route';
 import C from 'ui/utils/constants';
-import { get, set, observer } from '@ember/object';
 
 export default Route.extend({
   access:   service(),
@@ -60,10 +60,12 @@ export default Route.extend({
 
       cancel(get(this, 'hideTimer'));
 
+      // console.log('Loading', id);
       this.notifyAction('need-to-load');
 
       if ( !get(this, 'loadingShown') ) {
         set(this, 'loadingShown', true);
+        // console.log('Loading Show', id);
         this.notifyLoading(true);
 
         schedule('afterRender', () => {

--- a/app/authenticated/controller.js
+++ b/app/authenticated/controller.js
@@ -31,6 +31,13 @@ export default Controller.extend({
       if ( bg ) {
         $('BODY').css('background', bg); // eslint-disable-line
       }
+
+      // Add class to hide Page Header and Footer when embedded
+      const embedded = window.top !== window;
+
+      if (embedded) {
+        $('BODY').addClass('embedded'); // eslint-disable-line
+      }
     });
   }),
 

--- a/app/initializers/route-spy.js
+++ b/app/initializers/route-spy.js
@@ -13,9 +13,12 @@ export function initialize() {
       }.on('didTransition'),
 
       willTranstionNotify: function(transition) {
+        const router = window.ls('router');
+
         window.top.postMessage({
           action: 'before-navigation',
-          target: transition.targetName
+          target: transition.targetName,
+          url:    router.urlFor(transition.targetName)
         })
       }.on('willTransition')
     });

--- a/app/initializers/route-spy.js
+++ b/app/initializers/route-spy.js
@@ -1,0 +1,49 @@
+import Router from '@ember/routing/router';
+
+export function initialize(application) {
+  const isEmbedded = window !== window.top;
+
+  if (isEmbedded) {
+    Router.reopen({
+      notifyTopFrame: function() {
+        window.top.postMessage({
+          action: 'did-transition',
+          url:    this.currentURL
+        })
+      }.on('didTransition'),
+
+      willTranstionNotify: function(transition) {
+        window.top.postMessage({
+          action: 'before-navigation',
+          target: transition.targetName
+        })
+      }.on('willTransition')
+    });
+
+    // Add listener for post messages to change the route in the application
+    window.addEventListener('message', (event) => {
+      const msg = event.data || {};
+
+      // Navigate when asked to
+      if (msg.action === 'navigate') {
+        const router = window.ls('router');
+
+        // If the route being asked for is already loaded, then
+        if (router.currentRouteName === msg.name) {
+          window.top.postMessage({
+            action: 'did-transition',
+            url:    router.urlFor(msg.name)
+          })
+        }
+
+        router.transitionTo(msg.name);
+      }
+    });
+  }
+}
+
+export default {
+  name: 'route-spy',
+  initialize,
+
+};

--- a/app/initializers/route-spy.js
+++ b/app/initializers/route-spy.js
@@ -40,6 +40,12 @@ export function initialize() {
         }
 
         router.transitionTo(msg.name);
+      } else if (msg.action == 'set-theme') {
+        const userTheme = window.ls('userTheme');
+
+        if (userTheme) {
+          userTheme.setTheme( msg.name, false);
+        }
       }
     });
   }

--- a/app/initializers/route-spy.js
+++ b/app/initializers/route-spy.js
@@ -14,11 +14,18 @@ export function initialize() {
 
       willTranstionNotify: function(transition) {
         const router = window.ls('router');
+        let url;
+
+        if (transition.targetName && transition.to) {
+          try {
+            url = router.urlFor(transition.targetName, transition.to.params );
+          } catch (e) {}
+        }
 
         window.top.postMessage({
           action: 'before-navigation',
           target: transition.targetName,
-          url:    router.urlFor(transition.targetName)
+          url
         })
       }.on('willTransition')
     });
@@ -31,7 +38,7 @@ export function initialize() {
       if (msg.action === 'navigate') {
         const router = window.ls('router');
 
-        // If the route being asked for is already loaded, then
+        // If the route being asked for is already loaded, send a did-transition event
         if (router.currentRouteName === msg.name) {
           window.top.postMessage({
             action: 'did-transition',

--- a/app/initializers/route-spy.js
+++ b/app/initializers/route-spy.js
@@ -1,6 +1,6 @@
 import Router from '@ember/routing/router';
 
-export function initialize(application) {
+export function initialize() {
   const isEmbedded = window !== window.top;
 
   if (isEmbedded) {

--- a/app/initializers/route-spy.js
+++ b/app/initializers/route-spy.js
@@ -40,7 +40,7 @@ export function initialize() {
         }
 
         router.transitionTo(msg.name);
-      } else if (msg.action == 'set-theme') {
+      } else if (msg.action === 'set-theme') {
         const userTheme = window.ls('userTheme');
 
         if (userTheme) {

--- a/app/styles/components/_page-header.scss
+++ b/app/styles/components/_page-header.scss
@@ -8,6 +8,14 @@ $nav-spacing: 3.5px;
 $project-nav-hover: $secondary !default;
 $project-nav-active: $dropdown-link-hover-bg !default;
 
+.embedded HEADER {
+  display: none;
+}
+
+.embedded FOOTER {
+  display: none;
+}
+
 .page-header {
   @include no-select;
   margin-bottom: 10px;

--- a/lib/global-admin/addon/security/cloud-credentials/index/template.hbs
+++ b/lib/global-admin/addon/security/cloud-credentials/index/template.hbs
@@ -2,7 +2,7 @@
   <div class="right-buttons">
     {{#link-to-external
        "nodes.node-templates"
-       classNames="btn btn-sm bg-primary"
+       classNames="btn btn-sm bg-primary hide-when-embedded"
     }}
       <i class="icon icon-gear"/>
       {{t "cloudCredentialsPage.rightButtons.nodeTemplates"}}

--- a/lib/nodes/addon/node-templates/template.hbs
+++ b/lib/nodes/addon/node-templates/template.hbs
@@ -2,7 +2,7 @@
   <div class="right-buttons">
     {{#link-to-external
        "global-admin.security.cloud-credentials"
-       classNames="btn btn-sm bg-primary"
+       classNames="btn btn-sm bg-primary hide-when-embedded"
     }}
       <i class="icon icon-gear"></i>
       {{t "nodeTemplatesPage.rightButtons.cloudCredentials"}}


### PR DESCRIPTION
This PR adds hooks into the Ember UI to enable it to be embedded into the Dashboard UI.

When embedded:

- Adds a class to the page to hide the header and footer
- Listens to route events and sends messages to the outer app
- Sends loading events during page load
- Adds a class 'hide-when-embedded' that can then be used to hide elements that should be hidden when embedded (e.g. certain buttons)
- Adds support for ensuring the theme is set the same as the outer UI
