### PR TITLE
[2.6] Add support for custom cloud-init for nodes in OKE driver

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/component.js
@@ -49,6 +49,7 @@ export default Component.extend(ClusterDriver, {
         region:                'us-phoenix-1',
         nodeShape:             'VM.Standard2.1',
         nodeImage:             '',
+        nodeUserDataContents:  '',
         vcn:                   '',
         securityListId:        '',
         cpSubnetAccess:        'public',

--- a/lib/shared/addon/components/cluster-driver/driver-oracleoke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-oracleoke/template.hbs
@@ -483,6 +483,25 @@
 
           </div>
 
+          <div class="row">
+            <div class="col span-12">
+              <label class="acc-label pb-5">
+                {{t "clusterNew.oracleoke.nodeUserData.label"}}
+              </label>
+              {{input-text-file
+                      accept="text/plain,.sh,.bash,.init"
+                      canChangeName=false
+                      classNames="box"
+                      minHeight=200
+                      placeholder="clusterNew.oracleoke.nodeUserData.placeholder"
+                      value=config.nodeUserDataContents
+              }}
+              <p class="help-block">
+                {{t "clusterNew.oracleoke.nodeUserData.help"}}
+              </p>
+            </div>
+          </div>
+
         </div>
 
       {{/accordion-list-item}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4399,6 +4399,10 @@ clusterNew:
     nodeShape:
       label: Instance Shape'
       required: Instance Shape is required
+    nodeUserData:
+      label: Optionally provide a custom initialization script for nodes
+      placeholder: Optional cloud-init
+      help: 'cloud-init is run when the nodes boot up for the first time to automate custom tasks.'
     os:
       label: Operating System
     quantityPerSubnet:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

This PR adds support for specifying custom cloud-init for nodes. 


<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======

New feature.

<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-->



Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 
**Depends on:**
- https://github.com/rancher/rancher/pull/37844


Further comments
======



<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->


**OCI node-template prompting the user to optionally set custom cloud-init for nodes:**


![cloud-init-screenshot](https://user-images.githubusercontent.com/13613687/170838083-a6c2cc19-a3c4-4df7-a703-9cb975d0ea12.png)


