### PR TITLE
Update eks node group asg desired and minsize to 0

### DIFF
--- a/lib/shared/addon/components/node-group-row/template.hbs
+++ b/lib/shared/addon/components/node-group-row/template.hbs
@@ -385,7 +385,7 @@
           </label>
           <InputNumber
             @value={{mut model.desiredSize}}
-            @min={{1}}
+            @min={{0}}
             @classNames="form-control"
           />
         </div>
@@ -405,7 +405,7 @@
           </label>
           <InputNumber
             @value={{mut model.minSize}}
-            @min={{1}}
+            @min={{0}}
             @classNames="form-control"
           />
         </div>


### PR DESCRIPTION
Issue: 
https://github.com/rancher/rancher/issues/38698
https://github.com/rancher/dashboard/issues/6731

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
## Proposed changes
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

We are updating the AWS SDK to [version 1.44](https://github.com/aws/aws-sdk-go/releases/tag/v1.44.83) and with that, comes the ability to scale a node group in an EKS cluster to 0 nodes. The rancher ui won't allow you to set a 0 value for `desiredSize` and `minSize` in the node group config so this change updates the ui to allow that.