### PR TITLE
Prevent creation of clusters with node pools with non-unique names

### DIFF
--- a/lib/shared/addon/components/cru-node-pools/component.js
+++ b/lib/shared/addon/components/cru-node-pools/component.js
@@ -214,6 +214,10 @@ export default Component.extend({
       }
     }
 
+    if (this.uniqueHostNameError) {
+      errors.push(intl.t('clusterNew.nodePools.errors.hostnamePrefix'));
+    }
+
     get(this, 'nodePools').forEach((pool) => {
       // ClusterId is required but not known yet
       if ( !get(pool, 'clusterId') ) {
@@ -260,6 +264,25 @@ export default Component.extend({
     });
 
     return templates;
+  }),
+
+  uniqueHostNameError: computed('nodePools.@each.hostnamePrefix', function() {
+    // Host name prefixes must be unique
+    const nodePools = get(this, 'nodePools');
+    const names = {};
+    let isError = false;
+
+    nodePools.map((p) => {
+      const { hostnamePrefix = '' } = p;
+
+      if (names[hostnamePrefix]) {
+        isError = true;
+      } else {
+        names[hostnamePrefix] = true;
+      }
+    });
+
+    return isError;
   }),
 
   etcdOk: computed('nodePools.@each.{quantity,etcd}', function() {

--- a/lib/shared/addon/components/cru-node-pools/template.hbs
+++ b/lib/shared/addon/components/cru-node-pools/template.hbs
@@ -53,6 +53,12 @@
   <p class="help-block">{{t "clusterNew.rke.helptext"}}</p>
 {{/if}}
 
+{{#if uniqueHostNameError}}
+  {{#banner-message icon="icon-alert" color="bg-error"}}
+    <p>{{t "clusterNew.nodePools.errors.hostnamePrefix" }}</p>
+  {{/banner-message}}
+{{/if}}
+
 <div class="mt-20">
   <button class="btn bg-primary icon-btn" type="button" {{action "addPool" }}>
     <i class="icon icon-plus text-small" />

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4318,6 +4318,9 @@ clusterNew:
     label: Cluster Name
     placeholder: e.g. sandbox
     required: '"Cluster Name" is required'
+  nodePools:
+    errors:
+      hostnamePrefix: Node pools must have unique name prefixes
   nodes:
     detail: Customize the nodes that will be created
     title: Node Options


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/4465
Addresses https://github.com/rancher/dashboard/issues/4444

There are issues if you create a cluster with node pools where the name prefix used for the node pools is non-unique.

This PR adds validation to prevent the user doing this and also displays a banner as the edit the from to indicate that this is not allowed.

![image](https://user-images.githubusercontent.com/1955897/167629005-a4133eda-d96e-4ae2-9015-c56f4a87b1eb.png)
