### PR TITLE
Adding windows deprecated banners for rke1 on the clusters and provisioning pages

### DIFF
--- a/lib/global-admin/addon/clusters/index/controller.js
+++ b/lib/global-admin/addon/clusters/index/controller.js
@@ -114,6 +114,9 @@ export default Controller.extend({
         return cluster;
       }
     });
-  })
+  }),
 
+  hasWindowsRke1Cluster: computed('_allClusters.[]', function() {
+    return get(this, '_allClusters').any((cluster) => cluster.isWindows && cluster.isRKE);
+  })
 });

--- a/lib/global-admin/addon/clusters/index/template.hbs
+++ b/lib/global-admin/addon/clusters/index/template.hbs
@@ -1,3 +1,9 @@
+{{#if hasWindowsRke1Cluster}}
+<div>
+  {{banner-message icon='icon-alert' color='bg-warning mb-10 mt-10' message=(t
+  'clusterNew.rke.windowsSupport.deprecated')}}
+</div>
+{{/if}}
 <section class="header">
   <h1>
     {{t "clustersPage.header"}}

--- a/lib/shared/addon/components/form-network-config/template.hbs
+++ b/lib/shared/addon/components/form-network-config/template.hbs
@@ -41,6 +41,7 @@
       <label class="acc-label">
         {{t "clusterNew.rke.windowsSupport.label"}}
       </label>
+      {{banner-message icon='icon-alert' color='bg-warning mb-10 mt-10' message=(t 'clusterNew.rke.windowsSupport.deprecated')}}
       <CheckComputedOverride
         @applyClusterTemplate={{applyClusterTemplate}}
         @clusterTemplateCreate={{clusterTemplateCreate}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4735,6 +4735,7 @@ clusterNew:
         even: Setting {count} etcd nodes is a waste of hardware because it doesn't increase the quorum until you have an odd number.
         noEtcd: The number of etcd nodes should not be less than 1.
     windowsSupport:
+      deprecated: Windows support is being deprecated for RKE1. We suggest migrating to RKE2/K3s.
       disabled: Not support {plugin} network provider.
       help: Available for Kubernetes 1.15 or above with Flannel network provider.
       label: Windows Support


### PR DESCRIPTION
rancher/dashboard#5995

![image](https://user-images.githubusercontent.com/55104481/172477354-967df446-f6b7-4623-b108-d311d3933b38.png)
![cluster-windows-banner](https://user-images.githubusercontent.com/55104481/180459247-198d491e-b097-4c59-96f8-039049e3955f.png)

