### PR TITLE
Use existing cluster config as defaults for RKE template clusters

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -1654,12 +1654,13 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
   },
 
   initClusterTemplateQuestions() {
-    let {
-      clusterTemplateQuestions,
-      primaryResource,
-    } = this;
+    let { clusterTemplateQuestions } = this;
 
-    if (clusterTemplateQuestions && clusterTemplateQuestions.length > 0) {
+    // Use the existing cluster config values as defaults for the questions
+    // because one or more values could already be overridden.
+    let primaryResource = get(this, 'config');
+
+    if (clusterTemplateQuestions && clusterTemplateQuestions.length > 0 && primaryResource) {
       clusterTemplateQuestions.forEach((question) => {
         let path = question.variable;
 


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/5032 by making it so that if you create a cluster from an RKE template and override some values, the next time you edit the form, your own values are used as the defaults instead of the defaults for provisioning a new cluster.

To test this PR:

1. I created an RKE template and set the 'Node Port Range' to `30000-32767`. Set 'Allow user override' for the Node Port Range.
2. Created an RKE1 cluster from the RKE template. Overrode the value for node port range and set it to `30000-31000`.
3. In cluster manager, went to the new cluster and clicked **Edit Config.**
4. Confirmed that my override value - `30000-31000` - was shown as the default instead of the default value from the RKE template.
<img width="1321" alt="Screen Shot 2022-03-16 at 5 07 34 PM" src="https://user-images.githubusercontent.com/20599230/158713005-6380cd07-6bd2-4137-8352-40108b7b2021.png">


Related issue: https://github.com/rancher/rancher/issues/21758