### PR TITLE
Minor improvements when embedded

### DIFF
--- a/app/application/controller.js
+++ b/app/application/controller.js
@@ -2,7 +2,7 @@ import { oneWay } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import { run } from '@ember/runloop';
-import { observer } from '@ember/object';
+import { observer, set } from '@ember/object';
 
 export default Controller.extend({
   settings: service(),
@@ -19,6 +19,7 @@ export default Controller.extend({
   state:             null,
   code:              null,
   isPopup:           null,
+  isEmbedded:        false,
 
   tooltip:           oneWay('tooltipService.tooltipOpts.type'),
   tooltipTemplate:   oneWay('tooltipService.tooltipOpts.template'),
@@ -29,6 +30,10 @@ export default Controller.extend({
     if ( this.get('app.environment') === 'development' ) {
       run.backburner.DEBUG = true;
     }
+
+    const embedded = window.top !== window;
+
+    set(this, 'isEmbedded', embedded);
   },
 
   // currentRouteName is set by Ember.Router

--- a/app/application/template.hbs
+++ b/app/application/template.hbs
@@ -19,22 +19,26 @@
 {{outlet "overlay"}}
 {{outlet "error"}}
 
+{{#unless isEmbedded}}
 <SettingsOverridableBanner
   id="setting-ui-header-banner"
   @show={{settings.showHeaderBanner}}
   @model={{settings.bannerContent}}
 />
+{{/unless}}
 <div
   id="application"
   class="container no-inline-space {{if settings.showHeaderBanner 'with-ui-header-banner' ''}} {{if settings.showFooterBanner 'with-ui-footer-banner' ''}}"
 >
   {{outlet}}
 </div>
+{{#unless isEmbedded}}
 <SettingsOverridableBanner
   id="setting-ui-footer-banner"
   @show={{settings.showFooterBanner}}
   @model={{settings.bannerContent}}
 />
+{{/unless}}
 
 {{component tooltip tooltipTemplate=tooltipTemplate class="container-tooltip" id="tooltip-base" role="tooltip" aria-hidden="false"}}
 {{modal-root}}

--- a/app/initializers/route-spy.js
+++ b/app/initializers/route-spy.js
@@ -3,6 +3,8 @@ import Router from '@ember/routing/router';
 export function initialize() {
   const isEmbedded = window !== window.top;
 
+  let stylesheet = null;
+
   if (isEmbedded) {
     Router.reopen({
       notifyTopFrame: function() {
@@ -43,6 +45,23 @@ export function initialize() {
         if (userTheme) {
           userTheme.setTheme( msg.name, false);
         }
+      } else if (msg.action === 'colors') {
+        const head = document.getElementsByTagName('head')[0];
+
+        // Inject stylesheet to customize some colors
+        if (stylesheet) {
+          head.removeChild(stylesheet);
+        }
+
+        let css = `.bg-primary { background-color: ${ msg.primary }; color: ${ msg.primaryText } }\n `;
+
+        css += `.ember-basic-dropdown-content > li > a:hover {background-color: ${ msg.primary }; color: ${ msg.primaryText } }\n `;
+        css += `.ember-basic-dropdown-content > li > a:focus {background-color: ${ msg.primary }; color: ${ msg.primaryText } }\n `;
+
+        stylesheet = document.createElement('style');
+        stylesheet.setAttribute('type', 'text/css');
+        stylesheet.appendChild(document.createTextNode(css));
+        head.appendChild(stylesheet);
       }
     });
   }

--- a/app/initializers/route-spy.js
+++ b/app/initializers/route-spy.js
@@ -48,7 +48,7 @@ export function initialize() {
       } else if (msg.action === 'colors') {
         const head = document.getElementsByTagName('head')[0];
 
-        // Inject stylesheet to customize some colors
+        // Inject stylesheet to customize some styles to reflect the primary color
         if (stylesheet) {
           head.removeChild(stylesheet);
         }


### PR DESCRIPTION
This PR:

- Hides the fixed customizable banners, since they are already present in the Vue UI when embedded
- Adds the ability for the Vue UI to inform the Ember UI of the primary color and primary text color - we will then inject minimal stylesheet overrides to use this color in a couple of places. This is enough to reflect the primary color as set in the Vue UI. This means that when the SUSE theme is set, the buttons in the embedded UI and the dropdowns will also use green.