### PR TITLE
do not add duplicate query params to oauth redirects

### DIFF
--- a/lib/shared/addon/azure-ad/service.js
+++ b/lib/shared/addon/azure-ad/service.js
@@ -28,11 +28,15 @@ export default Service.extend({
   login() {
     const provider     = get(this, 'access.providers').findBy('id', 'azuread');
     const authRedirect = get(provider, 'redirectUrl');
-    let redirect     = Util.addQueryParams(authRedirect, additionalRedirectParams);
+    let redirect = authRedirect;
+
+    Object.keys(additionalRedirectParams).forEach((key) => {
+      if (!authRedirect.includes(key)){
+        redirect = Util.addQueryParam(redirect, key, additionalRedirectParams[key])
+      }
+    })
 
     redirect = Util.addQueryParams(redirect, { state: this.oauth.encodeState(this.oauth.generateState('azuread')) });
-
-
     window.location.href = redirect;
   },
 
@@ -49,7 +53,11 @@ export default Service.extend({
       }
     };
 
-    url = Util.addQueryParams(url, additionalRedirectParams);
+    Object.keys(additionalRedirectParams).forEach((key) => {
+      if (!url.includes(key)){
+        url = Util.addQueryParam(url, key, additionalRedirectParams[key])
+      }
+    })
     const state = this.oauth.encodeState(this.oauth.generateState('azuread'))
 
     url = Util.addQueryParams(url, { state });


### PR DESCRIPTION
[#6316](https://github.com/rancher/dashboard/issues/6316) - As part of the endpoint migration process @maxsokolovsky found that the UI has been using a redirect url with a duplicated query parameter, which ultimately causes an error. 

This PR resolves the issue by only adding query params that are not already present in the url obtained from the backend (via an `authProvider` resource). I've opted to implement this in a way that only affects azure ad auth to negate the need to re-test other areas of the UI.