### PR TITLE
Ensure we use same catalog filtering in the dropdown

### DIFF
--- a/lib/shared/addon/components/catalog-index/component.js
+++ b/lib/shared/addon/components/catalog-index/component.js
@@ -138,7 +138,7 @@ export default Component.extend({
 
   matchingSearch: computed('inScopeTemplates.@each.{name,description}', 'search', function() {
     const search = (get(this, 'search') || '').toLowerCase();
-    const all = get(this, 'inScopeTemplates');
+    const all = get(this, 'inScopeTemplates').filter((tpl) => Object.keys(get(tpl, 'versionLinks') || {}).length > 0);
 
     if ( !search ) {
       return all;


### PR DESCRIPTION
Addresses https://github.com/rancher/rancher/issues/35670

When we show the charts, we only show those that have versions. In the category dropdown, however, we were not using this same filter, so the counts in the dropdown can be different to what we show.

This PR applies the same filter.