### PR TITLE
Remove K8s 1.22 and older from EKS creation form

### DIFF
--- a/lib/shared/addon/utils/amazon.js
+++ b/lib/shared/addon/utils/amazon.js
@@ -683,7 +683,7 @@ export const EKS_REGIONS = [
 ];
 
 // from https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-export const EKS_VERSIONS = ['1.23', '1.22', '1.21', '1.20']; // sort newest->oldest so we dont have to run any logic to sort like other provider versions
+export const EKS_VERSIONS = ['1.23']; // sort newest->oldest so we dont have to run any logic to sort like other provider versions
 
 export const nameFromResource = function(r, idField) {
   let id = r[idField];


### PR DESCRIPTION
Partly adresses https://github.com/rancher/dashboard/issues/7203

Before:
<img width="751" alt="Screen Shot 2022-10-17 at 7 54 18 PM" src="https://user-images.githubusercontent.com/20599230/196332431-e479c64f-f28f-416b-80d0-da5879c5116e.png">

After:
<img width="702" alt="Screen Shot 2022-10-17 at 7 58 35 PM" src="https://user-images.githubusercontent.com/20599230/196332447-92f28ddd-79dd-43bb-852a-9085724e5f87.png">
