### PR TITLE
GKE V2 Expose zones for a regional cluster

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-gke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/component.js
@@ -310,11 +310,18 @@ export default Component.extend(ClusterDriver, {
     if (locationType === 'regional') {
       setProperties(this, {
         'config.zone':      null,
-        'config.locations': [],
+        'config.locations': ['us-central1-c'],
+        'config.region':    'us-central1'
       });
     } else {
-      set(this, 'config.region', null);
+      setProperties(this, {
+        'config.region':    null,
+        'config.zone':      'us-central1-c',
+        'config.locations': [],
+      });
     }
+
+    this.send('loadZones');
   }),
 
   clusterSecondaryRangeNameChanged: observer('config.ipAllocationPolicy.clusterSecondaryRangeName', 'secondaryIpRangeContent.[]', function() {
@@ -557,17 +564,20 @@ export default Component.extend(ClusterDriver, {
     return true;
   }),
 
-  locationContent: computed('config.zone', 'zoneChoices', function() {
-    const zone = get(this, 'config.zone')
+  locationContent: computed('config.{region,zone}', 'zoneChoices', 'regionChoices', function() {
+    const { region, zone } = this.config;
+    const { locationType, zoneChoices } = this;
+    let locationName = null;
 
-    if ( !zone ) {
-      return [];
+    if (locationType === 'zonal') {
+      const arr = zone.split('-')
+
+      locationName = `${ arr[0] }-${ arr[1] }`;
+    } else {
+      locationName = region;
     }
-    const arr = zone.split('-')
-    const locationName = `${ arr[0] }-${ arr[1] }`
-    const zoneChoices = get(this, 'zoneChoices')
 
-    return zoneChoices.filter((z) => (z.name || '').startsWith(locationName) && z.name !== zone)
+    return zoneChoices.filter((z) => (z.name || '').startsWith(locationName) && z.name !== zone);
   }),
 
   maintenanceWindowChoice: computed('maintenanceWindowTimes.[]', 'config.maintenanceWindow', function() {
@@ -789,14 +799,6 @@ export default Component.extend(ClusterDriver, {
 
     const config = get(this, 'config') || {}
 
-    const locationType = get(this, 'locationType');
-
-    if ( locationType === this.google.defaultZoneType ) {
-      set(config, 'region', null);
-    } else {
-      set(config, 'zone', null);
-    }
-
     if (get(this, 'config.useIpAliases')) {
       set(config, 'clusterIpv4Cidr', null);
     }
@@ -805,14 +807,25 @@ export default Component.extend(ClusterDriver, {
       delete config.masterAuthorizedNetworks.cidrBlocks
     }
 
+    const locationType = get(this, 'locationType');
+
+    if ( locationType === this.google.defaultZoneType ) {
+      set(config, 'region', null);
+    } else {
+      set(config, 'zone', null);
+    }
+
     const locationContent = get(this, 'locationContent')
     const locations = locationContent.filter((l) => l.checked).map((l) => l.name)
 
-    if (this.locationType === 'zonal') {
-      if (locations.length > 0) {
+    if (locations.length > 0) {
+      if (this.locationType === 'zonal') {
         locations.push(get(config, 'zone'))
-        set(config, 'locations', locations)
       }
+
+      set(config, 'locations', locations)
+    } else {
+      set(config, 'locations', []);
     }
 
     return this._super(...arguments);

--- a/lib/shared/addon/components/cluster-driver/driver-gke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/template.hbs
@@ -120,22 +120,9 @@
                 />
               </InputOrDisplay>
             </div>
-            <div class="col span-2">
-              <label class="acc-label">
-                {{t "clusterNew.googlegke.locations.label"}}
-              </label>
-              {{#each locationContent as |location|}}
-                <div class="checkbox">
-                  <label>
-                    {{input type="checkbox" checked=location.checked}}
-                    {{location.name}}
-                  </label>
-                </div>
-              {{/each}}
-            </div>
           {{/if}}
           {{#if (eq locationType "regional")}}
-            <div class="col span-6">
+            <div class="col span-4">
               <label class="acc-label">
                 {{t "clusterNew.googlegke.region.label"}}
               </label>
@@ -156,6 +143,19 @@
               </InputOrDisplay>
             </div>
           {{/if}}
+          <div class="col span-2">
+            <label class="acc-label">
+              {{t "clusterNew.googlegke.locations.label"}}
+            </label>
+            {{#each locationContent as |location|}}
+              <div class="checkbox">
+                <label>
+                  {{input type="checkbox" checked=location.checked}}
+                  {{location.name}}
+                </label>
+              </div>
+            {{/each}}
+          </div>
         </div>
         {{#if (eq step 2)}}
           <SaveCancel
@@ -591,6 +591,8 @@
         <div class="row">
           {{#each config.nodePools as |nodePool|}}
             <GkeNodePoolRow
+              @locationType={{locationType}}
+              @locationContent={{locationContent}}
               @originalCluster={{model.originalCluster}}
               @isNew={{isNewOrEditable}}
               @machineTypes={{machineTypes}}

--- a/lib/shared/addon/components/gke-node-pool-row/component.js
+++ b/lib/shared/addon/components/gke-node-pool-row/component.js
@@ -16,18 +16,18 @@ export default Component.extend({
   serviceVersions: service('version-choices'),
   layout,
 
-  cluster:               null,
-  originalCluster:       null,
-  nodePool:              null,
-  nodeAdvanced:          false,
-  oauthScopesSelection:  null,
-  scopeConfig:           null,
-  diskTypeContent:       null,
-  imageTypeContent:      null,
-  machineTypes:          null,
-  nodeVersions:          null,
-  controlPlaneVersion:   null,
-  upgradeVersion:        false,
+  cluster:                 null,
+  originalCluster:         null,
+  nodePool:                null,
+  nodeAdvanced:            false,
+  oauthScopesSelection:    null,
+  scopeConfig:             null,
+  diskTypeContent:         null,
+  imageTypeContent:        null,
+  machineTypes:            null,
+  nodeVersions:            null,
+  controlPlaneVersion:     null,
+  upgradeVersion:          false,
 
   init() {
     this._super(...arguments);
@@ -117,6 +117,19 @@ export default Component.extend({
 
     set(this.nodePool.config, 'oauthScopes', this.google.mapOauthScopes(this.oauthScopesSelection, this.scopeConfig));
   })),
+
+  regionalTotalNodeCounts: computed('locationType', 'nodePool.initialNodeCount', 'locationContent.@each.checked', function() {
+    const { locationType } = this;
+    let totalLocations = this.locationContent.filterBy('checked').length;
+
+    if (locationType === 'zonal') {
+      // willSave in the cluster will add the selected zone as the default location in the locations array
+      totalLocations = totalLocations + 1;
+    }
+
+    return this?.nodePool?.initialNodeCount * totalLocations;
+  }),
+
 
   showManagementWarning: computed('originalCluster.gkeStatus.upstreamSpec.imported', 'nodePool.management.{autoUpgrade,autoRepair}', function() {
     const { nodePool, originalCluster } = this;

--- a/lib/shared/addon/components/gke-node-pool-row/template.hbs
+++ b/lib/shared/addon/components/gke-node-pool-row/template.hbs
@@ -192,6 +192,14 @@
           @min={{1}}
           @classNames="form-control"
         />
+        {{#if (gt regionalTotalNodeCounts nodePool.initialNodeCount)}}
+          <span class="pl-10 help-block text-warning">
+            {{t
+              "clusterNew.googlegke.locations.warning"
+              totalNodes=regionalTotalNodeCounts
+            }}
+          </span>
+        {{/if}}
       </div>
       <div class="col span-3">
         <label class="acc-label">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3825,6 +3825,7 @@ clusterNew:
       zone: Zonal
     locations:
       label: Additional Zones
+      warning: "Total (in all zones): {totalNodes}"
     loggingMonitoringWarning: Logging and Monitoring service options can be created independently, but they may not be updated separately. They must both either be NONE or have their corresponding service set.
     loggingService:
       default: logging.googleapis.com/kubernetes


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This exposes Zones on a regional cluster type. This also adds a small label below each initial node count in each node pool that displays how many nodes in all zones for that node pool like GKE does. There is some weirdness here though, when we send off a regional cluster without any additional zones I believe it defaults to initialNodeCount in each zone available for this cluster.
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
New Feature
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#32345
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
