### PR TITLE
Fix vSphere content library creation type and minor visual issues

### DIFF
--- a/app/styles/components/_searchable-select.scss
+++ b/app/styles/components/_searchable-select.scss
@@ -111,4 +111,9 @@
       font-size: 1.8em;
       line-height: 1.5;
   }
+
+  input {
+    padding: 10px;
+    border-radius: 4px;
+  }
 }

--- a/lib/nodes/addon/components/driver-vmwarevsphere/component.js
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/component.js
@@ -312,7 +312,7 @@ export default Component.extend(NodeDriver, {
     return content;
   }),
 
-  contentLibraryContent: computed('config.{contentLibrary,datacenter}', 'model.cloudCredentialId', async function() {
+  contentLibraryContent: computed('config.{creationType,datacenter}', 'model.cloudCredentialId', async function() {
     const options = await this.requestOptions(
       'content-libraries',
       get(this, 'model.cloudCredentialId'),
@@ -325,7 +325,7 @@ export default Component.extend(NodeDriver, {
     return content;
   }),
 
-  libraryTemplateContent: computed('config.contentLibrary', 'model.cloudCredentialId', async function() {
+  libraryTemplateContent: computed('config.{contentLibrary,datacenter}', 'model.cloudCredentialId', async function() {
     const contentLibrary = get(this, 'config.contentLibrary');
 
     if (!contentLibrary) {
@@ -335,7 +335,7 @@ export default Component.extend(NodeDriver, {
     const options = await this.requestOptions(
       'library-templates',
       get(this, 'model.cloudCredentialId'),
-      undefined,
+      get(this, 'config.datacenter'),
       contentLibrary
     );
 


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
- The content library library templates weren't being requested because the data center wasn't being passed.
- Made searchable select look the same as new select.
- Made it so content library contents didn't get updated when the content library was selected



Types of changes
======
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
rancher/dashboard#4302

![vsphere-content-library](https://user-images.githubusercontent.com/55104481/149587200-af41b10e-0fa9-4f80-8673-00db3e019378.gif)


