### PR TITLE
Harvester: Remove Pod Scheduling from harvester RKE1

### DIFF
--- a/lib/nodes/addon/components/driver-harvester/template.hbs
+++ b/lib/nodes/addon/components/driver-harvester/template.hbs
@@ -224,7 +224,7 @@
           </button>
         </div>
 
-        <div class="row">
+        {{!-- <div class="row">
           <div class="col span-12">
             <label class="acc-label">
               {{t "nodeDriver.harvester.scheduling.pod.label"}}
@@ -240,7 +240,7 @@
             <i class="icon icon-plus text-small" />
             <span>{{t "formNodeAffinity.addRuleLabel"}}</span>
           </button>
-        </div>
+        </div> --}}
       {{/if}}
 
       {{#if isImported}}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

According to discussion of Harvester team, it's not applicable to display Pod Scheduling on harvester cluster config page.

Types of changes
======

Bugfix (non-breaking change which fixes an issue)

Linked Issues
======

- https://github.com/harvester/harvester/issues/2642

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
