### PR TITLE
Fix close icon alignment in search box

### DIFF
--- a/app/styles/components/_tables.scss
+++ b/app/styles/components/_tables.scss
@@ -101,9 +101,8 @@ TABLE {
       width: auto;
       padding-right: 60px;
     }
-
   }
-
+ 
   .fixed-header {
     z-index: 2;
     background: $table-header;
@@ -443,5 +442,12 @@ TABLE {
     .no-sort-spacer {
       line-height: 2em;
     }
+  }
+}
+
+.fixed-header-actions {
+  button.search-close-btn {
+    min-height: 32px;
+    line-height: 32px;
   }
 }

--- a/lib/shared/addon/components/sortable-table/template.hbs
+++ b/lib/shared/addon/components/sortable-table/template.hbs
@@ -38,7 +38,7 @@
               {{input value=searchText aria-title=(t "generic.search") type="search" class="input-sm pull-right" placeholder=(t "generic.search")}}
               {{#if searchText}}
                 <span class="input-group-btn">
-                  <button class="btn bg-transparent text-info pl-10 pr-10" type="button" {{action "clearSearch" }}><i
+                  <button class="search-close-btn btn bg-transparent text-info pl-10 pr-10" type="button" {{action "clearSearch" }}><i
                       class="icon icon-close" /></button>
                 </span>
               {{/if}}


### PR DESCRIPTION
Fixes broken close icon alignemnt:

![RancherSearchBoxClose](https://user-images.githubusercontent.com/1955897/131844651-c4dbf45b-2555-4e77-be71-6c84dbead04d.png)
