### PR TITLE
Can upgrade legacy multi-cluster apps

### DIFF
--- a/lib/global-admin/addon/multi-cluster-apps/catalog/launch/route.js
+++ b/lib/global-admin/addon/multi-cluster-apps/catalog/launch/route.js
@@ -19,17 +19,40 @@ export default Route.extend({
     var store = get(this, 'globalStore');
 
     var dependencies = {
-      tpl:        get(this, 'catalog').fetchTemplate(params.template),
       projects:   this.scope.getAllProjects(),
       clusters:   this.scope.getAllClusters(),
     };
 
-    if ( params.upgrade ) {
-      dependencies.upgrade = get(this, 'catalog').fetchTemplate(`${ params.template }-${ params.upgrade }`, true);
-    }
+
 
     if (params.appId) {
       dependencies.app = store.find('multiclusterapp', params.appId);
+      dependencies.app.then((appData) => {
+        const getCurrentVersion = (app) => {
+          const templateVersionId = app.templateVersionId;
+          const splitId = templateVersionId.split('-');
+          const currentVersion = splitId[splitId.length - 1];
+
+          return currentVersion;
+        }
+        const currentVersion = getCurrentVersion(appData);
+
+        // If an app ID is given, the current app version will be used in the
+        // multi-cluster app launch route.
+        dependencies.upgrade = get(this, 'catalog').fetchTemplate(`${ params.template }-${ params.upgrade }`, true, currentVersion);
+
+        dependencies.tpl = get(this, 'catalog').fetchTemplate(params.template, false, currentVersion);
+      })
+        .catch((err) => {
+          throw new Error(err);
+        })
+    } else {
+      // If an app ID is not given, the current app version will not be used
+      // in the multi-cluster app launch route.
+      if ( params.upgrade ) {
+        dependencies.upgrade = get(this, 'catalog').fetchTemplate(`${ params.template }-${ params.upgrade }`, true);
+      }
+      dependencies.tpl = get(this, 'catalog').fetchTemplate(params.template)
     }
 
     return hash(dependencies, 'Load dependencies').then((results) => {


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4774 by making it so that the currentVersion parameter is used when fetching the template details for multi-cluster apps.

The changes are nearly identical to the ones around here https://github.com/rancher/ui/pull/4794 and here https://github.com/rancher/ui/pull/4791 for adding the currentVersion parameter to the legacy app upgrade route. The only difference is that it's in a different file and the app id is taken from `templateVersionId` instead of `externalId`

To test this PR, 

1. I installed Rancher v2.6.2
2. Enabled the legacy feature flag
3. Installed multi-cluster apps
4. Upgraded Rancher to v2.6.3-rc8
5. Upgraded the multi-cluster apps successfully
6. Also verified that the change did not break the ability to install new multi-cluster apps
<img width="1342" alt="Screen Shot 2021-12-17 at 10 09 18 PM" src="https://user-images.githubusercontent.com/20599230/146630012-a122354b-8cb6-4b7a-8647-0f78b6d44947.png">
<img width="1321" alt="Screen Shot 2021-12-17 at 10 09 27 PM" src="https://user-images.githubusercontent.com/20599230/146630015-e0cc7c46-31d9-4fe2-b605-91d78b38183e.png">

