### PR TITLE
Use currentVersion parameter to upgrade legacy apps

### DIFF
--- a/app/catalog-tab/launch/route.js
+++ b/app/catalog-tab/launch/route.js
@@ -21,18 +21,29 @@ export default Route.extend({
   model(params, transition) {
     const { store, clusterStore } = this;
 
-    const dependencies = {
-      tpl:        get(this, 'catalog').fetchTemplate(params.template),
-      namespaces: clusterStore.findAll('namespace')
-    };
-
-    if ( params.upgrade ) {
-      dependencies.upgrade = get(this, 'catalog').fetchTemplate(`${ params.template }-${ params.upgrade }`, true);
-    }
+    let dependencies = { namespaces: clusterStore.findAll('namespace') };
 
     if (params.appId) {
       dependencies.app = store.find('app', params.appId);
+      dependencies.app.then((appData) => {
+        const getCurrentVersion = (app) => {
+          const externalId = app.externalId;
+          const splitId = externalId.split('version=')
+          const currentVersion = splitId[1];
+
+          return currentVersion;
+        }
+        const currentVersion = getCurrentVersion(appData);
+
+        dependencies.upgrade = get(this, 'catalog').fetchTemplate(`${ params.template }-${ params.upgrade }`, true, currentVersion);
+        dependencies.tpl = get(this, 'catalog').fetchTemplate(params.template, false, currentVersion);
+      })
+        .catch((err) => {
+          throw new Error(err);
+        })
     }
+
+
     if (params.appName) {
       dependencies.app = store.find('app', null, { filter: { name: params.appName } }).then((apps) => get(apps, 'firstObject'));
     }

--- a/app/models/app.js
+++ b/app/models/app.js
@@ -216,14 +216,16 @@ const App = Resource.extend(StateCounts, EndpointPorts, {
       const catalogId     = get(this, 'externalIdInfo.catalog');
       const vKeys         = Object.keys(get(this, 'catalogTemplate.versionLinks'));
       const latestVersion =  vKeys[vKeys.length - 1];
+      const currentVersion = get(this, 'externalIdInfo.version')
 
       get(this, 'router').transitionTo('catalog-tab.launch', templateId, {
         queryParams: {
-          appId:       get(this, 'id'),
-          catalog:     catalogId,
-          namespaceId: get(this, 'targetNamespace'),
-          upgrade:     latestVersion,
-          istio:       get(this, 'isIstio')
+          appId:        get(this, 'id'),
+          catalog:      catalogId,
+          namespaceId:  get(this, 'targetNamespace'),
+          upgrade:      latestVersion,
+          istio:        get(this, 'isIstio'),
+          currentVersion
         }
       });
     },

--- a/lib/shared/addon/catalog/service.js
+++ b/lib/shared/addon/catalog/service.js
@@ -67,7 +67,7 @@ export default Service.extend({
       let extInfo = parseHelmExternalId(app.get('externalId'));
 
       if ( extInfo && extInfo.templateId ) {
-        deps.push(this.fetchTemplate(extInfo.templateId, false));
+        deps.push(this.fetchTemplate(extInfo.templateId, false, extInfo.version));
       }
     });
 
@@ -81,7 +81,7 @@ export default Service.extend({
       let extInfo = get(app, 'externalIdInfo');
 
       if ( extInfo && extInfo.templateId ) {
-        deps.push(this.fetchTemplate(extInfo.templateId, false));
+        deps.push(this.fetchTemplate(extInfo.templateId, false, extInfo.version));
       }
     });
 
@@ -108,8 +108,9 @@ export default Service.extend({
     return get(this, 'globalStore').getById('templateversion', id);
   },
 
-  fetchTemplate(id, upgrade = false) {
+  fetchTemplate(id, upgrade = false, currentVersion) {
     let type, cached, params;
+    const clusterName = get(this, 'scope.currentCluster.id');
 
     if ( upgrade === true ) {
       type = 'templateversions';
@@ -117,11 +118,22 @@ export default Service.extend({
     } else {
       type = 'templates';
       // we cant check for cached here anylonger because the clusterName is used to build a dynamic versions list of compatible versions for this clusters kube version
-      params = { clusterName: get(this, 'scope.currentCluster.id') };
+      params = {
+        clusterName,
+        currentVersion
+      };
     }
 
     if ( cached ) {
       return resolve(cached);
+    }
+
+    params = {
+      // currentVersion allows legacy apps to be upgraded
+      // after Rancher is upgraded to a version higher than the app's max
+      // supported Rancher version
+      clusterName,
+      currentVersion,
     }
 
     let url = this._addLimits(`${ get(this, 'app.apiEndpoint') }/${ type }/${ id }`, params);


### PR DESCRIPTION
This PR partly addresses https://github.com/rancher/dashboard/issues/4774 by using the `currentVersion` parameter when requesting template details in the form to upgrade a legacy app.

The currentVersion parameter takes advantage of this fix https://github.com/rancher/rancher/issues/35680 which made it so that the available `versionLinks` are not empty when you try to upgrade a legacy app after upgrading Rancher to a version that is no longer supported by the legacy app.

To test this PR,

1. In Rancher v2.6.2, I enabled the legacy feature flag and installed legacy apps in the local `system` project.
2. I upgraded Rancher to v2.6.3-rc5 (because v2.6-head is considered prior to v2.6.0 for version compatibility)
3. I went to the legacy apps in the system project and tried to upgrade them
4. I confirmed that the form rendered successfully.
<img width="800" alt="Screen Shot 2021-12-16 at 12 23 38 AM" src="https://user-images.githubusercontent.com/20599230/146329601-0b01058c-4b1c-476d-a1c8-78ea966c95a7.png">

<img width="1274" alt="Screen Shot 2021-12-16 at 12 48 55 AM" src="https://user-images.githubusercontent.com/20599230/146329713-bef5d0c1-9481-4d10-8538-ac6f26185216.png">


Caveats

Previously, when trying to solve the problem of the form not rendering when `versionLinks` was empty, I created a PR https://github.com/rancher/ui/pull/4783 that replaced `versionLinks` with an object containing the current app version, assuming the current version was valid. This was not an ideal solution because the current app version on the front end was not guaranteed to be valid on the back end. It was also not a complete solution because even though adding the current version to `versionLinks` was enough to make the form render, the result of actually submitting the form was a back end validation error because the back end indicated the version was incompatible, even when the upgrade contained minor changes that did not involve changing the app version.

This PR is also incomplete for the same reason, in that the back end still blocks form submission:

```
Validation failed in API: incompatible kubernetes version [1.21.7+k3s1] for template [system-library-rancher-logging-0.3.0]
```
<img width="1456" alt="Screen Shot 2021-12-16 at 12 23 22 AM" src="https://user-images.githubusercontent.com/20599230/146330706-ea3f3739-632a-4c0b-8196-8ba72c78cbf7.png">

There still needs to be work done for the back end to allow the change. The failing upgrade request is to:

```
<server URL>/v3/project/local:p-gw9l2/apps/p-gw9l2:rancher-logging?action=upgrade
```

and the request payload is:

```
{"externalId":"catalog://?catalog=system-library&template=rancher-logging&version=0.3.0",
"answers":{"fluentd.cluster.dockerRoot":"/var/lib/docker","fluentd.enabled":"true","fluentd.fluentd-linux.cluster.dockerRoot":"/var/lib/docker","fluentd.fluentd-linux.enabled":"true","fluentd.fluentd-windows.enabled":"false","log-aggregator.enabled":"true","log-aggregator.flexVolumeDir":"/usr/libexec/kubernetes/kubelet-plugins/volume/exec","log-aggregator.log-aggregator-linux.enabled":"true","log-aggregator.log-aggregator-linux.flexVolumeDir":"/usr/libexec/kubernetes/kubelet-plugins/volume/exec"},
"valuesYaml":"",
"forceUpgrade":false}
```

Technically the back end already has the current app version because it is in the `externalId` in the request payload. I believe will still need to change to allow that request to go through.