### PR TITLE
Don't fail if we don't get component statuses

### DIFF
--- a/lib/monitoring/addon/components/cluster-dashboard/component.js
+++ b/lib/monitoring/addon/components/cluster-dashboard/component.js
@@ -91,7 +91,7 @@ export default Component.extend(CatalogUpgrade, {
       scheduler:         false,
       controllerManager: false,
     }
-    const componentStatuses = get(this, 'cluster.componentStatuses');
+    const componentStatuses = get(this, 'cluster.componentStatuses') || [];
 
     componentStatuses.forEach((status) => {
       if (status?.conditions?.firstObject?.type === 'Healthy' && status?.conditions?.firstObject?.status) {


### PR DESCRIPTION
Addresses [#4734](https://github.com/rancher/dashboard/issues/4734)

This is a trivial fix for this issue - the `componentStatuses` property of the cluster is undefined and we are not expecting that.

Although this PR fixes the problem in this case, we need to understand why we are no longer getting the component statuses metadata.