### PR TITLE
[2.6.9] Add support for Ubuntu 22.04 on Digital Ocean

### DIFF
--- a/app/styles/components/_forms.scss
+++ b/app/styles/components/_forms.scss
@@ -122,7 +122,7 @@ select {
     background: $input-bg;
     &.disabled,
     &[disabled] {
-      color: $mid-grey;
+      color: rgba($input-color-placeholder, 0.8);
       cursor: not-allowed;
     }
   }

--- a/lib/nodes/addon/components/driver-digitalocean/component.js
+++ b/lib/nodes/addon/components/driver-digitalocean/component.js
@@ -22,6 +22,7 @@ const VALID_IMAGES = [
   'ubuntu-16-04-x64',
   'ubuntu-18-04-x64',
   'ubuntu-20-04-x64',
+  'ubuntu-22-04-x64',
 ];
 
 export default Component.extend(NodeDriver, {


### PR DESCRIPTION
Addresses: https://github.com/rancher/dashboard/issues/6774

This PR:

- Adds Ubuntu 22.04 support for Digital Ocean
- Fixes a styling issue: on Linux, disabled options in the default OS select drop down can not be distinguished from normal ones.
