### PR TITLE
[2.5.x] GKE Imported Cluster warning

### DIFF
--- a/lib/shared/addon/components/gke-node-pool-row/component.js
+++ b/lib/shared/addon/components/gke-node-pool-row/component.js
@@ -28,12 +28,11 @@ export default Component.extend({
   nodeVersions:          null,
   controlPlaneVersion:   null,
   upgradeVersion:        false,
-  showManagementWarning: false,
 
   init() {
     this._super(...arguments);
 
-    const { nodePool, originalCluster } = this;
+    const { nodePool } = this;
 
     setProperties(this, {
       scopeConfig:            {},
@@ -54,12 +53,6 @@ export default Component.extend({
 
       if (isEmpty(this?.nodePool?.version) && !isEmpty(this?.cluster?.gkeConfig?.kubernetesVersion)) {
         set(this, 'nodePool.version', this?.cluster?.gkeConfig?.kubernetesVersion);
-      }
-
-      const isClusterImported = !isEmpty(originalCluster) && originalCluster?.gkeStatus?.upstreamSpec?.imported;
-
-      if (isClusterImported && !nodePool?.management?.autoRepair && !nodePool?.management?.autoUpgrade) {
-        set(this, 'showManagementWarning', true);
       }
     } else {
       setProperties(this, {
@@ -129,6 +122,18 @@ export default Component.extend({
 
     set(this.nodePool.config, 'oauthScopes', this.google.mapOauthScopes(this.oauthScopesSelection, this.scopeConfig));
   })),
+
+  showManagementWarning: computed('originalCluster.gkeStatus.upstreamSpec.imported', 'nodePool.management.{autoUpgrade,autoRepair}', function() {
+    const { nodePool, originalCluster } = this;
+
+    const isClusterImported = !isEmpty(originalCluster) && originalCluster?.gkeStatus?.upstreamSpec?.imported;
+
+    if (isClusterImported && ( !nodePool?.management?.autoRepair || !nodePool?.management?.autoUpgrade )) {
+      return true;
+    }
+
+    return false;
+  }),
 
   originalClusterVersion: computed('originalCluster.gkeConfig.kubernetesVersion', 'originalCluster.gkeStatus.upstreamSpec.kubernetesVersion', function() {
     if (!isEmpty(get(this, 'originalCluster.gkeConfig.kubernetesVersion'))) {

--- a/lib/shared/addon/components/gke-node-pool-row/component.js
+++ b/lib/shared/addon/components/gke-node-pool-row/component.js
@@ -16,22 +16,24 @@ export default Component.extend({
   serviceVersions: service('version-choices'),
   layout,
 
-  cluster:              null,
-  nodePool:             null,
-  nodeAdvanced:         false,
-  oauthScopesSelection: null,
-  scopeConfig:          null,
-  diskTypeContent:      null,
-  imageTypeContent:     null,
-  machineTypes:         null,
-  nodeVersions:         null,
-  controlPlaneVersion:  null,
-  upgradeVersion:       false,
+  cluster:               null,
+  originalCluster:       null,
+  nodePool:              null,
+  nodeAdvanced:          false,
+  oauthScopesSelection:  null,
+  scopeConfig:           null,
+  diskTypeContent:       null,
+  imageTypeContent:      null,
+  machineTypes:          null,
+  nodeVersions:          null,
+  controlPlaneVersion:   null,
+  upgradeVersion:        false,
+  showManagementWarning: false,
 
   init() {
     this._super(...arguments);
 
-    const { nodePool } = this;
+    const { nodePool, originalCluster } = this;
 
     setProperties(this, {
       scopeConfig:            {},
@@ -52,6 +54,12 @@ export default Component.extend({
 
       if (isEmpty(this?.nodePool?.version) && !isEmpty(this?.cluster?.gkeConfig?.kubernetesVersion)) {
         set(this, 'nodePool.version', this?.cluster?.gkeConfig?.kubernetesVersion);
+      }
+
+      const isClusterImported = !isEmpty(originalCluster) && originalCluster?.gkeStatus?.upstreamSpec?.imported;
+
+      if (isClusterImported && !nodePool?.management?.autoRepair && !nodePool?.management?.autoUpgrade) {
+        set(this, 'showManagementWarning', true);
       }
     } else {
       setProperties(this, {

--- a/lib/shared/addon/components/gke-node-pool-row/template.hbs
+++ b/lib/shared/addon/components/gke-node-pool-row/template.hbs
@@ -144,7 +144,10 @@
         </div>
       </div>
     </div>
-    <FormGkeTaints @taints={{nodePool.config.taints}} @editable={{isNewNodePool}} />
+    <FormGkeTaints
+      @taints={{nodePool.config.taints}}
+      @editable={{isNewNodePool}}
+    />
     <div class="row mt-20">
       <div class="col span-12 mb-0">
         <label class="acc-label">
@@ -201,14 +204,24 @@
         />
       </div>
     </div>
+    {{#if showManagementWarning}}
+      <div class="row">
+        <div class="col span-12">
+          <BannerMessage
+            @icon="icon-alert"
+            @color="bg-warning mb-10"
+            @message={{t "clusterNew.googlegke.autoRepairUpgradeWarning.label"}}
+          />
+        </div>
+      </div>
+    {{/if}}
     <div class="row">
       <div class="col span-6 mt-25">
         <div class="form-control-static">
           <div class="checkbox">
             <label>
               {{input type="checkbox" checked=nodePool.autoscaling.enabled}}
-              {{t "clusterNew.googlegke.autoscaling.label"
-              }}
+              {{t "clusterNew.googlegke.autoscaling.label"}}
             </label>
           </div>
         </div>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3658,6 +3658,8 @@ clusterNew:
     alphaFeatures:
       label: Alpha Features
       warning: Warning! <a href="https://cloud.google.com/kubernetes-engine/docs/concepts/alpha-clusters" target="_blank" rel="nofollow noopener noreferrer">Kubernetes Alpha Features</a> should not be used for production clusters. Alpha Clusters expire after 30 days along with other caveats. Ensure you fully understand this feature before enabling it.
+    autoRepairUpgradeWarning:
+      label: When editing an Imported cluster, we recommend that you enable Auto Upgrade and Auto Repair for node pools. These fields are required for clusters launched from the Release channel and recommended otherwise. If these fields are not enabled, you may not be able to recover this node pool.
     autoscaling:
       label: Autoscaling
     bigQuery:


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Add warning for imported clusters when the node pool does not contain the autoUpgrade and autoRepair management fields in a disabled state. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#32282
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
N/A
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
