### PR TITLE
Only show latest minor K8s version when editing K3s cluster

### DIFF
--- a/lib/shared/addon/components/managed-import-cluster-info/component.js
+++ b/lib/shared/addon/components/managed-import-cluster-info/component.js
@@ -68,7 +68,7 @@ export default Component.extend({
   }),
 
   allVersions: computed('releaseVersions.allVersions.[]', 'supportedK8sVersionRange', function() {
-    const currentVersion = get(this, `config.kubernetesVersion`);
+    let currentVersion = get(this, `config.kubernetesVersion`);
     const versionsMapped = [];
     let allVersions    = this.releaseVersions.allVersions || [];
 
@@ -93,7 +93,40 @@ export default Component.extend({
       }
     });
 
-    return versionsMapped;
+    const includeOnlyLatestMinorVersions = () => {
+      let result = []
+      let minorVersions = {}
+
+      for (let i = 0; i < versionsMapped.length; i++) {
+        const version = versionsMapped[i].value;
+        const versionPieces = version.split('.')
+        const minorVersion = versionPieces[0] + versionPieces[1];
+
+        if (!minorVersions[minorVersion] || minorVersions[minorVersion].value < version) {
+          minorVersions[minorVersion] = versionsMapped[i];
+        }
+      }
+      for (const minorVersion in minorVersions) {
+        // Don't add the version if it would
+        // duplicate the current version
+        if (minorVersions[minorVersion].value !== currentVersion) {
+          result.push(minorVersions[minorVersion])
+        }
+      }
+
+      // Always include the current version so that
+      // it shows as the default value in the form
+      result.push({
+        label: currentVersion,
+        value: currentVersion
+      });
+
+      return result;
+    }
+
+    const onlyLatestMinorVersions = includeOnlyLatestMinorVersions();
+
+    return onlyLatestMinorVersions;
   }),
 
   coerceToInt(value) {


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4543 by making it so that only the latest version (i.e., only one 1.21.x version, and only one 1.22.x version etc) are shown as options when editing K3s clusters.

Nancy already did this PR https://github.com/rancher/dashboard/pull/4154 which limits the versions when editing K3s clusters in the dashboard UI. However, this PR needed to make the same change to Ember. When you edit a K3s cluster, you are shown either the dashboad OR the Ember UI depending on whether the cluster was imported into Rancher or provisioned by Rancher. If you provisioned the K3s cluster in Rancher, you would see the new RKE2/K3s dashboard edit form. However, if you import a K3s cluster into Rancher, you will see the error reported in the above linked issue. Vince said the reason we still use Ember for editing imported K3s clusters is because there are some extra capabilities for imported K3s clusters that have not been forward ported to the dashboard UI.

To test this PR, 

1. I set up a node on Digital Ocean
2. I installed K3s on the node by running:

```
curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.20.13-rc2+k3s2" sh -
```
I intentionally used an older version so that more version options would be displayed when editing the cluster.
3. I imported the cluster into Rancher
4. From Cluster Manager, I went to the imported cluster and clicked Edit Config
5. I confirmed that the current Kubernetes version was shown in the K8s dropdown by default, and the other choices were limited to one for each K3s minor version
<img width="729" alt="Screen Shot 2022-01-24 at 4 31 38 PM" src="https://user-images.githubusercontent.com/20599230/150883411-4c3e9d72-64fe-4531-b5fb-6ddca19cc573.png">

<img width="714" alt="Screen Shot 2022-01-24 at 4 31 44 PM" src="https://user-images.githubusercontent.com/20599230/150883381-99d5bee6-c3db-47bb-a5a5-575c2263cadd.png">

