### PR TITLE
reinitialize node pools and members when cluster changes

### DIFF
--- a/lib/shared/addon/components/cru-node-pools/component.js
+++ b/lib/shared/addon/components/cru-node-pools/component.js
@@ -97,24 +97,7 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    const originalPools = (get(this, 'cluster.nodePools') || []).slice();
-
-    set(this, 'originalPools', originalPools);
-    set(this, 'nodePools', originalPools.slice().map((p) => p.clone()));
-
-    if ( get(this, 'mode') === 'new' && get(originalPools, 'length') === 0 ) {
-      get(this, 'nodePools').pushObject(get(this, 'globalStore').createRecord({
-        type:     'nodePool',
-        quantity: 1,
-        worker:   true,
-      }));
-    }
-
-    if (this.registerHook) {
-      this.registerHook(this.savePools.bind(this), 'savePools')
-    }
-
-    this.setDefaultNodeTemplate();
+    this.initNodePools()
   },
 
   didReceiveAttrs() {
@@ -157,6 +140,10 @@ export default Component.extend({
       get(this, 'modalService').toggleModal('modal-edit-node-pool', pool);
     },
   },
+
+  reloadNodePools: observer('nodeTemplates', function(){
+    this.initNodePools()
+  }),
 
   setDefaultNodeTemplate: observer('driver', function() {
     const templates = get(this, 'filteredNodeTemplates') || [];
@@ -306,6 +293,27 @@ export default Component.extend({
       return headers.filter((h) => h.name !== 'advanced')
     }
   }),
+
+  initNodePools(){
+    const originalPools = (get(this, 'cluster.nodePools') || []).slice();
+
+    set(this, 'originalPools', originalPools);
+    set(this, 'nodePools', originalPools.slice().map((p) => p.clone()));
+
+    if ( get(this, 'mode') === 'new' && get(originalPools, 'length') === 0 ) {
+      get(this, 'nodePools').pushObject(get(this, 'globalStore').createRecord({
+        type:     'nodePool',
+        quantity: 1,
+        worker:   true,
+      }));
+    }
+
+    if (this.registerHook) {
+      this.registerHook(this.savePools.bind(this), 'savePools')
+    }
+
+    this.setDefaultNodeTemplate();
+  },
 
   savePools() {
     if (this.isDestroyed || this.isDestroying || get(this, 'driver') === 'custom' ) {

--- a/lib/shared/addon/components/form-members/component.js
+++ b/lib/shared/addon/components/form-members/component.js
@@ -36,6 +36,10 @@ export default Component.extend({
     }
   },
 
+  didReceiveAttrs(){
+    this.buildUpdateList(get(this, 'primaryResource'))
+  },
+
   actions: {
     cancel() {
       this.goBack();


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This PR updates the cluster edit/create node pool and member components to re-initialize pools and members respectively when the cluster changes. This bug appears in the iFramed UI running in the dashboard, but not in the Ember UI running in standalone. It seems that when using the dashboard to navigate between editing RKE1 clusters, the embedded Ember UI navigates directly between the two clusters' edit views, so any relevant components' `init` function isn't re-run, and consequently the node pools and cluster members displayed aren't updated to reflect the new cluster.


Linked Issues
======


https://github.com/rancher/dashboard/issues/5343 - in addition to this problem with cluster members, you can see that the node pools section also shows the previous RKE1 cluster's config.


