### PR TITLE
Change label in Project monitoring page

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1654,7 +1654,7 @@ monitoringPage:
     disabled: Monitoring is disabled in the current cluster.
     toDisable: Monitoring is enabled. Click the Save button below will disable monitoring in current cluster.
   project:
-    title: Project Monitoring Configuration
+    title: V1 Project Monitoring Configuration
     disabled: Monitoring is disabled in the current project.
     toDisable: Monitoring is enabled. Click the Save button below will disable monitoring in current project.
   errors:


### PR DESCRIPTION
Addresses Github issue: [#5745](https://github.com/rancher/dashboard/issues/5745)
Addresses Zube issue: [#5774](https://zube.io/rancher/dashboard-ui/c/5774)

- Change label in Project monitoring page from `Project Monitoring Configuration` to `V1 Project Monitoring Configuration`

**Preview**
![Screenshot 2022-05-04 at 16 44 36](https://user-images.githubusercontent.com/97888974/166719956-9301a35c-9663-45d9-9d54-d74b3cc7c748.png)
