### PR TITLE
Drone builds were restricted to 2.6, update to match 2.7

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -74,7 +74,7 @@ steps:
       - tag
     ref:
       include:
-      - "refs/tags/v2.6.*"
+      - "refs/tags/v2.7.*"
 
 
 - name: upload-release
@@ -93,7 +93,7 @@ steps:
       - tag
     ref:
       include:
-      - "refs/tags/v2.6.*"
+      - "refs/tags/v2.7.*"
 
 - name: upload-release-tar
   pull: default
@@ -111,7 +111,7 @@ steps:
       - tag
     ref:
       include:
-      - "refs/tags/v2.6.*"
+      - "refs/tags/v2.7.*"
 
 - name: create-pr-in-rancher
   image: curlimages/curl:7.81.0
@@ -129,7 +129,7 @@ steps:
     - tag
     ref:
       include:
-      - "refs/tags/v2.6.*"
+      - "refs/tags/v2.7.*"
 
 volumes:
 - name: docker


### PR DESCRIPTION
- Last 2.7.0 RC tag failed to trigger build (https://drone-publish.rancher.io/rancher/ui/2594)
- This was due to references to v2.6 in their triggers
- I've updated these now to v.2.7 (these could probably be just `v*`, but we'll stick to a safer fix)
