### PR TITLE
[2.5.x] GKE V2 Remove Required from Subnetwork Name

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-gke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/component.js
@@ -420,12 +420,26 @@ export default Component.extend(ClusterDriver, {
         'config.ipAllocationPolicy.clusterSecondaryRangeName':  null,
         'config.ipAllocationPolicy.servicesSecondaryRangeName': null,
       });
+
+      if (this.disableNamelessSecondaryRanges) {
+        set(this, 'disableNamelessSecondaryRanges', false);
+      }
     } else {
       setProperties(this, {
         'config.ipAllocationPolicy.createSubnetwork':  false,
         'config.ipAllocationPolicy.subnetworkName':    null,
         'config.ipAllocationPolicy.nodeIpv4CidrBlock': null,
       });
+
+      const { sharedSubnets } = this;
+
+      const match = (sharedSubnets || []).findBy('subnetwork', subnetwork);
+
+      if (!isEmpty(match)) {
+        if (this.disableNamelessSecondaryRanges) {
+          set(this, 'disableNamelessSecondaryRanges', false);
+        }
+      }
     }
   }),
 

--- a/lib/shared/addon/components/cluster-driver/driver-gke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/template.hbs
@@ -285,31 +285,11 @@
                   }}
                 </InputOrDisplay>
               </div>
-              <div class="col span-6">
-                <label class="acc-label">
-                  {{t
-                    "clusterNew.googlegke.ipAllocationPolicy.clusterIpv4CidrBlock.accesslabel"
-                  }}
-                </label>
-                <InputOrDisplay
-                  @editable={{isNew}}
-                  @value={{config.ipAllocationPolicy.clusterIpv4CidrBlock}}
-                >
-                  <InputCidr
-                    @disabled={{not config.ipAllocationPolicy.useIpAliases}}
-                    @placeholder={{t
-                      "clusterNew.googlegke.ipAllocationPolicy.clusterIpv4CidrBlock.placeholder"
-                    }}
-                    @value={{mut config.ipAllocationPolicy.clusterIpv4CidrBlock
-                    }}
-                  />
-                </InputOrDisplay>
-              </div>
             {{else}}
               <div class="col span-6">
                 <label class="acc-label">
                   {{t
-                    "clusterNew.googlegke.ipAllocationPolicy.clusterSecondaryRangeName.label"
+                    "clusterNew.googlegke.ipPolicyClusterSecondaryRangeName.label"
                   }}
                 </label>
                 <InputOrDisplay
@@ -328,6 +308,25 @@
                 </InputOrDisplay>
               </div>
             {{/if}}
+            <div class="col span-6">
+              <label class="acc-label">
+                {{t
+                  "clusterNew.googlegke.ipAllocationPolicy.clusterIpv4CidrBlock.accesslabel"
+                }}
+              </label>
+              <InputOrDisplay
+                @editable={{and isNew (not config.ipAllocationPolicy.clusterSecondaryRangeName)}}
+                @value={{config.ipAllocationPolicy.clusterIpv4CidrBlock}}
+              >
+                <InputCidr
+                  @disabled={{and (not config.ipAllocationPolicy.useIpAliases ) (not disableNamelessSecondaryRanges)}}
+                  @placeholder={{t
+                    "clusterNew.googlegke.ipAllocationPolicy.clusterIpv4CidrBlock.placeholder"
+                  }}
+                  @value={{mut config.ipAllocationPolicy.clusterIpv4CidrBlock}}
+                />
+              </InputOrDisplay>
+            </div>
           </div>
           <div class="row">
             {{#if config.ipAllocationPolicy.createSubnetwork}}
@@ -348,30 +347,11 @@
                   />
                 </InputOrDisplay>
               </div>
-              <div class="col span-6">
-                <label class="acc-label">
-                  {{t "clusterNew.googlegke.ipPolicyServicesIpv4CidrBlock.label"
-                  }}
-                </label>
-                <InputOrDisplay
-                  @editable={{isNew}}
-                  @value={{config.ipAllocationPolicy.servicesIpv4CidrBlock}}
-                >
-                  <InputCidr
-                    @disabled={{not config.ipAllocationPolicy.useIpAliases}}
-                    @placeholder={{t
-                      "clusterNew.googlegke.ipPolicyServicesIpv4CidrBlock.placeholder"
-                    }}
-                    @value={{mut config.ipAllocationPolicy.servicesIpv4CidrBlock
-                    }}
-                  />
-                </InputOrDisplay>
-              </div>
             {{else}}
               <div class="col span-6">
                 <label class="acc-label">
                   {{t
-                    "clusterNew.googlegke.ipAllocationPolicy.servicesSecondaryRangeName.label"
+                    "clusterNew.googlegke.ipPolicyServicesSecondaryRangeName.label"
                   }}
                 </label>
                 <InputOrDisplay
@@ -391,6 +371,23 @@
                 </InputOrDisplay>
               </div>
             {{/if}}
+            <div class="col span-6">
+              <label class="acc-label">
+                {{t "clusterNew.googlegke.ipPolicyServicesIpv4CidrBlock.label"}}
+              </label>
+              <InputOrDisplay
+                @editable={{and isNew (not config.ipAllocationPolicy.servicesSecondaryRangeName)}}
+                @value={{config.ipAllocationPolicy.servicesIpv4CidrBlock}}
+              >
+                <InputCidr
+                  @disabled={{and (not config.ipAllocationPolicy.useIpAliases ) (not disableNamelessSecondaryRanges)}}
+                  @placeholder={{t
+                    "clusterNew.googlegke.ipPolicyServicesIpv4CidrBlock.placeholder"
+                  }}
+                  @value={{mut config.ipAllocationPolicy.servicesIpv4CidrBlock}}
+                />
+              </InputOrDisplay>
+            </div>
           </div>
         </section>
         <AdvancedSection @advanced={{clusterAdvanced}}>

--- a/lib/shared/addon/components/cluster-driver/driver-gke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/template.hbs
@@ -270,7 +270,6 @@
               <div class="col span-6">
                 <label class="acc-label">
                   {{t "clusterNew.googlegke.ipPolicySubnetworkName.label"}}
-                  <FieldRequired />
                 </label>
                 <InputOrDisplay
                   @editable={{isNew}}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The field is not actually required. GKE will make up its own if not included.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#32351
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
Fixes a change that hide the cluster and service ranges from auto created subnetworks, when in fact it should only be disabled if a range name for either has been selected OR  a shared subnetwork has been selected. 
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
