### PR TITLE
Add support for KMS key encryption during cluster creation

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
@@ -57,6 +57,7 @@ export default Component.extend(ClusterDriver, {
         memory:                0,
         quantityPerSubnet:     1,
         quantityOfNodeSubnets: 1,
+        kmsKeyId:              '',
       });
 
       set(this, 'cluster.okeEngineConfig', config);
@@ -335,6 +336,12 @@ export default Component.extend(ClusterDriver, {
 
     if (!userOcid.startsWith('ocid1.user')) {
       errors.push('A valid user OCID is required');
+    }
+
+    const kmsKeyOcid = get(this, 'config.kmsKeyId');
+
+    if ((kmsKeyOcid.length > 0) && !kmsKeyOcid.startsWith('ocid1.key')) {
+      errors.push('Not a valid kms key OCID');
     }
 
     // TODO Add more specific errors

--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/template.hbs
@@ -208,7 +208,16 @@
               {{input type="text" name="compartment" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.compartmentOCID.placeholder') value=config.compartmentId}}
             {{/input-or-display}}
           </div>
-
+        </div>
+        <div class="row">
+          <div class="col span-4">
+            <label class="acc-label">
+              {{t 'clusterNew.oracleoke.kmsKeyId.label'}}
+            </label>
+            {{#input-or-display editable=isNew value=config.kmsKeyId}}
+              {{input type="text" name="kmsKeyId" classNames="form-control" placeholder=(t 'clusterNew.oracleoke.kmsKeyId.placeholder') value=config.kmsKeyId}}
+            {{/input-or-display}}
+          </div>
         </div>
       {{/accordion-list-item}}
       {{#if (eq step 2)}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4365,6 +4365,9 @@ clusterNew:
     localDisk:
       label: Local Disk
       placeholder: size GB
+    kmsKeyId:
+      label: KMS Key ID
+      placeholder: Optional, enter a valid KMS Key OCID
     node:
       detail: Choose the node type that will be used for this Kubernetes cluster
       loading: Loading configuration from Oracle Cloud Infrastructure


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->
Adds support for creating an OKE cluster where the Kubernetes secrets are encrypted at rest in etcd using the private kms vault master key.  

Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->
New feature which adds functionality.  Supports adding this key from the UI.

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relevant to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 
Related Issue
https://github.com/rancher-plugins/kontainer-engine-driver-oke/issues/32

Related PR's
https://github.com/rancher-plugins/kontainer-engine-driver-oke/pull/41
https://github.com/rancher/rancher/pull/33138


Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
<img width="801" alt="Screen Shot 2021-06-09 at 6 44 56 PM" src="https://user-images.githubusercontent.com/30269407/122132866-7ee95c80-cdf0-11eb-8304-9db84d7f531d.png">
