### PR TITLE
Hide fleet feature flag

### DIFF
--- a/lib/global-admin/addon/components/feature-flags/component.js
+++ b/lib/global-admin/addon/components/feature-flags/component.js
@@ -46,6 +46,6 @@ export default Component.extend({
   stickyHeader:        false,
 
   filteredFeatures: computed('model.[]', function() {
-    return get(this, 'model').filter((feature) => feature.name !== 'dashboard');
+    return get(this, 'model').filter((feature) => !['dashboard', 'fleet'].includes(feature.name));
   }),
 });


### PR DESCRIPTION
The user is not allowed to turn it off in 2.6, but it still exists as a flag for internal use because of how downstream clusters are provisioned.
