### PR TITLE
Add banners for 2.7 v1 deprecations

### DIFF
--- a/app/apps-tab/index/template.hbs
+++ b/app/apps-tab/index/template.hbs
@@ -1,3 +1,11 @@
+{{#banner-message color="bg-warning"}}
+  <p>{{t 'banner.apps' htmlSafe=true}}</p>
+{{/banner-message}}
+
+{{#banner-message color="bg-info"}}
+  <p>{{t 'banner.longhorn' htmlSafe=true}}</p>
+{{/banner-message}}
+
 <section class="header">
   <div class="pull-left">
     <h1>{{t 'nav.apps.apps'}}</h1>

--- a/app/authenticated/cluster/cluster-catalogs/template.hbs
+++ b/app/authenticated/cluster/cluster-catalogs/template.hbs
@@ -1,3 +1,7 @@
+{{#banner-message color="bg-warning"}}
+  <p>{{t 'banner.catalogs' htmlSafe=true}}</p>
+{{/banner-message}}
+
 <section class="header">
   <h1>{{t 'catalogSettings.header'}}</h1>
   <div class="right-buttons">

--- a/app/authenticated/project/project-catalogs/template.hbs
+++ b/app/authenticated/project/project-catalogs/template.hbs
@@ -1,3 +1,7 @@
+{{#banner-message color="bg-warning"}}
+  <p>{{t 'banner.catalogs' htmlSafe=true}}</p>
+{{/banner-message}}
+
 <section class="header">
   <h1>{{t 'catalogSettings.header'}}</h1>
   <div class="right-buttons">

--- a/lib/global-admin/addon/catalog/template.hbs
+++ b/lib/global-admin/addon/catalog/template.hbs
@@ -1,3 +1,7 @@
+{{#banner-message color="bg-warning"}}
+  <p>{{t 'banner.globalCatalogs' htmlSafe=true}}</p>
+{{/banner-message}}
+
 <section class="header">
   <h1>{{t 'catalogSettings.header'}}</h1>
   <div class="right-buttons">

--- a/lib/global-admin/addon/global-dns/entries/index/template.hbs
+++ b/lib/global-admin/addon/global-dns/entries/index/template.hbs
@@ -1,3 +1,7 @@
+{{#banner-message color="bg-warning"}}
+  <p>{{t 'banner.globalDnsEntries' htmlSafe=true}}</p>
+{{/banner-message}}
+
 <section class="header">
   <h1>
     {{t "globalDnsPage.header"}}

--- a/lib/global-admin/addon/global-dns/providers/index/template.hbs
+++ b/lib/global-admin/addon/global-dns/providers/index/template.hbs
@@ -1,4 +1,8 @@
-<section class="header">
+  {{#banner-message color="bg-warning"}}
+    <p>{{t 'banner.globalDnsProviders' htmlSafe=true}}</p>
+  {{/banner-message}}
+  
+  <section class="header">
   <h1>
     {{t "globalDnsPage.providersPage.title"}}
   </h1>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1015,6 +1015,12 @@ banner:
   pipeline21: Pipelines in Kubernetes 1.21+ are no longer supported.
   upgrade21: The legacy feature flag is enabled and not all legacy features are supported in Kubernetes 1.21+.
   secrets: Legacy project functionality can be used to manage secrets that need to be available to all namespaces in a project
+  globalDnsProviders: Global DNS Providers have been deprecated as of Rancher v2.7.0 and will be removed in a future release - check out the <a href="https://github.com/rancher/rancher/releases/tag/v2.7.0" target="_blank">Release Notes</a>.
+  globalDnsEntries: Global DNS Entries have been deprecated as of Rancher v2.7.0 and will be removed in a future release - check out the <a href="https://github.com/rancher/rancher/releases/tag/v2.7.0" target="_blank">Release Notes</a>.
+  globalCatalogs: Global Catalogs have been deprecated as of Rancher v2.7.0 and will be removed in a future release - check out the <a href="https://github.com/rancher/rancher/releases/tag/v2.7.0" target="_blank">Release Notes</a>.
+  catalogs: Catalogs have been deprecated as of Rancher v2.7.0 and will be removed in a future release - check out the <a href="https://github.com/rancher/rancher/releases/tag/v2.7.0" target="_blank">Release Notes</a>.
+  apps: Legacy Apps have been deprecated as of Rancher v2.7.0 and will be removed in a future release - check out the <a href="https://github.com/rancher/rancher/releases/tag/v2.7.0" target="_blank">Release Notes</a>.
+  longhorn: For more information on how to migrate the Longhorn chart installed in the legacy Rancher UI to the chart for the new Rancher UI see <a href="https://longhorn.io/kb/how-to-migrate-longhorn-chart-installed-in-old-rancher-ui-to-the-chart-in-new-rancher-ui/" target="_blank">here</a>.
 
 catalogPage:
   istio:


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/7210

Adds deprecation banners for features being deprecated in 2.7.

Deprecates:

- Global DNS Providers
- Global DNS Entries
- Catalogs (global, cluster and project)
- Apps (project)
- Adds an info banner on the Apps page about migrating Longhorn

Example banner:

![image](https://user-images.githubusercontent.com/1955897/196683463-a629f436-eb01-4242-a926-c45db1627aee.png)

Apps banner with Longhorn banner:

![image](https://user-images.githubusercontent.com/1955897/196683571-352a058b-e7b5-4c3f-92b1-170a40cca2e6.png)

