### PR TITLE
Shared subnets are shown in dropdown when provisioning GKE clusters

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-gke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/component.js
@@ -686,15 +686,40 @@ export default Component.extend(ClusterDriver, {
         label:  matchedSubnets.length > 0 ? `${ net.name } (subnets available)` : net.name,
       };
     });
-    const sharedSubnets = (get(this, 'sharedSubnets') || []).map((ssn) => {
-      return {
-        ...ssn,
-        group:  'Shared VPC',
-        shared: true,
-        name:   ssn?.network,
-      };
-    })
-    const merged = [...networks, ...sharedSubnets];
+
+    const sharedSubnets = get(this, 'sharedSubnets') || [];
+
+    const dedupeSharedSubnets = () => {
+      // Because the shared network comes in as an array of shared subnetworks,
+      // the network names of the shared networks need to be deduplicated.
+      let alreadyUsedNetworkNames = {};
+      let dedupedSharedSubnets = [];
+
+      for (let i = 0; i < sharedSubnets.length; i++){
+        const ssn = sharedSubnets[i];
+        const networkNamePath = ssn?.network.split('/');
+        const networkLabel = networkNamePath[networkNamePath.length - 1];
+
+        if (alreadyUsedNetworkNames[networkLabel]) {
+          // Avoid adding two entries for the same shared network name
+          continue;
+        }
+
+        alreadyUsedNetworkNames[networkLabel] = ssn;
+
+        dedupedSharedSubnets.push({
+          ...ssn,
+          group:  'Shared VPC',
+          shared: true,
+          name:   ssn?.network,
+          label:  networkLabel
+        });
+      }
+
+      return dedupedSharedSubnets;
+    }
+    const dedupedSharedSubnets = dedupeSharedSubnets(sharedSubnets)
+    const merged = [...networks, ...dedupedSharedSubnets];
 
     return merged;
   }),
@@ -735,9 +760,11 @@ export default Component.extend(ClusterDriver, {
 
       mappedSubnets = sharedVpcs.map((sVpc) => {
         const networkDisplayName = sVpc.network;
+        const subnetworkPath = sVpc.subnetwork.split('/');
+        const subnetworkLabel = subnetworkPath[subnetworkPath.length - 1];
 
         return {
-          label:             `${ sVpc.subnetwork } (${ sVpc.ipCidrRange })`,
+          label:             `${ subnetworkLabel } (${ sVpc.ipCidrRange })`,
           value:             sVpc.subnetwork,
           secondaryIpRanges: sVpc.secondaryIpRanges,
           networkDisplayName

--- a/lib/shared/addon/google/service.js
+++ b/lib/shared/addon/google/service.js
@@ -474,7 +474,6 @@ export default Service.extend({
       //     'subnetwork': 'projects/vpc-host-309518/regions/us-west1/subnetworks/vpc-host-subnet'
       //   }
       // ];
-
       return out;
     } catch (error) {
       return reject([error.body.error ?? error.body]);

--- a/lib/shared/addon/google/service.js
+++ b/lib/shared/addon/google/service.js
@@ -455,6 +455,7 @@ export default Service.extend({
     try {
       const xhr = await this.request(neuURL, 'GET');
       const out = xhr?.body?.subnetworks || [];
+
       // const out = [
       //   {
       //     'ipCidrRange':       '10.1.0.0/24',


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4763 by adding a `label` property to the shared subnet data, which is required in order for the items to display properly in the dropdown.

I didn't get access to a shared VPC, so in order to test this PR, I mocked the data - Colleen provided JSON output for the list of shared subnets and I added the output to `lib/shared/addon/google/service.js`. So during testing I changed to the async method `fetchSharedSubnets` to:

```
async fetchSharedSubnets(cluster, saved = false) {
    if (saved) {
      return;
    }
    const config = get(cluster, 'gkeConfig');
    const neuConfig = { ...config };

    delete neuConfig?.zone;
    delete neuConfig?.region;

    const neuURL = this.parseRequestData('/meta/gkeSharedSubnets', neuConfig, cluster?.id);

    try {
      const xhr = await this.request(neuURL, 'GET');
      // const out = xhr?.body?.subnetworks || [];
      // return out;
      return [
        {
          'ipCidrRange': '10.3.0.0/24',
          'network':     'projects/host-project-309915/global/networks/host-shared-vpc',
          'subnetwork':  'projects/host-project-309915/regions/us-west1/subnetworks/host-shared-vpc-us-west1-subnet-public'
        },
        {
          'ipCidrRange': '10.4.0.0/24',
          'network':     'projects/host-project-309915/global/networks/host-shared-vpc',
          'subnetwork':  'projects/host-project-309915/regions/us-west1/subnetworks/host-shared-vpc-us-west1-subnet-private'
        },
        {
          'ipCidrRange':       '10.2.0.0/24',
          'network':           'projects/host-project-309915/global/networks/host-shared-vpc',
          'secondaryIpRanges': [
            {
              'ipCidrRange': '10.7.0.0/21',
              'rangeName':   'pods',
              'status':      'UNUSED'
            },
            {
              'ipCidrRange': '10.8.0.0/21',
              'rangeName':   'services',
              'status':      'UNUSED'
            }
          ],
          'subnetwork': 'projects/host-project-309915/regions/us-east1/subnetworks/host-shared-vpc-us-east1-subnet-private'
        },
        {
          'ipCidrRange':       '10.1.0.0/24',
          'network':           'projects/host-project-309915/global/networks/host-shared-vpc',
          'secondaryIpRanges': [
            {
              'ipCidrRange': '10.5.0.0/21',
              'rangeName':   'pods',
              'status':      'UNUSED'
            },
            {
              'ipCidrRange': '10.6.0.0/21',
              'rangeName':   'services',
              'status':      'UNUSED'
            }
          ],
          'subnetwork': 'projects/host-project-309915/regions/us-east1/subnetworks/host-shared-vpc-us-east1-subnet-public'
        }
      ]
    } catch (error) {
      return reject([error.body.error ?? error.body]);
    }
  },
```

Then to test it, I opened the GKE cluster provisioning form and confirmed that the shared subnets were displayed properly:
<img width="706" alt="Screen Shot 2021-12-14 at 2 06 24 PM" src="https://user-images.githubusercontent.com/20599230/146080173-3ef8ab72-c941-4d20-87d0-7e5af98d1748.png">

But then I saw that although adding the `label` populated the dropdown, it wasn't enough to fully fix it, because then all the network options were the same, which is a bug that has existed since v2.5.8.

So I also did some cleanup to make it so that there is only one (deduplicated) `Network` option for each shared network, and then when that is selected, you can see the subnet options under `Node Subnet`:
<img width="1424" alt="Screen Shot 2021-12-14 at 5 15 55 PM" src="https://user-images.githubusercontent.com/20599230/146100417-caa47cf1-14f6-4483-a7e6-451ebfdf54f4.png">
<img width="1552" alt="Screen Shot 2021-12-14 at 5 16 13 PM" src="https://user-images.githubusercontent.com/20599230/146100407-02a43782-fcf3-4d72-90d1-40dca8d11d87.png">



For reference, Colleen provided these screenshots that show how it used to look in v2.5.8 for one shared subnetwork:
![image (6)](https://user-images.githubusercontent.com/20599230/146100529-2747052e-26eb-4099-a8b9-a34b34c91568.png)
![image (5)](https://user-images.githubusercontent.com/20599230/146100537-eb545248-134b-4fcb-91d9-904a238f3568.png)

