### PR TITLE
Fix EKS Access Endpoints wording

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3454,7 +3454,7 @@ clusterNew:
       access:
         endpoints:
           addActionLabel: Add Endpoint
-          helpBlock: Optionally limit access to the public endpoint via explicit CIDR blocks. If you limit access to specific CIDR blocks, then it is recommended that you also enable the private access to avoid loosing network communitcation to the cluster.
+          helpBlock: Optionally limit access to the public endpoint via explicit CIDR blocks. If you limit access to specific CIDR blocks, then it is recommended that you also enable private access to avoid losing network communication to the cluster.
           label: Public Access Endpoints
           valueLabel: Endpoints
         help: Configuring Public/Priavte API access is an advanced use case. Users are encouraged to read the EKS cluster endpoint access control <a href="https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html" target="_blank"  rel="nofollow noopener noreferrer">documentation</a>.


### PR DESCRIPTION
Spelling and grammar changes to the `helpBlock` portion of the `Public Access Endpoints` section.