### PR TITLE
Disable growls when embedded

### DIFF
--- a/lib/shared/addon/growl/service.js
+++ b/lib/shared/addon/growl/service.js
@@ -3,15 +3,22 @@ import Errors from 'ui/utils/errors';
 import 'jgrowl';
 import { setProperties } from '@ember/object';
 import { escapeHtml } from 'shared/utils/util';
+import { set } from '@ember/object';
+
 
 export default Service.extend({
   app:  service(),
   intl: service(),
 
+  isEmbedded: false,
+
 
   init() {
     this._super(...arguments);
     this.initjGrowlDefaults();
+    const isEmbedded = window !== window.top;
+
+    set(this, 'isEmbedded', isEmbedded);
   },
 
   initjGrowlDefaults() {
@@ -35,7 +42,7 @@ export default Service.extend({
       opt.header = title;
     }
 
-    return $.jGrowl(escapeHtml(body), opt);
+    return this.isEmbedded ?  null : $.jGrowl(escapeHtml(body), opt)
   },
 
   success(title, body) {


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/6460

I had a hard time reliably producing websocket error growls in the embedded ember ui and ended up uncommenting code [here](https://github.com/rancher/ui/blob/master/lib/shared/addon/mixins/subscribe.js#L292) to test.