### PR TITLE
fix: Only display valid Linode types for LKE node pools

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-linodelke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-linodelke/component.js
@@ -107,7 +107,7 @@ export default Component.extend(ClusterDriver, {
             errors:      [],
             step:        2,
             regions:     responses.regions.data.filter((region) => (region.status === 'ok' && region.capabilities.includes('Kubernetes'))),
-            nodeTypes:   responses.nodeTypes.data.filter((type) => (type.class !== 'nanode' && type.class !== 'gpu')),
+            nodeTypes:   responses.nodeTypes.data.filter((type) => (['standard', 'highmem', 'dedicated'].includes(type.class))),
             k8sVersions: responses.k8sVersions.data,
           });
 


### PR DESCRIPTION
This pull request alters the Linode LKE node pool type filtering logic to only include valid instance types. Previously the filter would allow certain invalid types and exclude valid types (`highmem`).

See: https://www.linode.com/docs/api/linode-types/#type-view__responses

Related issue: https://github.com/rancher/dashboard/issues/6424
