### PR TITLE
fix version sorting util and imported cluster upgrade versions listed

### DIFF
--- a/lib/shared/addon/components/managed-import-cluster-info/component.js
+++ b/lib/shared/addon/components/managed-import-cluster-info/component.js
@@ -7,6 +7,7 @@ import { satisfies } from 'shared/utils/parse-version';
 import { sortVersions } from 'shared/utils/sort';
 import C from 'shared/utils/constants';
 import { alias } from '@ember/object/computed';
+import { compare } from 'shared/utils/parse-version';
 
 export default Component.extend({
   settings:        service(),
@@ -102,7 +103,7 @@ export default Component.extend({
         const versionPieces = version.split('.')
         const minorVersion = versionPieces[0] + versionPieces[1];
 
-        if (!minorVersions[minorVersion] || minorVersions[minorVersion].value < version) {
+        if (!minorVersions[minorVersion] || compare(minorVersions[minorVersion].value, version) < 0) {
           minorVersions[minorVersion] = versionsMapped[i];
         }
       }

--- a/lib/shared/addon/utils/parse-version.js
+++ b/lib/shared/addon/utils/parse-version.js
@@ -78,7 +78,7 @@ export function parse(str) {
     str = str.substr(1);
   }
 
-  let parts = str.split(/[.-]/);
+  let parts = str.split(/[.+-]/);
 
   return parts;
 }


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/5257
This issue impacts an Ember page iFramed into the dashboard. There are two parts: fixing the version comparison function and ensuring we use that function to compare versions in the `includeOnlyLatestMinorVersions` filter. The `compare` function wasn't parsing build versions (separated with `+`). Note the difference in the [dashboard code](https://github.com/rancher/dashboard/blob/master/utils/version.js#L14)

The dashboard ticket includes repro steps, but to clarify: 

> To Reproduce
...
>2. Point KDM to dev-v2.6

This will already be correct if your local cluster is a dev version eg you installed v2.6-head. If not, you'll need to change the rke metadata config global setting: 
```
{
  "refresh-interval-minutes": "1440",
  "url": "https://releases.rancher.com/kontainer-driver-metadata/dev-v2.6/data.json"
}
```
To refresh version options after updating that setting, navigate from the Ember global view to Tools>Drivers, and click the 'Refresh Kubernetes Metadata' button in the upper right.