### PR TITLE
Can enable project network isolation for imported clusters

### DIFF
--- a/app/styles/components/_accordion.scss
+++ b/app/styles/components/_accordion.scss
@@ -98,3 +98,7 @@ $acc-label              : $text-muted !default;
     display: inline-block;
   }
 }
+
+.reservedSpaceForBanner {
+  height: 80px;
+}

--- a/lib/shared/addon/components/managed-import-cluster-info/component.js
+++ b/lib/shared/addon/components/managed-import-cluster-info/component.js
@@ -43,6 +43,17 @@ export default Component.extend({
     return get(this.config, upgradeStrategyPath);
   }),
 
+  enableNetworkPolicy: computed('config', 'configField', {
+    get() {
+      return !!get(this.config, 'enableNetworkPolicy');
+    },
+    set(key, value) {
+      set(this, 'cluster.enableNetworkPolicy', value);
+
+      return value;
+    }
+  }),
+
   serverConcurrency: computed('upgradeStrategy.serverConcurrency', {
     get() {
       return get(this, 'upgradeStrategy.serverConcurrency');

--- a/lib/shared/addon/components/managed-import-cluster-info/template.hbs
+++ b/lib/shared/addon/components/managed-import-cluster-info/template.hbs
@@ -87,12 +87,48 @@
     </div>
   </div>
 </div>
-{{#if showAce}}
-  <AuthorizedEndpoint
-    @mode={{mode}}
-    @cluster={{cluster}}
-    @clusterTemplateCreate={{clusterTemplateCreate}}
-    @clusterTemplateRevision={{model.clusterTemplateRevision}}
-    @applyClusterTemplate={{applyClusterTemplate}}
-  />
-{{/if}}
+<div class="row">
+  <div class="col span-6">
+  {{#if showAce}}
+    <AuthorizedEndpoint
+      @mode={{mode}}
+      @cluster={{cluster}}
+      @clusterTemplateCreate={{clusterTemplateCreate}}
+      @clusterTemplateRevision={{model.clusterTemplateRevision}}
+      @applyClusterTemplate={{applyClusterTemplate}}
+    />
+  {{/if}}
+  </div>
+  <div class="col span-6">
+
+    {{#input-or-display
+      editable=(not-eq mode "view")
+      value=config.enableNetworkPolicy
+    }}
+      <label class="acc-label">
+        {{t "clusterNew.rke.networkPolicy.label"}}
+      </label>
+      <div class="radio">
+        <label>
+          {{radio-button selection=enableNetworkPolicy value=true}}
+          {{t "generic.enabled"}}
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          {{radio-button selection=enableNetworkPolicy value=false}}
+          {{t "generic.disabled"}}
+        </label>
+      </div>
+      <div class="reservedSpaceForBanner">
+        {{#if enableNetworkPolicy}}
+          <BannerMessage
+            @icon="icon-alert"
+            @color="bg-warning mt-0"
+            @message={{t "clusterNew.import.clusterOptions.warning"}}
+          />
+        {{/if}}
+      </div>
+    {{/input-or-display}}
+  </div>
+</div>


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4574 by adding radio buttons to allow enabling project network isolation for imported clusters.

<img width="1419" alt="Screen Shot 2022-02-24 at 3 04 05 PM" src="https://user-images.githubusercontent.com/20599230/155615277-f6a0e43e-55c2-4f5c-84e6-796b60abc533.png">


Currently this input is going to always be displayed because for imported clusters, we don't know if the cluster has a CNI that supports project network isolation. (Ryan Sanna to confirm.)

When PNI is enabled, we show the same warning that is used when the option is enabled for RKE1 clusters:
<img width="738" alt="Screen Shot 2022-02-24 at 2 44 42 PM" src="https://user-images.githubusercontent.com/20599230/155613023-bf75d356-58a6-4a7b-9e82-3435a00477c4.png">

## Testing

To test this PR,

1. I imported a K3s cluster (I tested the same steps on both K3s and RKE2 clusters)
2. In Cluster Management, I went to the imported cluster and clicked Edit Config
3. Went to Project Network Isolation and clicked Enabled
4. Clicked Save

Verified that for both K3s and RKE2, `enabledNetworkPolicy` was set to true in the cluster data in the network request
<img width="762" alt="Screen Shot 2022-02-24 at 5 20 47 PM" src="https://user-images.githubusercontent.com/20599230/155630161-6e964619-512d-4d9b-95d0-9825d1ba1ae9.png">

## Outstanding Questions

Which Kubernetes distro(s) do we want to support? On both K3s and RKE2 clusters, when you save the changes, you get the API error that says it is not a valid option to set `enableNetworkPolicy` to true:
<img width="1297" alt="Screen Shot 2022-02-24 at 5 20 09 PM" src="https://user-images.githubusercontent.com/20599230/155630362-22644f3b-fdb6-45c3-8b4b-8de2f7025c41.png">

Also, Cody noticed that the form for K3s clusters already exposes an option for enabling PNI under advanced options, even though the API throws the above error if you enable it. Should this option be exposed under Advanced Options for both K3s and RKE2? Currently the form for RKE2 doesn't have an advanced options section.

Here are the existing advanced options for imported K3s clusters:
<img width="1424" alt="Screen Shot 2022-02-24 at 4 36 31 PM" src="https://user-images.githubusercontent.com/20599230/155630590-cafdc729-96b8-47e5-a5fc-8da802dac657.png">

