### PR TITLE
Marking aks k8s versions >= 1.24.0 as experimental

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-aks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-aks/component.js
@@ -16,6 +16,7 @@ import { addQueryParams } from 'shared/utils/util';
 import { DEFAULT_AKS_CONFIG, DEFAULT_AKS_NODE_POOL_CONFIG } from 'ui/models/cluster';
 import { regionsWithAZs } from 'ui/utils/azure-choices';
 import layout from './template';
+import { satisfies, coerceVersion } from 'shared/utils/parse-version';
 
 const NETWORK_POLICY = [
   {
@@ -54,6 +55,10 @@ const LB_SKUS = [
     value: 'Basic'
   }
 ];
+
+
+// Because aks just put out 1.24.0 as a preview we're releasing it as experimental until we can adequately test it. https://github.com/rancher/dashboard/issues/6513
+const EXPERIMENTAL_RANGE = '>= 1.24.0'
 
 export default Component.extend(ClusterDriver, {
   globalStore:          service(),
@@ -296,7 +301,8 @@ export default Component.extend(ClusterDriver, {
         const isEdit                        = mode === 'edit';
         const versionz                      = (get(versions, 'body') || []);
         const upgradeVersionz               = (get(upgradeVersions, 'body.upgrades') || []);
-        const initialVersion                = isEdit ? this.config.kubernetesVersion : Semver.maxSatisfying(versionz, this.defaultK8sVersionRange); // default in azure ui
+        const nonExperimentalVersions       = versionz.filter((v) =>  !satisfies(coerceVersion(v), EXPERIMENTAL_RANGE));
+        const initialVersion                = isEdit ? this.config.kubernetesVersion : Semver.maxSatisfying(nonExperimentalVersions, this.defaultK8sVersionRange); // default in azure ui
 
         if (!isEdit && initialVersion) {
           set(this, 'cluster.aksConfig.kubernetesVersion', initialVersion);
@@ -542,7 +548,7 @@ export default Component.extend(ClusterDriver, {
     } = this;
 
     // azure versions come in oldest to newest
-    return this.versionChoiceService.parseCloudProviderVersionChoices(( versions || [] ).reverse(), initialVersion, mode);
+    return this.versionChoiceService.parseCloudProviderVersionChoices(( versions || [] ).reverse(), initialVersion, mode, null, false, EXPERIMENTAL_RANGE);
   }),
 
   networkChoice: computed({

--- a/lib/shared/addon/version-choices/service.js
+++ b/lib/shared/addon/version-choices/service.js
@@ -12,7 +12,7 @@ export default Service.extend({
 
   defaultK8sVersionRange: alias(`settings.${ C.SETTING.VERSION_SYSTEM_K8S_DEFAULT_RANGE }`),
 
-  parseCloudProviderVersionChoices(versions, providerVersion, mode, maxVersionRange = null, includePrerelease = false) {
+  parseCloudProviderVersionChoices(versions, providerVersion, mode, maxVersionRange = null, includePrerelease = false, experimentalRange = null) {
     let {
       intl,
       defaultK8sVersionRange
@@ -22,8 +22,9 @@ export default Service.extend({
 
     return versions.map((version) => {
       if (satisfies(coerceVersion(version), maxVersionRange, { includePrerelease })) {
+        const experimental = experimentalRange && satisfies(coerceVersion(version), experimentalRange) ? intl.t('generic.experimental')  : '';
         const out = {
-          label: version,
+          label: `${ version  } ${ experimental }`,
           value: version,
         };
 


### PR DESCRIPTION
rancher/dashboard#6513
![experimental](https://user-images.githubusercontent.com/55104481/182231547-fb884bab-75e9-47b9-8395-6e5f82747457.gif)

