### PR TITLE
Clarify that GKE maintenance window time is UTC

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3939,7 +3939,7 @@ clusterNew:
       label: Machine Type
       prompt: Choose a Type...
     maintenanceWindow:
-      label: Maintenance Window
+      label: Maintenance Window - UTC
     masterAuthPassword:
       label: Master Endpoint Password
       placeholder: Your Master Endpoint Password


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4894 by changing the label for the maintenance window dropdown in the GKE cluster provisioning form.

To test this PR,

1. I created Google cloud credentials
2. Went to cluster manager and opened the form to create a GKE cluster
3. Used the `rancher-qa` project ID and Google cloud credentials to get farther down in the form
4. In the Additional Options section, confirmed that the label for the maintenance window is now **Maintenance Window - UTC**
<img width="663" alt="Screen Shot 2022-01-11 at 10 16 44 PM" src="https://user-images.githubusercontent.com/20599230/149068740-d1afa420-047b-416c-91f5-5a90f7e3298f.png">

