### PR TITLE
Add support for private control-plane and speicying network params

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
@@ -51,7 +51,8 @@ export default Component.extend(ClusterDriver, {
         nodeImage:             '',
         vcn:                   '',
         securityListId:        '',
-        subnetAccess:          'public',
+        cpSubnetAccess:        'public',
+        npSubnetAccess:        'private',
         flexOcpus:             0,
         memory:                0,
         quantityPerSubnet:     1,
@@ -236,6 +237,11 @@ export default Component.extend(ClusterDriver, {
       } else {
         set(this, 'config.enablePrivateNodes', true);
       }
+      if (get(this, 'config.cpSubnetAccess') === 'public') {
+        set(this, 'config.enablePrivatControlPlane', false);
+      } else {
+        set(this, 'config.enablePrivatControlPlane', true);
+      }
 
       this.send('driverSave', cb);
     },
@@ -265,10 +271,15 @@ export default Component.extend(ClusterDriver, {
     label: e[1],
     value: e[0]
   })),
-  selectedSubnetAccess: computed('config.subnetAccess', function() {
-    const subnetAccess = get(this, 'config.subnetAccess');
+  selectedSubnetAccess: computed('config.npSubnetAccess', function() {
+    const subnetAccess = get(this, 'config.npSubnetAccess');
 
     return subnetAccess && subnetAccessMap[subnetAccess];
+  }),
+  selectedControlPlaneSubnetAccess: computed('config.cpSubnetAccess', function() {
+    const cpSubnetAccess = get(this, 'config.cpSubnetAccess');
+
+    return cpSubnetAccess && subnetAccessMap[cpSubnetAccess];
   }),
   canAuthenticate: computed('config.tenancyId', 'config.region', 'config.userOcid', 'config.fingerprint', 'config.privateKeyContents', function() {
     return get(this, 'config.tenancyId') && get(this, 'config.region') && get(this, 'config.userOcid') && get(this, 'config.fingerprint') && get(this, 'config.privateKeyContents') ? false : true;
@@ -277,7 +288,7 @@ export default Component.extend(ClusterDriver, {
     return !(get(this, 'config.compartmentId') && get(this, 'config.kubernetesVersion'));
   }),
 
-  canSaveVCN: computed('vcnCreationMode', 'config.vcnName', 'config.loadBalancerSubnetName1', 'config.loadBalancerSubnetName2', 'config.subnetAccess', 'config.vcnCidr', function() {
+  canSaveVCN: computed('vcnCreationMode', 'config.vcnName', 'config.loadBalancerSubnetName1', 'config.loadBalancerSubnetName2', 'config.npSubnetAccess', 'config.vcnCidr', function() {
     const mode = get(this, 'vcnCreationMode');
 
     if (mode === 'Quick') {
@@ -286,7 +297,7 @@ export default Component.extend(ClusterDriver, {
       // Driver will use the same compartment as the cluster if not set.
       return (get(this, 'config.vcnName') && get(this, 'config.loadBalancerSubnetName1')) ? false : true;
     } else if (mode === 'Custom') {
-      return (get(this, 'config.subnetAccess') && get(this, 'config.vcnCidr')) ? false : true;
+      return (get(this, 'config.npSubnetAccess') && get(this, 'config.vcnCidr')) ? false : true;
     }
 
     return true;
@@ -342,7 +353,15 @@ export default Component.extend(ClusterDriver, {
       if (get(this, 'config.vcnCompartmentId') === '') {
         set(this, 'config.vcnCompartmentId', get(this, 'config.compartmentId'));
       }
-      if (get(this, 'config.subnetAccess') === 'public') {
+      if (get(this, 'config.vcnName') !== '') {
+        set(this, 'config.skipVcnDelete', true);
+      }
+      if (get(this, 'config.cpSubnetAccess') === 'public') {
+        set(this, 'config.enablePrivatControlPlane', false);
+      } else {
+        set(this, 'config.enablePrivatControlPlane', true);
+      }
+      if (get(this, 'config.npSubnetAccess') === 'public') {
         set(this, 'config.enablePrivateNodes', false);
       } else {
         set(this, 'config.enablePrivateNodes', true);

--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/template.hbs
@@ -139,7 +139,7 @@
             {{t 'clusterNew.oracleoke.quantityPerSubnet.label'}}
           </label>
           {{#input-or-display editable=(or (eq mode "new") eq mode "editing") value=config.quantityPerSubnet}}
-            {{input-integer min=1 max=maxNodeCount value=config.quantityPerSubnet classNames="form-control" placeholder=(t 'clusterNew.oracleoke.quantityPerSubnet.placeholder')}}
+            {{input-integer min=0 max=maxNodeCount value=config.quantityPerSubnet classNames="form-control" placeholder=(t 'clusterNew.oracleoke.quantityPerSubnet.placeholder')}}
             <p class="help-block">
               {{t 'clusterNew.oracleoke.quantityPerSubnet.help'}}
             </p>
@@ -191,7 +191,7 @@
               {{t 'clusterNew.oracleoke.quantityPerSubnet.label'}}
             </label>
             {{#input-or-display editable=(and (eq step 2) isNew) value=config.quantityPerSubnet}}
-              {{input-integer min=1 max=maxNodeCount value=config.quantityPerSubnet classNames="form-control" placeholder=(t 'clusterNew.oracleoke.quantityPerSubnet.placeholder')}}
+              {{input-integer min=0 max=maxNodeCount value=config.quantityPerSubnet classNames="form-control" placeholder=(t 'clusterNew.oracleoke.quantityPerSubnet.placeholder')}}
               <p class="help-block">
                 {{t 'clusterNew.oracleoke.quantityPerSubnet.help'}}
               </p>
@@ -272,19 +272,46 @@
               {{#if (eq vcnCreationMode "Custom")}}
                 <div class="row">
                   <div class="col span-6">
+                    <label class="acc-label">{{t 'clusterNew.oracleoke.controlPlaneSubnet.label'}}{{field-required}}</label>
+                    {{#input-or-display editable=(and (eq step 3) isNew) value=selectedSubnetAccess}}
+                      {{searchable-select class="form-control"
+                                          content=subnetAccessChoices
+                                          value=config.cpSubnetAccess
+                      }}
+                    {{/input-or-display}}
+                  </div>
+                  <div class="col span-6">
                     <label class="acc-label">{{t 'clusterNew.oracleoke.subnet.label'}}{{field-required}}</label>
                     {{#input-or-display editable=(and (eq step 3) isNew) value=selectedSubnetAccess}}
                       {{searchable-select class="form-control"
                                           content=subnetAccessChoices
-                                          value=config.subnetAccess
+                                          value=config.npSubnetAccess
                       }}
                     {{/input-or-display}}
                   </div>
-
+                </div>
+                <div class="row">
+                  <div class="col span-12">
+                    {{#if (and (not-eq config.cpSubnetAccess "public") (eq step 3))}}
+                      {{banner-message
+                              icon="icon-alert"
+                              color="bg-warning mb-10"
+                              message=(t "clusterNew.oracleoke.controlPlaneSubnet.warning")
+                      }}
+                    {{/if}}
+                  </div>
+                </div>
+                <div class="row">
                   <div class="col span-6">
-                    <label class="acc-label">{{t 'clusterNew.oracleoke.cidr.label'}}</label>
-                    {{#input-or-display editable=(and (eq step 3) isNew) value=config.vcnCidr}}
-                      {{input type="text" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.cidr.placeholder') value=config.vcnCidr}}
+                    <label class="acc-label">{{t 'clusterNew.oracleoke.podCidr.label'}}</label>
+                    {{#input-or-display editable=(and (eq step 3) isNew) value=config.podCidr}}
+                      {{input type="text" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.podCidr.placeholder') value=config.podCidr}}
+                    {{/input-or-display}}
+                  </div>
+                  <div class="col span-6">
+                    <label class="acc-label">{{t 'clusterNew.oracleoke.serviceCidr.label'}}</label>
+                    {{#input-or-display editable=(and (eq step 3) isNew) value=config.serviceCidr}}
+                      {{input type="text" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.serviceCidr.placeholder') value=config.serviceCidr}}
                     {{/input-or-display}}
                   </div>
                 </div>
@@ -306,6 +333,22 @@
                       {{input type="text" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.existingVCNDetails.vcnNamePlaceholder') value=config.vcnName}}
                     {{/input-or-display}}
                   </div>
+                </div>
+                <div class="row">
+                  <div class="col span-6">
+                    <label class="acc-label">{{t 'clusterNew.oracleoke.existingVCNDetails.controlPlaneSubnetName'}}{{field-required}}</label>
+                    {{#input-or-display editable=(and (eq step 3) isNew) value=config.controlPlaneSubnetName}}
+                      {{input type="text" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.existingVCNDetails.controlPlaneSubnetNamePlaceholder') value=config.controlPlaneSubnetName}}
+                    {{/input-or-display}}
+                  </div>
+
+                  <div class="col span-6">
+                    <label class="acc-label">{{t 'clusterNew.oracleoke.existingVCNDetails.nodePoolPlaneSubnetName'}}</label>
+                    {{#input-or-display editable=(and (eq step 3) isNew) value=config.nodePoolSubnetName}}
+                      {{input type="text" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.existingVCNDetails.nodePoolSubnetNamePlaceholder') value=config.nodePoolSubnetName}}
+                    {{/input-or-display}}
+                  </div>
+
                 </div>
                 <div class="row">
                   <div class="col span-6">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4220,6 +4220,16 @@ clusterNew:
       label: Virtual Cloud Network CIDR
       placeholder: e.g. 172.16.0.0/16
       required: Virtual Cloud Network CIDR is required
+    podCidr:
+      error: Virtual Cloud CIDR format error
+      label: Kubernetes Pod CIDR block
+      placeholder: e.g. 10.244.0.0/16
+      required: Kubernetes Pod CIDR block is required
+    serviceCidr:
+      error: Virtual Cloud CIDR format error
+      label: Kubernetes Service CIDR block
+      placeholder: e.g. 10.96.0.0/16
+      required: Kubernetes Service CIDR block is required
     cluster:
       detail: Choose the Kubernetes version, the number of nodes, and the target compartment for the cluster.
       loading: Loading VCNs from Oracle Cloud Infrastructure
@@ -4234,10 +4244,14 @@ clusterNew:
       compartmentOCID: OCID of the VCN's compartment
       compartmentOCIDHelp: leave blank if it's the cluster compartment
       compartmentOCIDPlaceholder: e.g. ocid1.compartment.oc1..aaaaaaaa...
-      lbSubnetName1: Name of first pre-existing LB subnet
-      lbSubnetName1Placeholder: e.g. my-lb-sub-1
+      lbSubnetName1: Name of pre-existing LB subnet
+      lbSubnetName1Placeholder: e.g. svc-sub-1
       lbSubnetName2: Name of second pre-existing LB subnet (if applicable)
-      lbSubnetName2Placeholder: e.g. my-lb-sub-2
+      lbSubnetName2Placeholder: e.g. svc-sub-2
+      nodePoolPlaneSubnetName: Name of pre-existing node-pool subnet
+      nodePoolSubnetNamePlaceholder: e.g. nodepool-sub
+      controlPlaneSubnetName: Name of pre-existing control plane subnet
+      controlPlaneSubnetNamePlaceholder: e.g. k8sendpoint-sub
       vcnName: Name of the pre-existing VCN
       vcnNamePlaceholder: e.g. my-vcn
     flexShapeConfig:
@@ -4290,8 +4304,12 @@ clusterNew:
     storageType:
       label: Default Persistent Volume Disk Type
     subnet:
-      label: Subnet Access
-      required: Subnet access is required
+      label: Node-pool Subnet Access
+      required: Node-pool subnet access is required
+    controlPlaneSubnet:
+      label: Control plane Subnet Access
+      required: Control plane subnet access is required
+      warning: Rancher needs to be able to access the Kubernetes API on a private IP for this option to be successful. Typically, this requires VCN peering or running Rancher in the same VCN that hosts the (existing) control plane subnet.
     subnetAccessOptions:
       custom: Custom Create
       existing: Existing


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

This PR adds support for opting for a private control-plane and setting custom pod and service CIDRs and node subnet names when configuring the custom VPC/VCN settings.  

The OKE kontainer cluster driver itself is backwards compatible if these new parameters are not specified.

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

New feature.

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-->



Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 
**Depends on:**
- https://github.com/rancher/rancher/pull/32658

Other tracking issue:
- https://github.com/rancher-plugins/kontainer-engine-driver-oke/issues/26
- https://github.com/rancher-plugins/kontainer-engine-driver-oke/issues/30

Further comments
======



<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->


**OKE cluster driver allowing for setting custom CIDRs and a private control plane. Note warning if a private control plane is selected:**
![Screen Shot 2021-05-07 at 5 11 21 PM](https://user-images.githubusercontent.com/13613687/117519302-e261ae00-af57-11eb-9222-b7ffd2c421c3.png)

![Screen Shot 2021-05-07 at 5 11 31 PM](https://user-images.githubusercontent.com/13613687/117519298-dd9cfa00-af57-11eb-8cc6-62c209ac17dc.png)




**OKE cluster driver asking for user to specify the control-plane and node-pool subets in the existing VPC/VCN use-case:**

![Screen Shot 2021-05-10 at 12 26 39 PM](https://user-images.githubusercontent.com/13613687/117713984-2be60f00-b18b-11eb-96c5-28d8d03ddd80.png)



