### PR TITLE
Fix reload issue when embedding istio configuration

### DIFF
--- a/lib/istio/addon/components/modal-delete-istio/component.js
+++ b/lib/istio/addon/components/modal-delete-istio/component.js
@@ -46,9 +46,15 @@ export default Component.extend(ModalBase, {
       }
 
       PromiseAll(promises).then(() => {
-        setTimeout(() => {
-          window.location.href = window.location.href; // eslint-disable-line no-self-assign
-        }, 1000);
+        const isEmbedded = window.top !== window;
+
+        if (isEmbedded) {
+          window.top.postMessage({ action: 'reload' });
+        } else {
+          setTimeout(() => {
+            window.location.href = window.location.href; // eslint-disable-line no-self-assign
+          }, 1000);
+        }
       }).catch((err) => {
         get(this, 'growl').fromError(get(err, 'body.message'));
       }).finally(() => {


### PR DESCRIPTION
After disabling istio, the page reloads itself - when embedded, this causes problems.

This fix will post a message to the outer UI (dashboard) when embedded, so it can properly reload the embedded frame - otherwise we get dashboard embedded in dashboard