### PR TITLE
Improving the default selection behavior for network policy in gkev2

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-gke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/component.js
@@ -264,6 +264,12 @@ export default Component.extend(ClusterDriver, {
     },
   },
 
+  networkPolicyEnabledChanged: observer('config.networkPolicyEnabled', function() {
+    if (get(this, 'isNew') && get(this, 'config.networkPolicyEnabled')) {
+      set(this, 'config.clusterAddons.networkPolicyConfig', true);
+    }
+  }),
+
   networkPolicyChanged: observer('cluster.enableNetworkPolicy', function() {
     const { cluster } = this;
 


### PR DESCRIPTION
When `Network Policy for Nodes` is selected `Network Policy Config (master only)` is also selected when creating a new cluster

https://github.com/rancher/dashboard/issues/3941#issuecomment-877325656
