### PR TITLE
Add High Availability LKE cluster support

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-linodelke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-linodelke/component.js
@@ -64,6 +64,9 @@ export default Component.extend(ClusterDriver, {
     let configField = get(this, 'configField');
 
     setProperties(this, {
+      // We should store the previous state of HA to disallow downgrades
+      'highAvailability':     config ? config.highAvailability : false,
+
       'newTag':               '',
       'selectedNodePoolType': '',
       'selectedNodePoolObj':  {},
@@ -79,6 +82,7 @@ export default Component.extend(ClusterDriver, {
         accessToken:       '',
         region:            'us-central',
         kubernetesVersion: '',
+        highAvailability: false,
         tags:              [],
         nodePools:         []
       });

--- a/lib/shared/addon/components/cluster-driver/driver-linodelke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-linodelke/component.js
@@ -46,16 +46,18 @@ const NODE_POOL_HEADERS = [
 ];
 
 export default Component.extend(ClusterDriver, {
-  intl:            service(),
-  linode:          service(),
+  intl:                         service(),
+  linode:                       service(),
   layout,
-  configField:     'lkeEngineConfig',
-  step:            1,
-  lanChanged:      null,
-  refresh:         false,
-  sortBy:          '',
-  descending:      false,
-  nodePoolHeaders: NODE_POOL_HEADERS,
+  configField:                  'lkeEngineConfig',
+  step:                         1,
+  lanChanged:                   null,
+  refresh:                      false,
+  sortBy:                       '',
+  descending:                   false,
+  nodePoolHeaders:              NODE_POOL_HEADERS,
+  // This value is currently not returned by the Linode API
+  highAvailabilityMonthlyPrice: 60.0,
 
   init() {
     this._super(...arguments);
@@ -66,7 +68,6 @@ export default Component.extend(ClusterDriver, {
     setProperties(this, {
       // We should store the previous state of HA to disallow downgrades
       'highAvailability':     config ? config.highAvailability : false,
-
       'newTag':               '',
       'selectedNodePoolType': '',
       'selectedNodePoolObj':  {},
@@ -82,7 +83,7 @@ export default Component.extend(ClusterDriver, {
         accessToken:       '',
         region:            'us-central',
         kubernetesVersion: '',
-        highAvailability: false,
+        highAvailability:  false,
         tags:              [],
         nodePools:         []
       });

--- a/lib/shared/addon/components/cluster-driver/driver-linodelke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-linodelke/template.hbs
@@ -94,6 +94,7 @@
                 <label>
                   {{radio-button selection=cluster.lkeEngineConfig.highAvailability value=true}}
                   {{t "generic.enabled"}}
+                  (+{{format-number highAvailabilityMonthlyPrice style='currency' currency='USD'}}/{{t "clusterNew.linodelke.highAvailability.month"}})
                 </label>
               </div>
               <div class="radio">

--- a/lib/shared/addon/components/cluster-driver/driver-linodelke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-linodelke/template.hbs
@@ -81,6 +81,34 @@
           </div>
         {{/if}}
         <div class="row">
+          <div class="col span-6">
+            <label class="acc-label">
+              {{t "clusterNew.linodelke.highAvailability.label"}}
+              {{field-required}}
+            </label>
+            {{#input-or-display
+            editable=true
+            value=cluster.lkeEngineConfig.highAvailability
+            }}
+              <div class="radio">
+                <label>
+                  {{radio-button selection=cluster.lkeEngineConfig.highAvailability value=true}}
+                  {{t "generic.enabled"}}
+                </label>
+              </div>
+              <div class="radio">
+                <label>
+                  {{radio-button selection=cluster.lkeEngineConfig.highAvailability disabled=highAvailability value=false}}
+                  {{t "generic.disabled"}}
+                </label>
+              </div>
+            {{/input-or-display}}
+            <p class="help-block">
+              {{t "clusterNew.linodelke.highAvailability.warning"}}
+            </p>
+          </div>
+        </div>
+        <div class="row">
           <div class="header mt-40 mb-0">
             <div class="pull-left">
               <h2 class="mb-0">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4275,6 +4275,7 @@ clusterNew:
     highAvailability:
       label: High Availability
       warning: Once a cluster has been upgraded to High Availability, it cannot be downgraded.
+      month: month
     kubernetesVersion:
       label: Kubernetes Version
       placeholder: Select a kubernetes version for your cluster
@@ -4652,7 +4653,7 @@ clusterNew:
     networkPolicy:
       label: Project Network Isolation
       editHelp: The Project Network Isolation option cannot be changed after the cluster is created
-      selectNetworkPolicyHelp: You must have a Network Policy selected to use Project Network Isolation 
+      selectNetworkPolicyHelp: You must have a Network Policy selected to use Project Network Isolation
     nodeName:
       detail: Optionally configure the node name as identification instead of the actual hostname
       placeholder: e.g. my-worker-node

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4272,6 +4272,9 @@ clusterNew:
       loading: Saving your cluster configuration
       next: Proceed to Node pool selection
       title: Cluster Configuration
+    highAvailability:
+      label: High Availability
+      warning: Once a cluster has been upgraded to High Availability, it cannot be downgraded.
     kubernetesVersion:
       label: Kubernetes Version
       placeholder: Select a kubernetes version for your cluster


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

This pull request adds an option to the LKE UI component for provisioning and updating Linode Kubernetes Engine clusters with [High Availability Control Planes](https://www.linode.com/docs/guides/introduction-to-high-availability/).

Types of changes
======

- New Feature

Linked Issues
======

Feature Request: https://github.com/rancher/rancher/issues/38189

Further comments
======

- There is currently a bug in `kontainer-engine-driver-lke` when updating **only** the `High Availability` field
    - https://github.com/linode/kontainer-engine-driver-lke/pull/19