### PR TITLE
Hide tenantId option in Azure cloud creds

### DIFF
--- a/lib/global-admin/addon/components/cloud-credential-azure/component.js
+++ b/lib/global-admin/addon/components/cloud-credential-azure/component.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import layout from './template';
 import { inject as service } from '@ember/service';
-import { set } from '@ember/object';
 
 export default Component.extend({
   router: service(),
@@ -10,17 +9,4 @@ export default Component.extend({
 
   tag:              null,
   config:           null,
-  tenantIdRequired: false,
-
-  init() {
-    this._super(...arguments);
-
-    const currentRoute = this.router.currentRoute;
-
-    if (currentRoute?.name === 'global-admin.clusters.new.launch' && currentRoute?.params?.provider === 'azureaksv2') {
-      set(this, 'tenantIdRequired', true);
-    } else {
-      set(this, 'tenantIdRequired', false);
-    }
-  },
 });

--- a/lib/global-admin/addon/components/cloud-credential-azure/template.hbs
+++ b/lib/global-admin/addon/components/cloud-credential-azure/template.hbs
@@ -26,23 +26,6 @@
 </div>
 <div class="row">
   <div class="col span-6">
-    <label class="acc-label" for="azure-tenant-id">
-      {{t "modalAddCloudKey.azure.tenantId.label"}}
-      {{#if tenantIdRequired}}
-        <FieldRequired />
-      {{/if}}
-    </label>
-    <Input
-      @classNames="form-control"
-      @id="azure-tenant-id"
-      @type="text"
-      @value={{mut config.tenantId}}
-    />
-    {{#unless tenantIdRequired}}
-      <p class="help-block">{{t "modalAddCloudKey.azure.tenantId.help"}}</p>
-    {{/unless}}
-  </div>
-  <div class="col span-6">
     <label class="acc-label" for="azure-subscription-id">
       {{t "modalAddCloudKey.azure.subscriptionId.label"}}
       <FieldRequired />

--- a/lib/shared/addon/components/cluster-driver/driver-aks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-aks/component.js
@@ -463,7 +463,7 @@ export default Component.extend(ClusterDriver, {
     return cloudCredentials.filter((cc) => {
       const isAzure = Object.prototype.hasOwnProperty.call(cc, 'azurecredentialConfig');
 
-      if (isAzure && !isEmpty(cc.azurecredentialConfig?.tenantId)) {
+      if (isAzure) {
         return true;
       }
 

--- a/lib/shared/addon/utils/amazon.js
+++ b/lib/shared/addon/utils/amazon.js
@@ -679,7 +679,7 @@ export const EKS_REGIONS = [
 ];
 
 // from https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-export const EKS_VERSIONS = ['1.20', '1.19', '1.18', '1.17', '1.16', '1.15']; // sort newest->oldest so we dont have to run any logic to sort like other provider versions
+export const EKS_VERSIONS = ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16', '1.15']; // sort newest->oldest so we dont have to run any logic to sort like other provider versions
 
 export const nameFromResource = function(r, idField) {
   let id = r[idField];

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -8329,10 +8329,6 @@ modalAddCloudKey:
     subscriptionId:
       label: Subscription ID
       placeholder: Your Azure subscription ID
-    tenantId:
-      label: Tenant ID
-      placeholder: A long UUID string
-      help: Cloud Credentials without a Tenant ID will not be availabe when launching a hosted Azure AKS cluster.
   digitalocean:
     accessToken:
       label: Access Token


### PR DESCRIPTION
The backend will look this up so the user does not need to provide it.