### PR TITLE
Add Storage Options and Log Options fields to RKE1 node template

### DIFF
--- a/lib/shared/addon/components/form-engine-opts/template.hbs
+++ b/lib/shared/addon/components/form-engine-opts/template.hbs
@@ -81,6 +81,36 @@
   <div class="row inline-form">
     <div class="col span-2 col-inline">
       <label class="acc-label">
+        {{t "formEngineOpts.storageOpts.label"}}
+        </label>
+        </div>
+        <div class="col span-10">
+          {{form-key-value
+          initialMap=machine.storageOpt
+          changed=(action (mut machine.storageOpt))
+          addActionLabel="formEngineOpts.storageOpts.addActionLabel"
+          }}
+        </div>
+        </div>
+        <hr />
+        <div class="row inline-form">
+          <div class="col span-2 col-inline">
+            <label class="acc-label">
+              {{t "formEngineOpts.logOpts.label"}}
+            </label>
+          </div>
+          <div class="col span-10">
+            {{form-key-value
+            initialMap=machine.logOpt
+            changed=(action (mut machine.logOpt))
+            addActionLabel="formEngineOpts.logOpts.addActionLabel"
+            }}
+          </div>
+        </div>
+        <hr />
+        <div class="row inline-form">
+          <div class="col span-2 col-inline">
+            <label class="acc-label">
         {{t "formEngineOpts.engineLabels.label"}}
       </label>
     </div>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -6618,6 +6618,12 @@ formEngineOpts:
     addActionLabel: Add Engine Option
     keyPlaceholder: e.g. log-driver
     valuePlaceholder: e.g. syslog
+  logOpts:
+    label: Log Options
+    addActionLabel: Add Log Option
+  storageOpts:
+    label: Storage Options
+    addActionLabel: Add Storage Option
   engineLabels:
     label: Engine Labels
     addActionLabel: Add Engine Label


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/5821 by adding new fields for RKE1 node templates. It adds new inputs to add key-value pairs for log options (`logOpt`) and storage options (`storageOpt`).

There are only a few changes made because the engine options are reused across multiple node templates for different cloud providers.

To test this PR,

1. I created Digital Ocean cloud credentials
2. From cluster management, went to **RKE1 Node Configuration > Node Templates**
3. Started to create a Digital Ocean node template
4. Confirmed that the Log Options and Storage Options are available
<img width="799" alt="Screen Shot 2022-07-16 at 3 42 06 AM" src="https://user-images.githubusercontent.com/20599230/179351815-a574ac31-99b9-4eb4-a771-32f1909c12b4.png">
5. Confirmed that when you expand them, you can enter key-value pairs

<img width="834" alt="Screen Shot 2022-07-16 at 3 38 02 AM" src="https://user-images.githubusercontent.com/20599230/179351837-25e14b9e-66aa-4932-8617-6dfbca5f411e.png">

9. Confirmed that the values are sent in the POST request when the node template is saved
<img width="483" alt="Screen Shot 2022-07-16 at 3 40 34 AM" src="https://user-images.githubusercontent.com/20599230/179351879-fc501efe-fb11-491d-994f-cd120480346d.png">

