### PR TITLE
Fix eks radio button layout

### DIFF
--- a/app/styles/components/_forms.scss
+++ b/app/styles/components/_forms.scss
@@ -388,6 +388,16 @@ input.input-lg,
   padding: 5px 0;
 }
 
+// Ensure lists of radio buttons stack vertically and have appropriate spacing between options
+.radio-list {
+  display: flex;
+  flex-direction: column;
+
+  > label:not(:first-child) {
+    margin-top: 5px;
+  }
+}
+
 .image-radio-container {
   @include clearfix;
 

--- a/lib/shared/addon/components/cluster-driver/driver-amazoneks/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-amazoneks/template.hbs
@@ -121,7 +121,7 @@
             {{t "nodeDriver.amazoneks.role.label"}}
           </label>
           {{#if (eq step 2)}}
-            <div class="radio pt-0">
+            <div class="radio pt-0 radio-list">
               <label>
                 {{radio-button
                   selection=serviceRoleMode

--- a/lib/shared/addon/components/cluster-driver/driver-eks/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-eks/template.hbs
@@ -110,7 +110,7 @@
               {{t "clusterNew.amazoneks.role.label"}}
             </label>
             {{#if (eq step 2)}}
-              <div class="radio pt-0">
+              <div class="radio pt-0 radio-list">
                 <label>
                   {{radio-button
                     selection=serviceRoleMode


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/6272

Straight-forward PR.

Ensures that the radio buttons stay vertically-stacked when browser window is wide. 