### PR TITLE
[2.5.14]: Backport: Apply weave network config when using an RKE template

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -18,7 +18,7 @@ import ManageLabels from 'shared/mixins/manage-labels';
 import C from 'shared/utils/constants';
 import { coerceVersion, maxSatisfying } from 'shared/utils/parse-version';
 import {
-  keysToCamel, keysToDecamelize, removeEmpty, ucFirst, validateCertWeakly
+  keysToCamel, keysToDecamelize, randomStr, removeEmpty, ucFirst, validateCertWeakly
 } from 'shared/utils/util';
 import InputTextFile from 'ui/components/input-text-file/component';
 import layout from './template';
@@ -66,6 +66,8 @@ const {
   CLUSTER_TEMPLATE_IGNORED_OVERRIDES,
   NETWORK_CONFIG_DEFAULTS: { DEFAULT_BACKEND_TYPE }
 } = C;
+
+const { WEAVE } = C.NETWORK_CONFIG_DEFAULTS;
 
 export default InputTextFile.extend(ManageLabels, ClusterDriver, {
   globalStore:               service(),
@@ -1098,6 +1100,17 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
           if (questions.length > 0) {
             errors = this.checkRequiredQuestionsHaveAnswers(questions, answers);
+          }
+
+          // When creating from an RKE Cluster Templat with weave networking, add provider password
+          const networkType = get(cluster, 'rancherKubernetesEngineConfig.network.plugin');
+
+          if (networkType === WEAVE) {
+            const provider = get(cluster, 'rancherKubernetesEngineConfig.network.weaveNetworkProvider');
+
+            if (provider) {
+              answers['rancherKubernetesEngineConfig.network.weaveNetworkProvider.password'] = randomStr(16, 16, 'password');
+            }
           }
 
           if (isEmpty(errors)) {

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -1102,11 +1102,11 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
             errors = this.checkRequiredQuestionsHaveAnswers(questions, answers);
           }
 
-          // When creating from an RKE Cluster Templat with weave networking, add provider password
+          // When creating from an RKE Cluster Template with weave networking, add provider password
           const networkType = get(cluster, C.NETWORK_QUESTIONS.PLUGIN);
 
           if (networkType === WEAVE) {
-            const provider = get(cluster, C.NETWORK_QUESTION.WEAVE_NETWORK_PROVIDER);
+            const provider = get(cluster, C.NETWORK_QUESTIONS.WEAVE_NETWORK_PROVIDER);
 
             if (provider) {
               answers[C.NETWORK_QUESTIONS.WEAVE_PASSWORD] = randomStr(16, 16, 'password');

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -1103,13 +1103,13 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
           }
 
           // When creating from an RKE Cluster Templat with weave networking, add provider password
-          const networkType = get(cluster, 'rancherKubernetesEngineConfig.network.plugin');
+          const networkType = get(cluster, C.NETWORK_QUESTIONS.PLUGIN);
 
           if (networkType === WEAVE) {
-            const provider = get(cluster, 'rancherKubernetesEngineConfig.network.weaveNetworkProvider');
+            const provider = get(cluster, C.NETWORK_QUESTION.WEAVE_NETWORK_PROVIDER);
 
             if (provider) {
-              answers['rancherKubernetesEngineConfig.network.weaveNetworkProvider.password'] = randomStr(16, 16, 'password');
+              answers[C.NETWORK_QUESTIONS.WEAVE_PASSWORD] = randomStr(16, 16, 'password');
             }
           }
 

--- a/lib/shared/addon/components/cru-cluster-template/component.js
+++ b/lib/shared/addon/components/cru-cluster-template/component.js
@@ -7,9 +7,7 @@ import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 import Errors from 'ui/utils/errors';
 import { reject } from 'rsvp';
-
-const NETWORK_PLUGIN_QUESTION = 'rancherKubernetesEngineConfig.network.plugin';
-const WEAVE_NETWORK_PLUGIN_QUESTION = 'rancherKubernetesEngineConfig.network.weaveNetworkProvider.password';
+import C from 'shared/utils/constants';
 
 export default Component.extend(ViewNewEdit, ChildHook, {
   globalStore:                service(),
@@ -99,15 +97,15 @@ export default Component.extend(ViewNewEdit, ChildHook, {
 
     // Make sure we add a question for the weave network configuration
     if (this.clusterTemplateRevision && this.clusterTemplateRevision.questions) {
-      const allowNetworkOverride = this.clusterTemplateRevision.questions.find((q) => q.variable === NETWORK_PLUGIN_QUESTION);
+      const allowNetworkOverride = this.clusterTemplateRevision.questions.find((q) => q.variable === C.NETWORK_QUESTIONS.PLUGIN);
 
       if (!!allowNetworkOverride) {
-        let question = this.clusterTemplateRevision.questions.find((q) => q.variable === WEAVE_NETWORK_PLUGIN_QUESTION);
+        let question = this.clusterTemplateRevision.questions.find((q) => q.variable === C.NETWORK_QUESTIONS.WEAVE_PASSWORD);
 
         if (!question) {
           question = this.globalStore.createRecord({
             type:            'question',
-            variable:        WEAVE_NETWORK_PLUGIN_QUESTION,
+            variable:        C.NETWORK_QUESTIONS.WEAVE_PASSWORD,
             priamryResource: this.clusterTemplateRevision.clusterConfig,
           });
 

--- a/lib/shared/addon/components/cru-cluster-template/component.js
+++ b/lib/shared/addon/components/cru-cluster-template/component.js
@@ -2,11 +2,14 @@ import Component from '@ember/component';
 import layout from './template';
 import ViewNewEdit from 'shared/mixins/view-new-edit';
 import ChildHook from 'shared/mixins/child-hook';
-import { get, set } from '@ember/object';
+import { get, set, setProperties } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';
 import Errors from 'ui/utils/errors';
 import { reject } from 'rsvp';
+
+const NETWORK_PLUGIN_QUESTION = 'rancherKubernetesEngineConfig.network.plugin';
+const WEAVE_NETWORK_PLUGIN_QUESTION = 'rancherKubernetesEngineConfig.network.weaveNetworkProvider.password';
 
 export default Component.extend(ViewNewEdit, ChildHook, {
   globalStore:                service(),
@@ -93,6 +96,32 @@ export default Component.extend(ViewNewEdit, ChildHook, {
   willSave() {
     set(this, 'clusterTemplateRevision.clusterTemplateId', '__TEMPID__');
     this.validate();
+
+    // Make sure we add a question for the weave network configuration
+    if (this.clusterTemplateRevision && this.clusterTemplateRevision.questions) {
+      const allowNetworkOverride = this.clusterTemplateRevision.questions.find((q) => q.variable === NETWORK_PLUGIN_QUESTION);
+
+      if (!!allowNetworkOverride) {
+        let question = this.clusterTemplateRevision.questions.find((q) => q.variable === WEAVE_NETWORK_PLUGIN_QUESTION);
+
+        if (!question) {
+          question = this.globalStore.createRecord({
+            type:            'question',
+            variable:        WEAVE_NETWORK_PLUGIN_QUESTION,
+            priamryResource: this.clusterTemplateRevision.clusterConfig,
+          });
+
+          this.clusterTemplateRevision.questions.push(question);
+        }
+
+        setProperties(question, {
+          type:         'string',
+          default:      '',
+          hideQuestion: true,
+          isBuiltIn:    true,
+        });
+      }
+    }
 
     return this._super(...arguments);
   },

--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -915,6 +915,12 @@ C.CLUSTER_TEMPLATE_ROLES = {
   READ_ONLY: 'read-only',
 }
 
+C.NETWORK_QUESTIONS = {
+  PLUGIN:                 'rancherKubernetesEngineConfig.network.plugin',
+  WEAVE_NETWORK_PROVIDER: 'rancherKubernetesEngineConfig.network.weaveNetworkProvider',
+  WEAVE_PASSWORD:         'rancherKubernetesEngineConfig.network.weaveNetworkProvider.password',
+}
+
 // these fields are filtered when launching a cluster with a template because they have UI components
 C.CLUSTER_TEMPLATE_IGNORED_OVERRIDES = [
   'defaultPodSecurityPolicyTemplateId',


### PR DESCRIPTION
backport of: https://github.com/rancher/ui/pull/4826