### PR TITLE
Set max-width to the form to avoid overflow of their own components

### DIFF
--- a/app/styles/components/_forms.scss
+++ b/app/styles/components/_forms.scss
@@ -46,6 +46,7 @@ select {
 form {
     display: block;
     position: relative;
+    max-width: 100vw;
 }
 
 label {


### PR DESCRIPTION
#5414

Prevented `form` content to overflow in some cases by setting max width, e.g. RKE1 Node Template cloud-config field for Sphere.

![Screenshot from 2022-03-16 19-10-41](https://user-images.githubusercontent.com/5009481/158658579-8a41fe8a-71ff-492f-a39b-a515dc46519e.png)
