### PR TITLE
[1.6] Adding c6* AWS instance types

### DIFF
--- a/app/components/machine/driver-amazonec2/component.js
+++ b/app/components/machine/driver-amazonec2/component.js
@@ -282,6 +282,76 @@ let INSTANCE_TYPES = [
     group: 'M3 - General Purpose',
     name:  'm3.2xlarge'
   },
+  
+  {
+    group: 'C6g - High CPU',
+    name:  'c6g.medium'
+  },
+  {
+    group: 'C6g - High CPU',
+    name:  'c6g.large'
+  },
+  {
+    group: 'C6g - High CPU',
+    name:  'c6g.xlarge'
+  },
+  {
+    group: 'C6g - High CPU',
+    name:  'c6g.2xlarge'
+  },
+  {
+    group: 'C6g - High CPU',
+    name:  'c6g.4xlarge'
+  },
+  {
+    group: 'C6g - High CPU',
+    name:  'c6g.8xlarge'
+  },
+  {
+    group: 'C6g - High CPU',
+    name:  'c6g.12xlarge'
+  },
+  {
+    group: 'C6g - High CPU',
+    name:  'c6g.16xlarge'
+  },
+  {
+    group: 'C6g - High CPU',
+    name:  'c6g.metal'
+  },
+  
+  {
+    group: 'C6gn - High CPU',
+    name:  'c6gn.medium'
+  },
+  {
+    group: 'C6gn - High CPU',
+    name:  'c6gn.large'
+  },
+  {
+    group: 'C6gn - High CPU',
+    name:  'c6gn.xlarge'
+  },
+  {
+    group: 'C6gn - High CPU',
+    name:  'c6gn.2xlarge'
+  },
+  {
+    group: 'C6gn - High CPU',
+    name:  'c6gn.4xlarge'
+  },
+  {
+    group: 'C6gn - High CPU',
+    name:  'c6gn.8xlarge'
+  },
+  {
+    group: 'C6gn - High CPU',
+    name:  'c6gn.12xlarge'
+  },
+  {
+    group: 'C6gn - High CPU',
+    name:  'c6gn.16xlarge'
+  },
 
   {
     group: 'C5 - High CPU',


### PR DESCRIPTION
Proposed changes
======
Adds AWS C6* instance types to the in-app UI.

Types of changes
======
New feature (non-breaking change which adds functionality)

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======

AWS `c6` instance types are the newest generation of high CPU instances in AWS.  More details [here](https://aws.amazon.com/ec2/instance-types/c6/).