### PR TITLE
Add EKS 1.22, Remove EKS 1.18

### DIFF
--- a/lib/shared/addon/utils/amazon.js
+++ b/lib/shared/addon/utils/amazon.js
@@ -681,7 +681,7 @@ export const EKS_REGIONS = [
 ];
 
 // from https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-export const EKS_VERSIONS = ['1.21', '1.20', '1.19', '1.18']; // sort newest->oldest so we dont have to run any logic to sort like other provider versions
+export const EKS_VERSIONS = ['1.22', '1.21', '1.20', '1.19']; // sort newest->oldest so we dont have to run any logic to sort like other provider versions
 
 export const nameFromResource = function(r, idField) {
   let id = r[idField];


### PR DESCRIPTION
Proposed changes
======
Add EKS 1.22, Remove unsupported EKS 1.18
See https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html

Cluster provisioning screen
![Bildschirmfoto 2022-04-26 um 11 59 14](https://user-images.githubusercontent.com/243056/165276967-69a457cf-004e-4607-955f-060d8c8dcc52.png)

Provisioned cluster
![Bildschirmfoto 2022-04-26 um 11 58 18](https://user-images.githubusercontent.com/243056/165276978-76d37b1a-b78b-4439-9a39-36269aeac207.png)

Types of changes
======
New feature (non-breaking change which adds functionality)

Linked Issues
======
https://github.com/rancher/dashboard/issues/5716
