### PR TITLE
Display "(experimental)" if version is not in supported range

### DIFF
--- a/lib/shared/addon/components/managed-import-cluster-info/component.js
+++ b/lib/shared/addon/components/managed-import-cluster-info/component.js
@@ -12,7 +12,6 @@ export default Component.extend({
   settings:        service(),
   releaseVersions: service(),
   intl:            service(),
-  globalStore:     service(),
 
   layout,
 

--- a/lib/shared/addon/components/managed-import-cluster-info/component.js
+++ b/lib/shared/addon/components/managed-import-cluster-info/component.js
@@ -3,16 +3,23 @@ import layout from './template';
 import { inject as service } from '@ember/service';
 import { computed, get, set } from '@ember/object';
 import Semver from 'semver';
+import { satisfies } from 'shared/utils/parse-version';
 import { sortVersions } from 'shared/utils/sort';
+import C from 'shared/utils/constants';
+import { alias } from '@ember/object/computed';
 
 export default Component.extend({
+  settings:        service(),
   releaseVersions: service(),
   intl:            service(),
+  globalStore:     service(),
 
   layout,
 
   editing:     false,
   configField: 'k3sConfig',
+
+  supportedK8sVersionRange: alias(`settings.${ C.SETTING.VERSION_K8S_SUPPORTED_RANGE }`),
 
   config: computed('cluster.{k3sConfig,rke2Config}', 'configField', function() {
     return get(this, `cluster.${ this.configField }`);
@@ -61,7 +68,7 @@ export default Component.extend({
     }
   }),
 
-  allVersions: computed('releaseVersions.allVersions.[]', function() {
+  allVersions: computed('releaseVersions.allVersions.[]', 'supportedK8sVersionRange', function() {
     const currentVersion = get(this, `config.kubernetesVersion`);
     const versionsMapped = [];
     let allVersions    = this.releaseVersions.allVersions || [];
@@ -73,10 +80,16 @@ export default Component.extend({
     allVersions = [...sortVersions(allVersions).reverse()];
 
     allVersions.forEach((v) => {
+      let experimental = false
+
+      if (this.supportedK8sVersionRange) {
+        experimental = !satisfies(v, this.supportedK8sVersionRange);
+      }
+
       if (Semver.gte(v, currentVersion)) {
         versionsMapped.pushObject({
           value: v,
-          label: v,
+          label: `${ v } ${ experimental ? this.intl.t('generic.experimental') : '' }`,
         });
       }
     });


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->
This adds `(experimental)' to labels that fall outside of the k8s supported version range for the in the Kubernetes Version dropdown. At this time of writing, K3S v1.22 and above should be marked as experimental, but this flag was not showing when attempting to edit an imported cluster. 

Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->
Bugfix

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 
rancher/dashboard#4787

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->

I took some time to search for K3S appropriate version ranges, but did not find any associated settings that already existed. There were some potential leads in `lib/shared/addon/release-versions/service.js` and `server/proxies/api.js`, but I didn't see any associated settings being set anywhere.. Opted to stick with the supported k8s versions as a result.
