### PR TITLE
Change AKS experimental label to apply to K8s 1.25+

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-aks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-aks/component.js
@@ -57,8 +57,10 @@ const LB_SKUS = [
 ];
 
 
-// Because aks just put out 1.24.0 as a preview we're releasing it as experimental until we can adequately test it. https://github.com/rancher/dashboard/issues/6513
-const EXPERIMENTAL_RANGE = '>= 1.24.0'
+// Because aks just put out 1.25.0 as a preview we're releasing
+// it as experimental until we can adequately test it.
+// https://github.com/rancher/dashboard/issues/7217
+const EXPERIMENTAL_RANGE = '>= 1.25.0'
 
 export default Component.extend(ClusterDriver, {
   globalStore:          service(),


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/7217

Before: 
<img width="789" alt="Screen Shot 2022-10-20 at 12 05 00 PM" src="https://user-images.githubusercontent.com/20599230/197035830-4fe12109-ca84-4aa5-9863-a9fda1ddc51a.png">

After:

<img width="756" alt="Screen Shot 2022-10-20 at 12 05 40 PM" src="https://user-images.githubusercontent.com/20599230/197035949-ac68bb28-df55-4ea8-bb17-780a62bb3f56.png">
