### PR TITLE
Now just choose region/zone based on location type instead of preferring region over zone

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-googlegke/component.js
@@ -540,8 +540,9 @@ export default Component.extend(ClusterDriver, {
       return;
     }
 
-    const region = get(this, 'config.region');
-    const zone = region ? undefined : get(this, 'config.zone');
+    const locationType = get(this, 'locationType');
+    const region = locationType === 'regional' ? get(this, 'config.region') : undefined;
+    const zone = locationType === 'zonal' ? get(this, 'config.zone') : undefined;
 
     return get(this, 'globalStore').rawRequest({
       url:    '/meta/gkeVersions',


### PR DESCRIPTION
Region is set by default so it was getting chosen over zone even when zone was set.

https://github.com/rancher/rancher/issues/33527#issuecomment-878476927
