### PR TITLE
Use default catalog template versions

### DIFF
--- a/app/models/multiclusterapp.js
+++ b/app/models/multiclusterapp.js
@@ -76,7 +76,15 @@ const MultiClusterApp = Resource.extend({
     upgrade() {
       const templateId    = get(this, 'externalIdInfo.templateId');
       const catalogId     = get(this, 'externalIdInfo.catalog');
-      const vKeys         = Object.keys(get(this, 'catalogTemplate.versionLinks'));
+      let vKeys         = Object.keys(get(this, 'catalogTemplate.versionLinks'));
+
+      if ( !vKeys || !Object.keys(vKeys).length ) {
+        // If you install a legacy app and then upgrade Rancher,
+        // the versionLinks object can be empty. In that case,
+        // use the current template version.
+        vKeys = [this.templateVersion.version]
+      }
+
       const latestVersion =  vKeys[vKeys.length - 1];
 
       get(this, 'router').transitionTo('global-admin.multi-cluster-apps.catalog.launch', templateId, {

--- a/lib/global-admin/addon/multi-cluster-apps/catalog/launch/route.js
+++ b/lib/global-admin/addon/multi-cluster-apps/catalog/launch/route.js
@@ -43,6 +43,12 @@ export default Route.extend({
       // get diff versions
       links = results.tpl.versionLinks;
 
+      if ( !links || !Object.keys(links).length ) {
+        // If you install a legacy app and then upgrade Rancher,
+        // the versionLinks object can be empty. In that case,
+        // use the default template version.
+        links = { [results.tpl.defaultVersion ]: `/v3/templateVersions/${ results.tpl.id }-${ results.tpl.defaultVersion }` }
+      }
       if (app && params.appId && !params.upgrade) {
         def = get(app, 'externalIdInfo.version');
       }
@@ -136,7 +142,7 @@ export default Route.extend({
           versionLinks:       links,
           versionsArray:      verArr,
         };
-      });
+      })
     });
   },
 

--- a/lib/shared/addon/mixins/catalog-app.js
+++ b/lib/shared/addon/mixins/catalog-app.js
@@ -88,10 +88,18 @@ export default Mixin.create({
     return out;
   }),
 
-  defaultUrl: computed('templateResource.defaultVersion', 'versionLinks', function() {
+  defaultUrl: computed('catalogTemplate.{id,name}', 'templateResource.defaultVersion', 'templateVersion.version', 'versionLinks', function() {
     const defaultVersion = get(this, 'templateResource.defaultVersion');
-    const versionLinks   = get(this, 'versionLinks');
+    let versionLinks   = get(this, 'versionLinks');
 
+    if ( !versionLinks || !Object.keys(versionLinks).length ) {
+      // If you install a legacy app and then upgrade Rancher,
+      // the versionLinks object can be empty. In that case,
+      // use the current template version.
+
+      versionLinks = [this.templateVersion.version]
+      this.catalogTemplate.versionLinks = { [this.templateVersion.version ]: `/v3/templateVersions/${ this.catalogTemplate.id }-${ this.templateVersion.version }` }
+    }
     if ( defaultVersion && versionLinks && versionLinks[defaultVersion] ) {
       return versionLinks[defaultVersion];
     }


### PR DESCRIPTION
This PR addresses both of these related issues: https://github.com/rancher/dashboard/issues/4627 and https://github.com/rancher/dashboard/issues/4628

Another related issue is https://github.com/rancher/dashboard/issues/4645

This PR makes it so that if you have a legacy multicluster app where the max Rancher version is v2.6.2, then you upgrade Rancher to v2.6.3, then try to upgrade the app, you can at least see the upgrade form now. Previously it was just erroring out.

But now if you make a change to the app template and click upgrade, you get an error from the back end saying the version is incompatible. I think this means the back end needs another change to allow legacy apps to be updated even if their chart version is incompatible with Rancher.

This screenshot shows an app installed in v2.6.2, with the Rancher max version set to v2.6.2, which now still has an upgrade form in v2.6.3rc1:
<img width="1234" alt="Screen Shot 2021-11-25 at 8 38 37 PM" src="https://user-images.githubusercontent.com/20599230/143525563-04b76b35-152c-4d5a-a1db-4b41d6054219.png">

But there is some additional back end work to be done because when you try to upgrade it, the back end doesn't allow it:
<img width="1243" alt="Screen Shot 2021-11-25 at 8 38 22 PM" src="https://user-images.githubusercontent.com/20599230/143525573-484ffdaa-292a-4bf5-ab80-df459a376c21.png">


The PR also makes it so that when you go to find the installed multi-cluster app in Apps & Marketplace, if you go to upgrade it, instead of showing you a broken form, it gives you a link back to the multi-cluster app page with the form that works:
<img width="1274" alt="Screen Shot 2021-11-26 at 3 41 16 PM" src="https://user-images.githubusercontent.com/20599230/143659562-bb8840e9-15c8-4043-8c70-66d5d47210bd.png">
The result is:
<img width="1275" alt="Screen Shot 2021-11-26 at 3 41 28 PM" src="https://user-images.githubusercontent.com/20599230/143659547-fea0c3db-8420-4c96-8756-26dafdea2c25.png">



