### PR TITLE
Fix fleet link when embedded

### DIFF
--- a/lib/shared/addon/scope/service.js
+++ b/lib/shared/addon/scope/service.js
@@ -215,6 +215,10 @@ export default Service.extend({
       link = 'https://localhost:8005/';
     } else {
       link = '/dashboard/';
+
+      if (window.top !== window) {
+        link = '/k/dashboard/';
+      }
     }
 
     return link;


### PR DESCRIPTION
A small fix when embedded - the help lints for fleet went straight to dashboard, resulting in the dashboard UI being embedded in itself.

This PR updates the link only when embedded to use the different route which is is then captured to ensure that the dashboard does the appropriate route navigation rather than embedding itself.

Now uses the same pattern as `dashboardLink` in the code below.