### PR TITLE
Preventing users from editing an eks cluster when the cloud credential is inaccessible

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-eks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-eks/component.js
@@ -31,6 +31,7 @@ export default Component.extend(ClusterDriver, {
   errors:                 null,
   otherErrors:            null,
   clusterErrors:          null,
+  credentialError:        null,
   serviceRoleMode:        'default',
   vpcSubnetMode:          'default',
   allImages:              null,
@@ -190,6 +191,7 @@ export default Component.extend(ClusterDriver, {
     finishAndSelectCloudCredential(cred) {
       if (cred) {
         set(this, 'config.amazonCredentialSecret', get(cred, 'id'));
+        set(this, 'credentialError', false);
 
 
         this.send('startAwsConfiguration');
@@ -235,6 +237,15 @@ export default Component.extend(ClusterDriver, {
 
         if (mode === 'edit') {
           step = 4;
+        }
+
+        if (get(this, 'credentialError')) {
+          const errors = this.errors || [];
+
+          errors.unshift(this.intl.t('nodeDriver.amazoneks.access.credentialError'))
+
+          set(this, 'errors', errors);
+          step = 1;
         }
 
         set(this, 'step', step);
@@ -610,6 +621,10 @@ export default Component.extend(ClusterDriver, {
 
       set(this, 'serviceRoles', eksRoles);
     } catch (err) {
+      if (err.message.includes('Authentication Token')) {
+        set(this, 'credentialError', true);
+      }
+
       get(this, 'errors').pushObject(err);
     }
   },

--- a/lib/shared/addon/components/form-auth-cloud-credential/component.js
+++ b/lib/shared/addon/components/form-auth-cloud-credential/component.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import layout from './template';
-import { get, set } from '@ember/object';
+import { computed, get, set } from '@ember/object';
 import { next } from '@ember/runloop';
 import { isEmpty } from '@ember/utils';
 
@@ -64,6 +64,16 @@ export default Component.extend({
       set(this, 'showAddCloudCredential', false);
     },
   },
+
+  cloudCredentialSelected: computed('cloudCredentialKey', 'cloudCredentials', 'primaryResource', function() {
+    const cloudCredentialKey = get(this, 'cloudCredentialKey');
+    const credential = get(this, `primaryResource.${ cloudCredentialKey }`);
+    const cloudCredentials = get(this, 'cloudCredentials') || [];
+
+    console.log('sdfsd', credential, cloudCredentials);
+
+    return credential && cloudCredentials.findIndex((c) => c.id === credential) >= 0;
+  }),
 
   initSingleOrAddCredential() {
     let {

--- a/lib/shared/addon/components/form-auth-cloud-credential/template.hbs
+++ b/lib/shared/addon/components/form-auth-cloud-credential/template.hbs
@@ -51,7 +51,7 @@
 {{else}}
   {{#unless hideSave}}
     {{save-cancel
-      saveDisabled=(or (unless (get primaryResource cloudCredentialKey) true) disableSave)
+      saveDisabled=(or (not cloudCredentialSelected) disableSave)
       save=progressStep
       cancel=cancel
       createLabel=createLabel

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -8872,6 +8872,7 @@ nodeDriver:
       next: "Next: Configure Cluster"
       loading: Loading Cluster Option from Amazon...
       help: "Paste in your AWS key pair here. Use only IAM access keys, using keys generated from the root user will make the cluster unreachable."
+      credentialError: There was a problem accessing the cluster using the selected credential
     clusterOption:
       title: Cluster Options
       detail: Customize the cluster that will be used to launch EKS Instances


### PR DESCRIPTION
https://github.com/rancherlabs/rancher-security/issues/820

Disable Next if a credential isn't selected:
![Screenshot 2021-07-21 143929](https://user-images.githubusercontent.com/55104481/126564221-446a62f8-59ef-497c-95a8-66c6a2161d58.png)

Show an error message and don't proceed past step 1 if there was an error pertaining to credentials (would happen if the user had access to a credential which didn't have access to the cluster):
![Screenshot 2021-07-21 143831](https://user-images.githubusercontent.com/55104481/126564220-aa8e2a24-a14f-4608-969d-f53e4d00eb77.png)