### PR TITLE
Providing a way for overflow content to be visible within the new table styling

### DIFF
--- a/app/styles/base/_helpers.scss
+++ b/app/styles/base/_helpers.scss
@@ -182,6 +182,10 @@
   visibility: hidden;
 }
 
+.overflow-visible {
+  overflow: visible !important;
+}
+
 @mixin list-unstyled {
   margin: 0;
   padding: 0;

--- a/lib/shared/addon/components/form-share-member/template.hbs
+++ b/lib/shared/addon/components/form-share-member/template.hbs
@@ -12,7 +12,7 @@
 {{/if}}
 
 <div class="row">
-  <SortableTable @class="grid" @body={{membersRows}} @searchText={{searchText}} @descending={{descending}}
+  <SortableTable @class="grid" @tableClassNames="overflow-visible" @body={{membersRows}} @searchText={{searchText}} @descending={{descending}}
     @sortBy={{sortBy}} @bulkActions={{false}} @pagingLabel="pagination.cluster" @headers={{membersHeaders}}
     @stickyHeader={{false}} @search={{false}} as |sortable kind member dt|>
     {{#if (eq kind "row")}}


### PR DESCRIPTION
This specifically fixes an issue where a user couldn't add members because the members dropdown was being hidden.

rancher/dashboard#3980