### PR TITLE
[backport] Fix vSphere content library creation type and minor visual issues

### DIFF
--- a/lib/nodes/addon/components/driver-vmwarevsphere/component.js
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/component.js
@@ -312,7 +312,7 @@ export default Component.extend(NodeDriver, {
     return content;
   }),
 
-  contentLibraryContent: computed('config.{contentLibrary,datacenter}', 'model.cloudCredentialId', async function() {
+  contentLibraryContent: computed('config.{creationType,datacenter}', 'model.cloudCredentialId', async function() {
     const options = await this.requestOptions(
       'content-libraries',
       get(this, 'model.cloudCredentialId'),
@@ -325,7 +325,7 @@ export default Component.extend(NodeDriver, {
     return content;
   }),
 
-  libraryTemplateContent: computed('config.contentLibrary', 'model.cloudCredentialId', async function() {
+  libraryTemplateContent: computed('config.{contentLibrary,datacenter}', 'model.cloudCredentialId', async function() {
     const contentLibrary = get(this, 'config.contentLibrary');
 
     if (!contentLibrary) {
@@ -335,7 +335,7 @@ export default Component.extend(NodeDriver, {
     const options = await this.requestOptions(
       'library-templates',
       get(this, 'model.cloudCredentialId'),
-      undefined,
+      get(this, 'config.datacenter'),
       contentLibrary
     );
 


### PR DESCRIPTION
- The content library library templates weren't being requested because the data center wasn't being passed.
- Made it so content library contents didn't get updated when the content library was selected

fixes rancher/dashboard#5978

backport of https://github.com/rancher/ui/pull/4805

![image](https://user-images.githubusercontent.com/55104481/169168438-1495a487-d6c3-4bb9-8888-ace843929c9e.png)

