### PR TITLE
default to latest LKE version

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-linodelke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-linodelke/component.js
@@ -78,7 +78,7 @@ export default Component.extend(ClusterDriver, {
         description:       '',
         accessToken:       '',
         region:            'us-central',
-        kubernetesVersion: '1.18',
+        kubernetesVersion: '',
         tags:              [],
         nodePools:         []
       });
@@ -110,6 +110,9 @@ export default Component.extend(ClusterDriver, {
             nodeTypes:   responses.nodeTypes.data.filter((type) => (type.class !== 'nanode' && type.class !== 'gpu')),
             k8sVersions: responses.k8sVersions.data,
           });
+
+          // default to latest version of LKE
+          set(this, 'config.kubernetesVersion', responses.k8sVersions.data[0].id)
           cb(true);
         }).catch((err) => {
           if (err && err.body && err.body.errors && err.body.errors[0]) {


### PR DESCRIPTION
Proposed changes
======

This change sets the default config option `kubernetesVersion` to the latest supported LKE version. Previously, the default value was hardcoded as `1.18` (which is no longer supported and throws a `400 bad request`).

Since this state is only updated when the drop down selection is changed, if the user were to keep the drop down as-is with the latest version displayed and continue on with cluster creation, the driver would erroneously attempt to create a `1.18` cluster.

Types of changes
======

Bugfix

Linked Issues
======

Further comments
======
