### PR TITLE
Deployments: Check name for underscores

### DIFF
--- a/app/components/container/new-edit/template.hbs
+++ b/app/components/container/new-edit/template.hbs
@@ -10,6 +10,7 @@
       name=name
       nameDisabled=isUpgrade
       nameRequired=(not isUpgrade)
+      nameUnderscoreCheck=true
       bothColClass="col span-12 mt-0"
       colClass="col span-12 mt-0"
       description=description

--- a/lib/shared/addon/components/form-name-description/component.js
+++ b/lib/shared/addon/components/form-name-description/component.js
@@ -15,6 +15,7 @@ export default Component.extend({
 
   _name:        '',
   _description: '',
+  _nameValid:   true,
 
   nameLabel:           'formNameDescription.name.label',
   namePlaceholder:     'formNameDescription.name.placeholder',
@@ -22,6 +23,7 @@ export default Component.extend({
   nameRequired:        false,
   nameDisabled:        false,
   focusDisabledOnInit: false,
+  nameUnderscoreCheck: false,
 
   descriptionLabel:        'formNameDescription.description.label',
   descriptionHelp:         '',
@@ -109,6 +111,12 @@ export default Component.extend({
       set(this, 'model.name', val);
     } else {
       set(this, 'name', val);
+    }
+
+    if (get(this, 'nameUnderscoreCheck')) {
+      const valid = val.indexOf('_') === -1;
+
+      set(this, '_nameValid', valid);
     }
   },
 

--- a/lib/shared/addon/components/form-name-description/template.hbs
+++ b/lib/shared/addon/components/form-name-description/template.hbs
@@ -28,6 +28,7 @@
           }}
         {{/if}}
       {{#if nameHelpText}}<p class="text-info">{{nameHelpText}}</p>{{/if}}
+      {{#if (not _nameValid)}}<p class="text-error">{{t 'formNameDescription.name.underscoreError' }}</p>{{/if}}
     </div>
     {{#if hasBlock}}
       <div class="{{if (or hasBlock descriptionExpanded) bothColClass colClass}}">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -6981,6 +6981,7 @@ formNameDescription:
   name:
     label: Name
     placeholder: Name
+    underscoreError: Name can not contain the underscore character
   description:
     label: Description
     placeholder: Description


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/4861

Adds an optional check to the name/description input control that can check for underscores in name. Wires this in only for deployments.

Message is displayed below input box - this does cause other controls to move, but this is okay given the ember UI is deprecated.

![image](https://user-images.githubusercontent.com/1955897/196636215-17dbfecf-95cf-4fbb-86f9-c61af9e38722.png)