### PR TITLE
Redirect to dashboard once if cookie is not present

### DIFF
--- a/app/authenticated/route.js
+++ b/app/authenticated/route.js
@@ -153,6 +153,19 @@ export default Route.extend(Preload, {
     // Don't show any modals when embedded
     const isEmbedded = window.top !== window;
 
+    if ( !get(this, `cookies.${ C.COOKIE.REDIRECTED }`) ) {
+      // Send users to dashboard, if there's no redirect cookie, and not embedded
+      // So that if you're on <2.6 in Ember, upgrade, and get reloaded you end up in Dashboard.
+      this.cookies.set(C.COOKIE.REDIRECTED, true);
+
+      // If isEmbedded then you're already in Dashboard, so just set the cookie.
+      if ( !isEmbedded ) {
+        window.location.href = get(this, 'scope.dashboardBase');
+
+        return;
+      }
+    }
+
     if ( get(this, 'settings.isRancher') && !isEmbedded) {
       const telemetry = get(this, `settings.${ C.SETTING.TELEMETRY }`);
       const form = get(this, `settings.${ C.SETTING.FEEDBACK_FORM }`);

--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -34,6 +34,7 @@ var C = {
     LANG:                     'LANG',
     USERNAME:                 'R_USERNAME',
     ACTIVEDIRECTORY_USERNAME: 'ACTIVEDIRECTORY_USERNAME',
+    REDIRECTED:               'R_REDIRECTED',
     THEME:                    'R_THEME',
   },
 


### PR DESCRIPTION
If the R_REDIRECTED cookie is not present and you load a standalone page (not iframed), redirect to Dashboard once.  If you load it iframed, set the cookie but don't redirect.  This should get most users into Dashboard once on upgrade from older->2.6+