### PR TITLE
Fix typo in private control-plane property.

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
@@ -239,9 +239,9 @@ export default Component.extend(ClusterDriver, {
         set(this, 'config.enablePrivateNodes', true);
       }
       if (get(this, 'config.cpSubnetAccess') === 'public') {
-        set(this, 'config.enablePrivatControlPlane', false);
+        set(this, 'config.enablePrivateControlPlane', false);
       } else {
-        set(this, 'config.enablePrivatControlPlane', true);
+        set(this, 'config.enablePrivateControlPlane', true);
       }
 
       this.send('driverSave', cb);
@@ -367,9 +367,9 @@ export default Component.extend(ClusterDriver, {
         set(this, 'config.skipVcnDelete', true);
       }
       if (get(this, 'config.cpSubnetAccess') === 'public') {
-        set(this, 'config.enablePrivatControlPlane', false);
+        set(this, 'config.enablePrivateControlPlane', false);
       } else {
-        set(this, 'config.enablePrivatControlPlane', true);
+        set(this, 'config.enablePrivateControlPlane', true);
       }
       if (get(this, 'config.npSubnetAccess') === 'public') {
         set(this, 'config.enablePrivateNodes', false);


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

This PR fixes a typo in the private-control-plane option that prevents the value from being properly set on the driver. Note, this feature is not yet exposed on the 2.4 and 2.5 branches. 

<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

Bugfix.

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-->



Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 



Further comments
======

The backport of this feature to the 2.4 and 2.5 have the typo fix included:
- https://github.com/rancher/ui/pull/4720
- https://github.com/rancher/ui/pull/4719 


<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
