### PR TITLE
Add ability to compare RKE template revisions

### DIFF
--- a/app/components/modal-view-template-diff/component.js
+++ b/app/components/modal-view-template-diff/component.js
@@ -22,6 +22,7 @@ function sanitize(config) {
 
 export default Component.extend(ModalBase, {
   modalService: service('modal'),
+  intl:         service(),
 
   layout,
   classNames: ['modal-container', 'large-modal', 'large-height', 'alert'],
@@ -38,6 +39,8 @@ export default Component.extend(ModalBase, {
       const diff = jsondiffpatch.formatters.html.format(delta, templates[0]).htmlSafe();
 
       set(this, 'diff', diff);
+    } else {
+      set(this, 'diff', this.intl.t('clusterTemplatesPage.compare.error'));
     }
   },
 

--- a/app/components/modal-view-template-diff/component.js
+++ b/app/components/modal-view-template-diff/component.js
@@ -1,0 +1,47 @@
+import Component from '@ember/component';
+import { get, set } from '@ember/object';
+import { inject as service } from '@ember/service';
+import jsondiffpatch from 'jsondiffpatch';
+import ModalBase from 'shared/mixins/modal-base';
+
+import layout from './template';
+
+const HIDDEN_FIELDS = ['created', 'createdTS', 'links', 'actionLinks', 'id', 'conditions', 'uuid'];
+
+function sanitize(config) {
+  const result = {};
+
+  Object.keys(config).forEach((key) => {
+    if (!HIDDEN_FIELDS.includes(key)) {
+      result[key] = config[key]
+    }
+  });
+
+  return result;
+}
+
+export default Component.extend(ModalBase, {
+  modalService: service('modal'),
+
+  layout,
+  classNames: ['modal-container', 'large-modal', 'large-height', 'alert'],
+  diff:       '',
+
+  didReceiveAttrs() {
+    const templates = get(this, 'modalService.modalOpts');
+
+    if (templates.length === 2) {
+      const delta = jsondiffpatch.diff(sanitize(templates[0]), sanitize(templates[1]));
+
+      jsondiffpatch.formatters.html.hideUnchanged();
+
+      const diff = jsondiffpatch.formatters.html.format(delta, templates[0]).htmlSafe();
+
+      set(this, 'diff', diff);
+    }
+  },
+
+  cancel() {
+    get(this, 'modalService').toggleModal();
+  },
+});

--- a/app/components/modal-view-template-diff/template.hbs
+++ b/app/components/modal-view-template-diff/template.hbs
@@ -1,0 +1,13 @@
+<section class="horizontal-form container-fluid">
+  <h2>{{t "clusterTemplatesPage.compare.header" }}</h2>
+
+  <div class="mt-10 modal-scroll-panel">
+    <pre class="bg-setting" style="margin: 0; padding: 0">
+      {{diff}}
+    </pre>
+  </div>
+
+  <div class="footer-actions">
+    <button class="mt-10 btn bg-primary" type="button" {{action "cancel"}}>{{t 'clusterTemplatesPage.compare.closeModal'}}</button>
+  </div>
+</section>

--- a/app/styles/components/_modals.scss
+++ b/app/styles/components/_modals.scss
@@ -39,6 +39,23 @@ $modal-overlay                       : rgba($light-grey, 0.75) !default;
   }
 }
 
+.large-modal.large-height {
+  &.modal-container {
+    max-height: 95vh !important;
+    display: flex;
+
+    > section {
+      display: flex;
+      flex-direction: column;
+
+      > .modal-scroll-panel {
+        flex: 1;
+        overflow: auto;
+      }
+    }
+  }
+}
+
 .medium-modal {
   &.modal-container {
     width: calc(100% - 40px);

--- a/lib/global-admin/addon/cluster-templates/index/controller.js
+++ b/lib/global-admin/addon/cluster-templates/index/controller.js
@@ -1,0 +1,23 @@
+import Controller from '@ember/controller';
+import { get, set } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default Controller.extend({
+  modalService: service('modal'),
+
+  selection:             [],
+  canCompare:            false,
+
+  actions: {
+    selectionChanged(s) {
+      set(this, 'selection', s || []);
+      set(this, 'canCompare', s.length === 2);
+    },
+
+    showDiff() {
+      const compare = get(this, 'selection');
+
+      this.get('modalService').toggleModal('modal-view-template-diff', compare);
+    }
+  },
+});

--- a/lib/global-admin/addon/cluster-templates/index/template.hbs
+++ b/lib/global-admin/addon/cluster-templates/index/template.hbs
@@ -4,6 +4,11 @@
   </h1>
 
   <div class="right-buttons">
+    <button class="btn btn-sm bg-primary mr-10"
+      disabled={{not canCompare}}
+      type="button" {{action "showDiff" }}>
+      {{t "clusterTemplatesPage.compare.label"}}
+    </button>
     {{#link-to
        "cluster-templates.new"
        class="btn btn-sm bg-primary"
@@ -15,6 +20,6 @@
 </div>
 
 <div class="cluster-templates-index-container">
-  <ClusterTemplatesTable @clusterTemplates={{model.clusterTemplates}}
+  <ClusterTemplatesTable @selectionChanged={{action "selectionChanged" }} @clusterTemplates={{model.clusterTemplates}}
     @clusterTemplateRevisions={{model.clusterTemplateRevisions}} />
 </div>

--- a/lib/shared/addon/components/cluster-templates-table/component.js
+++ b/lib/shared/addon/components/cluster-templates-table/component.js
@@ -46,6 +46,7 @@ export default Component.extend({
   sortBy:                   'displayName',
   headers:                  HEADERS,
   extraSearchFields:        ['clusterTemplate.displayName'],
+  selectionChanged:         null,
 
   rows: computed('clusterTemplateRevisions.@each.{id,state,enabled}', function() {
     const { clusterTemplateRevisions = [] } = this;

--- a/lib/shared/addon/components/cluster-templates-table/template.hbs
+++ b/lib/shared/addon/components/cluster-templates-table/template.hbs
@@ -1,4 +1,4 @@
-<SortableTable @body={{rows}} @bulkActions={{true}} @class="grid" @descending={{descending}}
+<SortableTable @selectionChanged={{selectionChanged}} @body={{rows}} @bulkActions={{true}} @class="grid" @descending={{descending}}
   @groupByKey="clusterTemplateId" @groupByRef="clusterTemplate" @headers={{headers}}
   @pagingLabel="pagination.clusterTemplates" @searchText={{searchText}} @sortBy={{sortBy}}
   @extraSearchFields={{extraSearchFields}} @subRows={{true}} @suffix={{suffix}} as |sortable kind inst dt|>

--- a/lib/shared/addon/components/sortable-table/component.js
+++ b/lib/shared/addon/components/sortable-table/component.js
@@ -189,7 +189,7 @@ export default Component.extend(Sortable, StickyHeader, {
   selection: observer('selectedNodes.[]', function() {
     const callback = get(this, 'selectionChanged');
 
-    if (callback) {
+    if (typeof callback === 'function') {
       callback(get(this, 'selectedNodes'));
     }
   }),

--- a/lib/shared/addon/components/sortable-table/component.js
+++ b/lib/shared/addon/components/sortable-table/component.js
@@ -69,6 +69,8 @@ export default Component.extend(Sortable, StickyHeader, {
   page:                 1,
   pagingLabel:          'pagination.generic',
 
+  selectionChanged: null,
+
   showHeader: or('bulkActions', 'searchInPlace'),
 
   // -----
@@ -183,6 +185,14 @@ export default Component.extend(Sortable, StickyHeader, {
       node.send(action);
     },
   },
+
+  selection: observer('selectedNodes.[]', function() {
+    const callback = get(this, 'selectionChanged');
+
+    if (callback) {
+      callback(get(this, 'selectedNodes'));
+    }
+  }),
 
   // Pick a new sort if the current column disappears.
   headersChanged: observer('headers.@each.name', function() {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1430,6 +1430,7 @@ clusterTemplatesPage:
     label: Compare
     header: Compare RKE Template Revisions
     closeModal: Close
+    error: Two RKE Template Revisions required to perform diff
   new:
     header: Add RKE Template
   headers:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1426,6 +1426,10 @@ clusterTemplatesPage:
   index:
     header: RKE Templates
     newTemplate: Add Template
+  compare:
+    label: Compare
+    header: Compare RKE Template Revisions
+    closeModal: Close
   new:
     header: Add RKE Template
   headers:


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/5954

Select two RKE revisions and a new 'Compare' button will be enabled - clicking this brings up a modal dialog showing the diff between the two template revisions.
<img width="1284" alt="image" src="https://user-images.githubusercontent.com/1955897/196626618-28f19d20-930b-40b1-8f38-b564970fa180.png">

<img width="1284" alt="image" src="https://user-images.githubusercontent.com/1955897/196626996-b41a0673-fd4e-42d6-bb7a-c207b0d340f4.png">

<img width="1284" alt="image" src="https://user-images.githubusercontent.com/1955897/196626742-a613ad15-5a9e-445c-a22b-65fe0eee2543.png">

(note ember images shown - these pages also appear embedded in the vue UI)

This PR:

- Adds a selectionChanged to sortable table and the cluster revisions table
- Wires this in to the cluster revisions view and adds a compare button (enabled when 2 revisions selected)
- Shows diff in a modal