### PR TITLE
Fix german translation for certificates

### DIFF
--- a/translations/de-de.yaml
+++ b/translations/de-de.yaml
@@ -4173,7 +4173,7 @@ nav:
     community: Community
   infra:
     storagePage: Speicher
-    certificates: Zertificate
+    certificates: Zertifikate
     registries: Registries
     members: Mitglieder
   admin:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Correct german spelling for certificates:
certificates = Zertifikate (like certificate = Zertifikat)

Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

