### PR TITLE
Add helper to detect when any flexible shape is selected.

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
@@ -305,6 +305,9 @@ export default Component.extend(ClusterDriver, {
   canCreateCluster: computed('config.nodeShape', 'config.nodeImage', function() {
     return !(get(this, 'config.nodeShape') && get(this, 'config.nodeImage'));
   }),
+  isFlex: computed('config.nodeShape', function() {
+    return (get(this, 'config.nodeShape').includes('Flex'));
+  }),
 
   // Add custom validation beyond what can be done from the config API schema
   validate() {

--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/template.hbs
@@ -409,7 +409,7 @@
                 <div>{{config.nodeShape}}</div>
               {{/if}}
             </div>
-            {{#if (eq config.nodeShape "VM.Standard.E3.Flex")}}
+            {{#if isFlex}}
               <div class="col span-4">
                 <label class="acc-label" for="input-ocpu-count">
                   {{t "clusterNew.oracleoke.flexShapeConfig.label"}}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

This PR builds on this [previous PR](https://github.com/rancher/ui/pull/4249) by adding a helper to detect when _any_ flexible shape is selected so that the user can specify the number of oCPUs. 

Previously, only the `VM.Standard.E3.Flex` shape was detected (missing new shapes like `VM.Standard.E4.Flex`, `VM.Standard.A1.Flex` and shapes to come). 


<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix.

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-->



Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 
**Relates to:**
- https://github.com/rancher/ui/pull/4249


Further comments
======

[Back-port](https://github.com/rancher/ui/pull/4638) to 2.5 release. 


<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
![image](https://user-images.githubusercontent.com/13613687/119714635-f3dffc80-be17-11eb-8f5c-7b42063cde17.png)




