### PR TITLE
Now just choose region/zone based on location type instead of preferring region over zone

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
@@ -706,8 +706,9 @@ export default Component.extend(ClusterDriver, {
   },
 
   fetchVersions() {
-    const region = get(this, 'config.region');
-    const zone = region ? undefined : get(this, 'config.zone');
+    const locationType = get(this, 'locationType');
+    const region = locationType === REGION_TYPE ? get(this, 'config.region') : undefined;
+    const zone = locationType === ZONE_TYPE ? get(this, 'config.zone') : undefined;
 
     return get(this, 'globalStore').rawRequest({
       url:    '/meta/gkeVersions',


### PR DESCRIPTION

Region is set by default so it was getting chosen over zone even when zone was set.

https://github.com/rancher/rancher/issues/33527#issuecomment-878476927
