### PR TITLE
Add more deprecation warnings for Windows with RKE1

### DIFF
--- a/lib/monitoring/addon/components/cluster-dashboard/template.hbs
+++ b/lib/monitoring/addon/components/cluster-dashboard/template.hbs
@@ -3,6 +3,12 @@
     <p>{{t "tooltipExpire.label"}} {{#if cluster.canRotateCerts}}<a href="#" {{action "rotate"}}>{{t "tooltipExpire.link"}}</a>{{/if}}</p>
   {{/banner-message}}
 {{/if}}
+{{#if scope.currentCluster.isWindows }}
+  <div>
+    {{banner-message icon='icon-alert' color='bg-warning mb-10 mt-10' message=(t
+    'clusterNew.rke.windowsSupport.deprecated')}}
+  </div>
+{{/if}}
 {{#if cluster.nodeGroupVersionUpdate}}
   {{#banner-message color="bg-warning"}}
     <p>{{t "tooltipNodeGroupUpdate.label"}} <a href="#" {{action "edit"}}>{{t "tooltipNodeGroupUpdate.link"}}</a></p>

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -1295,6 +1295,10 @@
        as |al expandFn|
     }}
       {{#if isWindowsPreferedCluster}}
+      <div>
+        {{banner-message icon='icon-alert' color='bg-warning mb-10 mt-10' message=(t
+        'clusterNew.rke.windowsSupport.deprecated')}}
+      </div>
         {{#accordion-list-item
            title=(t "clusterNew.rke.system.title")
            detail=(t "clusterNew.rke.system.detail")

--- a/lib/shared/addon/components/modal-show-command/template.hbs
+++ b/lib/shared/addon/components/modal-show-command/template.hbs
@@ -11,6 +11,10 @@
     </div>
   {{else if isCustom}}
     {{#if cluster.windowsPreferedCluster}}
+      <div>
+        {{banner-message icon='icon-alert' color='bg-warning mb-10 mt-10' message=(t
+        'clusterNew.rke.windowsSupport.deprecated')}}
+      </div>
       <div class="row ml-40 pl-25 mb-20">
         <div class="col span-12">
           <h3>


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/6549 by adding RKE1 Windows deprecation warnings in more places.

To test,
1. In the Ember global view, go to add a cluster. Under **Create a new Kubernetes cluster,** click **Existing nodes.**
2. Enter a cluster name, set the network provider to Flannel, enable Windows support
5. Click Next
6. Confirm that the Windows deprecation warning is displayed:
<img width="1165" alt="Screen Shot 2022-08-11 at 3 02 02 PM" src="https://user-images.githubusercontent.com/20599230/184252876-a11d95c4-1917-48e5-bedf-b879bf53d7cc.png">
7. Click Done without running the registration command

8. Go to the detail page of the new Windows enabled cluster and confirm that the warning is shown there as well:

<img width="1184" alt="Screen Shot 2022-08-11 at 3 12 00 PM" src="https://user-images.githubusercontent.com/20599230/184253030-f2c7c528-026a-4a61-aaba-6fa4add42438.png">
9. Click Get Registration Command

10. Confirm that the warning is also displayed on the modal that appears (this one was not specifically requested in the linked issue, but it's in the same spirit):
<img width="1156" alt="Screen Shot 2022-08-11 at 3 29 18 PM" src="https://user-images.githubusercontent.com/20599230/184253390-c46198da-d0ae-4a3c-b025-a312a4c2b016.png">
12. Confirm that the warnings are not displayed for non-Windows-enabled clusters


Note: This PR doesn't remove the warning from the cluster list page because the warning correctly shows if at least one cluster is Windows enabled (still counts as Windows even if it doesn't have nodes yet)