### PR TITLE
Now we always show the command for custom import clusters

### DIFF
--- a/lib/shared/addon/components/cru-cluster/component.js
+++ b/lib/shared/addon/components/cru-cluster/component.js
@@ -303,12 +303,14 @@ export default Component.extend(ViewNewEdit, ChildHook, {
         name:     'import',
         driver:   'import',
         preSave:  true,
+        postSave: true
       });
 
       out.push({
         name:     'imported',
         driver:   'import',
         preSave:  true,
+        postSave: true
       });
 
       out.push({


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
We would spuriously skip the command step because we skipped post save and occasionally the cluster would have its state set to active which is an indication to skip the command.



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/rancher#32242
