### PR TITLE
Don't show events tab when embedded

### DIFF
--- a/lib/monitoring/addon/components/cluster-dashboard/component.js
+++ b/lib/monitoring/addon/components/cluster-dashboard/component.js
@@ -24,9 +24,18 @@ export default Component.extend(CatalogUpgrade, {
   components:        null,
   showClusterTabs:   true,
   templateId:        MONITORING_TEMPLATE,
+  isEmbedded:        false,
   monitoringEnabled: alias('scope.currentCluster.enableClusterMonitoring'),
   isMonitoringReady: alias('scope.currentCluster.isMonitoringReady'),
   componentStatuses: alias('scope.currentCluster.componentStatuses'),
+
+  init() {
+    this._super(...arguments);
+
+    const embedded = window.top !== window;
+
+    set(this, 'isEmbedded', embedded);
+  },
 
   actions: {
     edit() {

--- a/lib/monitoring/addon/components/cluster-dashboard/template.hbs
+++ b/lib/monitoring/addon/components/cluster-dashboard/template.hbs
@@ -118,14 +118,16 @@
   {{#if (and showClusterTabs scope.currentCluster.isMonitoringReady)}}
     {{cluster-dashboard-tabs dashboards=dashboards}}
   {{else}}
-    {{#accordion-list showExpandAll=false as | al expandFn |}}
-      {{resource-event-list
-        resourceType=(t "generic.cluster")
-        clusterEvents=true
-        expandAll=al.expandAll
-        expandFn=expandFn
-      }}
-    {{/accordion-list}}
+    {{#unless isEmbedded}}
+      {{#accordion-list showExpandAll=false as | al expandFn |}}
+        {{resource-event-list
+          resourceType=(t "generic.cluster")
+          clusterEvents=true
+          expandAll=al.expandAll
+          expandFn=expandFn
+        }}
+      {{/accordion-list}}
+    {{/unless}}
   {{/if}}
 {{else}}
   <div class="text-center text-muted">


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/3218

When monitoring is installed but not ready we show the events tab - this should not be shown when embedded.