### PR TITLE
Catalog app route only uses current version when necessary

### DIFF
--- a/app/catalog-tab/launch/route.js
+++ b/app/catalog-tab/launch/route.js
@@ -35,12 +35,19 @@ export default Route.extend({
         }
         const currentVersion = getCurrentVersion(appData);
 
+        // If an app ID is given, the current app version will be used in the app launch route.
         dependencies.upgrade = get(this, 'catalog').fetchTemplate(`${ params.template }-${ params.upgrade }`, true, currentVersion);
         dependencies.tpl = get(this, 'catalog').fetchTemplate(params.template, false, currentVersion);
       })
         .catch((err) => {
           throw new Error(err);
         })
+    } else {
+      // If an app ID is not given, the current app version will not be used in the app launch route.
+      if (params.upgrade) {
+        dependencies.upgrade = get(this, 'catalog').fetchTemplate(`${ params.template }-${ params.upgrade }`, true);
+      }
+      dependencies.tpl = get(this, 'catalog').fetchTemplate(params.template);
     }
 
 


### PR DESCRIPTION
This PR addresses https://github.com/rancher/rancher/issues/35907 by making it so that the UI only tries to use the current app version in the routes for the app install/upgrade form if the app is already installed.

To test this PR,

1. I installed Rancher v2.6.3-rc7
2. Enabled the legacy feature flag
3. Deployed a downstream RKE2 cluster
4. Opened Ember by going to `<serverURL>/g/clusters`
5. Clicked the new RKE2 cluster name
6. Clicked **Projects/Namespaces**
7. Clicked **Project: System**
8. Clicked **Launch** and verified that the form rendered successfully
9. Clicked **longhorn** and installed it
10. Changed a value in the **longhorn** upgrade form and it upgraded successfully