### PR TITLE
[2.5.x] GKE V2 Disable correct fields when not useing Ip Aliases

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-gke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/component.js
@@ -357,7 +357,7 @@ export default Component.extend(ClusterDriver, {
     }
   }),
 
-  networkChange: observer('config.network', 'subNetworkContent.[]', function() {
+  networkChange: observer('config.network', 'subNetworkContent.[]', 'config.ipAllocationPolicy.useIpAliases', function() {
     if (this.isDestroyed || this.isDestroying || this.saving) {
       return;
     }
@@ -373,10 +373,14 @@ export default Component.extend(ClusterDriver, {
           'config.ipAllocationPolicy.createSubnetwork':  false,
         });
       } else {
-        setProperties(this, {
-          'config.subnetwork':                           '',
-          'config.ipAllocationPolicy.createSubnetwork':  true,
-        });
+        if (this.config?.ipAllocationPolicy?.useIpAliases) {
+          setProperties(this, {
+            'config.subnetwork':                           '',
+            'config.ipAllocationPolicy.createSubnetwork':  true,
+          });
+        } else {
+          set(this, 'config.ipAllocationPolicy.createSubnetwork', false);
+        }
       }
 
       setProperties(this, {
@@ -386,10 +390,15 @@ export default Component.extend(ClusterDriver, {
     } else {
       setProperties(this, {
         'config.subnetwork':                                    '',
-        'config.ipAllocationPolicy.createSubnetwork':           true,
         'config.ipAllocationPolicy.clusterSecondaryRangeName':  null,
         'config.ipAllocationPolicy.servicesSecondaryRangeName': null,
       });
+
+      if (this.config?.ipAllocationPolicy?.useIpAliases) {
+        set(this, 'config.ipAllocationPolicy.createSubnetwork', true);
+      } else {
+        set(this, 'config.ipAllocationPolicy.createSubnetwork', false);
+      }
     }
   }),
 
@@ -426,7 +435,7 @@ export default Component.extend(ClusterDriver, {
     }
   }),
 
-  subnetworkChange: observer('config.subnetwork', function() {
+  subnetworkChange: observer('config.subnetwork', 'config.ipAllocationPolicy.useIpAliases', function() {
     if (this.isDestroyed || this.isDestroying || this.saving) {
       return;
     }
@@ -435,13 +444,14 @@ export default Component.extend(ClusterDriver, {
 
     if (isEmpty(subnetwork)) {
       setProperties(this, {
-        'config.ipAllocationPolicy.createSubnetwork':           true,
         'config.ipAllocationPolicy.clusterSecondaryRangeName':  null,
         'config.ipAllocationPolicy.servicesSecondaryRangeName': null,
       });
 
-      if (this.disableNamelessSecondaryRanges) {
-        set(this, 'disableNamelessSecondaryRanges', false);
+      if (this.config?.ipAllocationPolicy?.useIpAliases) {
+        set(this, 'config.ipAllocationPolicy.createSubnetwork', true);
+      } else {
+        set(this, 'config.ipAllocationPolicy.createSubnetwork', false);
       }
     } else {
       setProperties(this, {
@@ -449,16 +459,6 @@ export default Component.extend(ClusterDriver, {
         'config.ipAllocationPolicy.subnetworkName':    null,
         'config.ipAllocationPolicy.nodeIpv4CidrBlock': null,
       });
-
-      const { sharedSubnets } = this;
-
-      const match = (sharedSubnets || []).findBy('subnetwork', subnetwork);
-
-      if (!isEmpty(match)) {
-        if (this.disableNamelessSecondaryRanges) {
-          set(this, 'disableNamelessSecondaryRanges', false);
-        }
-      }
     }
   }),
 
@@ -585,12 +585,16 @@ export default Component.extend(ClusterDriver, {
   }),
 
 
-  networkContent: computed('config.zone', 'networks', 'sharedSubnets', function() {
+  networkContent: computed('config.zone', 'networks.[]', 'sharedSubnets.[]', 'subNetworks.[]', function() {
+    const subnets = get(this, 'subNetworks');
     const networks = (get(this, 'networks') || []).map((net) => {
+      const matchedSubnets = ( subnets || [] ).filterBy('network', net.selfLink);
+
       return {
         ...net,
         group:  'VPC',
-        shared: false
+        shared: false,
+        label:  matchedSubnets.length > 0 ? `${ net.name } (subnets available)` : net.name,
       };
     });
     const sharedSubnets = (get(this, 'sharedSubnets') || []).map((ssn) => {
@@ -625,9 +629,9 @@ export default Component.extend(ClusterDriver, {
     return [];
   }),
 
-  subNetworkContent: computed('subNetworks.[]', 'sharedSubnets.[]', 'config.network', 'config.zone', function() {
+  subNetworkContent: computed('subNetworks.[]', 'sharedSubnets.[]', 'config.network', 'config.zone', 'config.ipAllocationPolicy.useIpAliases', function() {
     const {
-      config: { network: networkName },
+      config: { network: networkName, ipAllocationPolicy: { useIpAliases = false } },
       networkContent,
       subNetworks = [],
       sharedSubnets = [],
@@ -673,12 +677,16 @@ export default Component.extend(ClusterDriver, {
         }
       });
 
-      const defaultSubnetAry = [{
-        label: this.intl.t('clusterNew.googlegke.ipPolicyCreateSubnetwork.autoLabel'),
-        value: '',
-      }];
+      if (useIpAliases) {
+        const defaultSubnetAry = [{
+          label: this.intl.t('clusterNew.googlegke.ipPolicyCreateSubnetwork.autoLabel'),
+          value: '',
+        }];
 
-      out = [...defaultSubnetAry, ...mappedSubnets];
+        out = [...defaultSubnetAry, ...mappedSubnets];
+      } else {
+        out = [...mappedSubnets];
+      }
     }
 
     return out;
@@ -801,6 +809,12 @@ export default Component.extend(ClusterDriver, {
 
     if (get(this, 'config.useIpAliases')) {
       set(config, 'clusterIpv4Cidr', null);
+    } else {
+      if (isEmpty(get(config, 'subnetwork'))) {
+        this.send('errorHandler', this.intl.t('clusterNew.googlegke.useIpAliases.error'));
+
+        return false;
+      }
     }
 
     if (!get(config, 'masterAuthorizedNetworks.enabled')) {

--- a/lib/shared/addon/components/cluster-driver/driver-gke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/template.hbs
@@ -153,7 +153,9 @@
                   <Input
                     @type="checkbox"
                     @checked={{location.checked}}
-                    @disabled={{and (not isNewOrEditable) (eq locationType "regional")
+                    @disabled={{and
+                      (not isNewOrEditable)
+                      (eq locationType "regional")
                     }}
                   />
                   {{location.name}}
@@ -231,7 +233,6 @@
                   classNames="form-control"
                   value=config.network
                   optionValuePath="name"
-                  optionLabelPath="name"
                 }}
               </InputOrDisplay>
             </div>
@@ -253,7 +254,6 @@
                   content=subNetworkContent
                   classNames="form-control"
                   value=config.subnetwork
-                  readOnly=(lte subNetworkContent.length 0)
                 }}
               </InputOrDisplay>
             </div>
@@ -286,6 +286,15 @@
                 </label>
               </div>
             </div>
+            <div class="col span-6">
+              {{#unless config.ipAllocationPolicy.useIpAliases}}
+                <BannerMessage
+                  @icon="icon-alert"
+                  @color="bg-warning mt-0"
+                  @message={{t "clusterNew.googlegke.useIpAliases.warning"}}
+                />
+              {{/unless}}
+            </div>
           </div>
           <div class="row">
             {{#if config.ipAllocationPolicy.createSubnetwork}}
@@ -302,7 +311,10 @@
                     placeholder=(t
                       "clusterNew.googlegke.ipPolicySubnetworkName.placeholder"
                     )
-                    disabled=(not config.ipAllocationPolicy.createSubnetwork)
+                    disabled=(or
+                      (not config.ipAllocationPolicy.createSubnetwork)
+                      (not config.ipAllocationPolicy.useIpAliases)
+                    )
                   }}
                 </InputOrDisplay>
               </div>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3965,6 +3965,8 @@ clusterNew:
       label: Task queue
     useIpAliases:
       label: Ip Aliases
+      warning: When Disabling IP Aliases you must select both a network and subnet.
+      error: Use IP Aliases is disabled, a network and subnetwork must be selected.
     userInfo:
       label: User Info
     zone:


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
The PR adds extra logic to reset and disable the correct set of fields when the IP Aliases flag is disabled. Additionally we will show a warning that the subnetwork will be required for create. 
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
Bugfix
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
rancher/rancher#32585
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
