### PR TITLE
Hide component statuses when not available

### DIFF
--- a/lib/monitoring/addon/components/cluster-dashboard/component.js
+++ b/lib/monitoring/addon/components/cluster-dashboard/component.js
@@ -108,6 +108,11 @@ export default Component.extend(CatalogUpgrade, {
     return out;
   }),
 
+  // Newer k8s does not have componentStatuses, so hide them all
+  haveComponentStatus: computed('cluster.componentStatuses.@each.{name,conditions}', function() {
+    return !!get(this, 'cluster.componentStatuses');
+  }),
+
   hideEtcdStatus: computed('cluster.clusterProvider', function() {
     const { clusterProvider } = this.cluster;
 

--- a/lib/monitoring/addon/components/cluster-dashboard/template.hbs
+++ b/lib/monitoring/addon/components/cluster-dashboard/template.hbs
@@ -40,63 +40,65 @@
   {{nodes-live nodes=nodes}}
 
   <div class="row mt-0">
-    {{#if (and whichComponentStatusExists.etcd (not hideEtcdStatus))}}
-      {{k8s-component-status
-        label="clusterDashboard.etcd"
-        showUrl=scope.currentCluster.isRKE
-        healthy=etcdHealthy
-        url=grafana.etcdUrl
-      }}
-    {{else}}
-      <div class="col mt-0 span-3">
-        {{#banner-message
-           icon="icon-alert"
-           color="bg-disabled mt-0"
+    {{#if haveComponentStatus}}
+      {{#if (and whichComponentStatusExists.etcd (not hideEtcdStatus))}}
+        {{k8s-component-status
+          label="clusterDashboard.etcd"
+          showUrl=scope.currentCluster.isRKE
+          healthy=etcdHealthy
+          url=grafana.etcdUrl
         }}
-          <p class="text-left">
-            {{t "clusterDashboard.etcdUnavailable"}}
-          </p>
-        {{/banner-message}}
-      </div>
+      {{else}}
+        <div class="col mt-0 span-3">
+          {{#banner-message
+            icon="icon-alert"
+            color="bg-disabled mt-0"
+          }}
+            <p class="text-left">
+              {{t "clusterDashboard.etcdUnavailable"}}
+            </p>
+          {{/banner-message}}
+        </div>
+      {{/if }}
+
+      {{#if whichComponentStatusExists.controllerManager}}
+        {{k8s-component-status
+          label="clusterDashboard.controllerManager"
+          healthy=controllerHealthy
+          url=grafana.controllerUrl
+        }}
+      {{else}}
+        <div class="col mt-0 span-3">
+          {{#banner-message
+            icon="icon-alert"
+            color="bg-disabled mt-0"
+          }}
+            <p class="text-left">
+              {{t "clusterDashboard.controllerManagerUnavailable"}}
+            </p>
+          {{/banner-message}}
+        </div>
+      {{/if}}
+
+      {{#if whichComponentStatusExists.scheduler}}
+        {{k8s-component-status
+          label="clusterDashboard.scheduler"
+          healthy=schedulerHealthy
+          url=grafana.schedulerUrl
+        }}
+      {{else}}
+        <div class="col mt-0 span-3">
+          {{#banner-message
+            icon="icon-alert"
+            color="bg-disabled mt-0"
+          }}
+            <p class="text-left">
+              {{t "clusterDashboard.schedulerUnavailable"}}
+            </p>
+          {{/banner-message}}
+        </div>
+      {{/if}}
     {{/if }}
-
-    {{#if whichComponentStatusExists.controllerManager}}
-      {{k8s-component-status
-        label="clusterDashboard.controllerManager"
-        healthy=controllerHealthy
-        url=grafana.controllerUrl
-      }}
-    {{else}}
-      <div class="col mt-0 span-3">
-        {{#banner-message
-           icon="icon-alert"
-           color="bg-disabled mt-0"
-        }}
-          <p class="text-left">
-            {{t "clusterDashboard.controllerManagerUnavailable"}}
-          </p>
-        {{/banner-message}}
-      </div>
-    {{/if}}
-
-    {{#if whichComponentStatusExists.scheduler}}
-      {{k8s-component-status
-        label="clusterDashboard.scheduler"
-        healthy=schedulerHealthy
-        url=grafana.schedulerUrl
-      }}
-    {{else}}
-      <div class="col mt-0 span-3">
-        {{#banner-message
-           icon="icon-alert"
-           color="bg-disabled mt-0"
-        }}
-          <p class="text-left">
-            {{t "clusterDashboard.schedulerUnavailable"}}
-          </p>
-        {{/banner-message}}
-      </div>
-    {{/if}}
 
     {{k8s-component-status
       label="clusterDashboard.node"


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/4734

Hides the component statuses when not available