### PR TITLE
Change language around private registry in RKE1 cluster config form

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1974,7 +1974,7 @@ cruVolumeClaimTemplate:
 cruPrivateRegistry:
   title:
     label: Private Registry
-    detail: Configure a default private registry for provisioning RKE cluster components. When enabled, all system images required for RKE cluster provisioning and system add-ons startup will be pulled from this registry.
+    detail: Configure a default cluster-level private registry to be used for all Rancher System Container Images.
   noData: This cluster does not have a private registry defined
   defaultError: You must designate one private registry as the default
   add:


### PR DESCRIPTION
This PR addresses the Ember part of https://github.com/rancher/dashboard/issues/6918

Before: 
<img width="965" alt="Screen Shot 2022-10-05 at 3 29 19 AM" src="https://user-images.githubusercontent.com/20599230/194040685-0b59d359-a270-477c-9635-ee3ff4ce337d.png">

After:

<img width="977" alt="Screen Shot 2022-10-05 at 3 31 34 AM" src="https://user-images.githubusercontent.com/20599230/194040738-e51cea1c-5b21-419b-8a80-028cbe913eca.png">



# QA Template
## What was fixed, or what changes have occurred
Updated private registry description in edit config form for RKE1 clusters
 
## Areas or cases that should be tested
When creating or editing an RKE1 cluster, confirm that the language has been updated
