### PR TITLE
Fixing how the frontend handles the bracket annotation when building cluster answers

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -1014,7 +1014,11 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
     if (questions && questions.length) {
       questions.forEach((quest) => {
-        let match = get(cluster, quest.variable);
+        // ember.object.get doesn't support bracket notation, this provides support for the notation by replace some[0].object with some.0.object
+        // which ember does support. I'm putting this here instead of replacing the answer variables because I think it's more intuitive to specify
+        // variables with the bracket notation.
+        const varaible = quest.variable.replaceAll('[', '.').replaceAll(']', '');
+        let match = get(cluster, varaible);
 
         if (match) {
           answers[quest.variable] = match;


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The front end wasn't sending answers to the backend when a user set the the
privateRegistries field when using an RKE template which allowed the field to
be overriden. This was happening because we weren't handling the bracket
notation properly.


Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
Front End issue: https://github.com/rancher/dashboard/issues/3940
Back End Issue: https://github.com/rancher/rancher/issues/27166


Before the fix
======
![private-registry-broken](https://user-images.githubusercontent.com/55104481/150210486-a7271498-4956-48b8-991a-f4110589c95f.gif)

After the fix
======
![private-registry-after](https://user-images.githubusercontent.com/55104481/150210508-56c43071-958a-44a4-94ac-b6a84cc592f8.gif)

