### PR TITLE
[2.6] Update initial kubernetes version for AKS

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-aks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-aks/component.js
@@ -270,8 +270,9 @@ export default Component.extend(ClusterDriver, {
 
         const isEdit                        = mode === 'edit';
         const versionz                      = (get(versions, 'body') || []);
+        const defaultVersion                = versionz[versionz.length - 1] || '';
         const upgradeVersionz               = (get(upgradeVersions, 'body.upgrades') || []);
-        const initialVersion                = isEdit ? this.config.kubernetesVersion : '1.19.9'; // default in azure ui //Semver.maxSatisfying(versionz, this.defaultK8sVersionRange);
+        const initialVersion                = isEdit ? this.config.kubernetesVersion : defaultVersion; // default in azure ui //Semver.maxSatisfying(versionz, this.defaultK8sVersionRange);
 
         if (!isEdit && initialVersion) {
           set(this, 'cluster.aksConfig.kubernetesVersion', initialVersion);

--- a/lib/shared/addon/components/cluster-driver/driver-aks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-aks/component.js
@@ -9,7 +9,7 @@ import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import ipaddr from 'ipaddr.js';
 import { hash } from 'rsvp';
-// import Semver from 'semver';
+import Semver from 'semver';
 import ClusterDriver from 'shared/mixins/cluster-driver';
 import C from 'shared/utils/constants';
 import { addQueryParams } from 'shared/utils/util';
@@ -270,9 +270,8 @@ export default Component.extend(ClusterDriver, {
 
         const isEdit                        = mode === 'edit';
         const versionz                      = (get(versions, 'body') || []);
-        const defaultVersion                = versionz[versionz.length - 1] || '';
         const upgradeVersionz               = (get(upgradeVersions, 'body.upgrades') || []);
-        const initialVersion                = isEdit ? this.config.kubernetesVersion : defaultVersion; // default in azure ui //Semver.maxSatisfying(versionz, this.defaultK8sVersionRange);
+        const initialVersion                = isEdit ? this.config.kubernetesVersion : Semver.maxSatisfying(versionz, this.defaultK8sVersionRange); // default in azure ui
 
         if (!isEdit && initialVersion) {
           set(this, 'cluster.aksConfig.kubernetesVersion', initialVersion);


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This updates the initial kubernetes version from the string '1.19.9' to an actual value in the list of versions.

Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->
Bugfix for rancher/dashboard#4262 - Kubernetes version defaults to 1.21.2 in Cluster Options and 19.9.9 in Node Pools

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 
rancher/dashboard#4262

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
Backports #4765 into 2.6-fixes