### PR TITLE
 Making gkev1 use the region parameter instead of the zone parameter when availavble

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
@@ -394,7 +394,7 @@ export default Component.extend(ClusterDriver, {
     }
   }),
 
-  zoneChanged: observer('config.zone', 'zones.[]', function() {
+  zoneChanged: observer('config.zone', 'zones.[]', 'locationType', 'config.region', function() {
     if (this.saving) {
       return;
     }
@@ -697,13 +697,17 @@ export default Component.extend(ClusterDriver, {
   },
 
   fetchVersions() {
+    const region = get(this, 'config.region');
+    const zone = region ? undefined : get(this, 'config.zone');
+
     return get(this, 'globalStore').rawRequest({
       url:    '/meta/gkeVersions',
       method: 'POST',
       data:   {
         credentials: get(this, 'config.credential'),
         projectId:   get(this, 'config.projectId'),
-        zone:        get(this, 'config.zone') || `${ get(this, 'config.region') }-b`,
+        zone,
+        region
       }
     }).then((xhr) => {
       const out = xhr.body;


### PR DESCRIPTION

rancher/rancher#33527
