### PR TITLE
Fix ember 'Go Home' link on not-found page

### DIFF
--- a/app/not-found/controller.js
+++ b/app/not-found/controller.js
@@ -1,0 +1,22 @@
+import Controller from '@ember/controller';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default Controller.extend({
+  router: service(),
+
+  actions: {
+    home() {
+      const target = `${ window.location.origin }/dashboard`;
+      const looped = window.location.href === target;
+
+      if (looped || get(this, 'app.environment') === 'development') {
+        const router = get(this, 'router');
+
+        router.transitionTo('authenticated');
+      } else {
+        window.location.href = '/dashboard';
+      }
+    }
+  }
+});

--- a/app/not-found/template.hbs
+++ b/app/not-found/template.hbs
@@ -4,7 +4,7 @@
     <div class="pl-20 text-center">
       <p>{{t 'notFoundPage.header'}}</p>
       <div>
-        {{#link-to "authenticated"}}{{t 'notFoundPage.linkTo'}}{{/link-to}}
+        <a href="#" onclick={{action "home"}}>{{t 'notFoundPage.linkTo'}}</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/5621

The Ember not found page always returns to the home of the Ember app - when in production, we want this to go to the Dashboard app - i.e. /dashboard