### PR TITLE
Fix select option disabled color

### DIFF
--- a/app/styles/components/_forms.scss
+++ b/app/styles/components/_forms.scss
@@ -122,7 +122,7 @@ select {
     background: $input-bg;
     &.disabled,
     &[disabled] {
-      color: $mid-grey;
+      color: rgba($input-color-placeholder, 0.8);
       cursor: not-allowed;
     }
   }


### PR DESCRIPTION
On Linux, disabled options in the default OS select drop down can not be distinguished from normal ones.

This PR fixes this.

See: https://github.com/rancher/dashboard/issues/6774 for an example