### PR TITLE
Add support for setting oCPUs and memory for flex node templates

### DIFF
--- a/lib/nodes/addon/components/driver-oci/component.js
+++ b/lib/nodes/addon/components/driver-oci/component.js
@@ -17,6 +17,8 @@ export default Component.extend(NodeDriver, {
   region:                 '',
   nodeAvailabilityDomain: '',
   nodeImage:              '',
+  nodeOcpus:               0,
+  nodeMemoryInGb:          0,
   step:                    1,
   regionChoices:          OCI_REGIONS,
 
@@ -51,6 +53,9 @@ export default Component.extend(NodeDriver, {
       value: '',
       label: '',
     };
+  }),
+  isFlex: computed('config.nodeShape', function() {
+    return (get(this, 'config.nodeShape').includes('Flex'));
   }),
   nodeShapeChoices: computed('config.{nodeCompartmentId,region}', 'model.cloudCredentialId', 'primaryResource.cloudCredentialId', async function() {
     let token = get(this, 'primaryResource.cloudCredentialId');

--- a/lib/nodes/addon/components/driver-oci/template.hbs
+++ b/lib/nodes/addon/components/driver-oci/template.hbs
@@ -104,6 +104,31 @@
       </div>
     </div>
 
+    {{#if isFlex}}
+      <div class="row">
+        <div class="col span-6">
+          <label class="acc-label" for="input-ocpu-count">
+            {{t "clusterNew.oracleoke.flexShapeConfig.label"}}
+          </label>{{field-required}}
+          {{input-number
+                  id="input-ocpu-count"
+                  min=1
+                  max=64
+                  value=config.nodeOcpus
+          }}
+        </div>
+        <div class="col span-6">
+          <label class="acc-label" for="input-memory-count">
+            {{t "clusterNew.oracleoke.flexShapeConfig.memory"}}
+          </label>{{field-required}}
+          {{input-number
+                  id="input-memory-count"
+                  value=config.nodeMemoryInGb
+          }}
+        </div>
+      </div>
+    {{/if}}
+
 
   {{/accordion-list-item}}
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4360,6 +4360,7 @@ clusterNew:
     flexShapeConfig:
       error: Default Persistent Volume Disk Size should be greater than 0
       label: Specify the number of OCPUs for the flex shape
+      memory: Specify the amount of memory (GB) for the flex shape
       placeholder: e.g. 10
     instance:
       detail: Configure the instance that will be used as nodes in the cluster.


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

This PR adds support for specifying the number of CPUs and the amount of memory in the node-template when a flexible shape has been selected. 


<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

New feature.

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-->



Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 
**Depends on:**
- https://github.com/rancher/rancher/pull/33631
- https://github.com/rancher/rancher/pull/33647 (2.5 back-port)
- https://github.com/rancher/rancher/pull/33648 (2.4 back-port)


Other tracking issues:
- https://github.com/rancher-plugins/rancher-machine-driver-oci/issues/7

Further comments
======



<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->


**OCI node-template prompting the user to set the required CPU and memory setting when a flex-shape has been selected in the instance details:**


![image](https://user-images.githubusercontent.com/13613687/125712020-84130f17-e14d-4152-a70c-21ff211b5f7e.png)


