### PR TITLE
Fix issue where we keep adding a % char to the maxWorkersUnavailable field

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -1139,6 +1139,12 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
           cluster.clearProvidersExcept(field);
         }
       }
+    } else {
+      // If validation fails, we stay on the form, so we need to undo the formatting of the max unavailable worker
+      // otherwise we keep adding a '%' to the input field
+      const maxUnavailableWorker = get(this, 'upgradeStrategy.maxUnavailableWorker');
+
+      set(this, 'upgradeStrategy.maxUnavailableWorker', maxUnavailableWorker.replace('%', ''));    
     }
 
     return ok;

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -1144,7 +1144,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       // otherwise we keep adding a '%' to the input field
       const maxUnavailableWorker = get(this, 'upgradeStrategy.maxUnavailableWorker');
 
-      set(this, 'upgradeStrategy.maxUnavailableWorker', maxUnavailableWorker.replace('%', ''));    
+      set(this, 'upgradeStrategy.maxUnavailableWorker', maxUnavailableWorker.replace('%', ''));
     }
 
     return ok;


### PR DESCRIPTION
Addresses: https://github.com/rancher/dashboard/issues/4870

Previously had fixed one issue - PR: https://github.com/rancher/ui/pull/4799/files

This fixed the reported issue when using an RKE template.

There is also another issue (which was why issue 4870 was re-opened) that occurs when not using an RKE template - we format the value and add a % when saving the form - if the validation fails, we don't undo that, so we end up adding a % to the value in the input box and this keeps getting added with each save.

This PR adds code to remove the % is the form validation fails.