### PR TITLE
Set 1.23 as minimum version for GKE and AKS

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-aks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-aks/component.js
@@ -61,6 +61,7 @@ const LB_SKUS = [
 // it as experimental until we can adequately test it.
 // https://github.com/rancher/dashboard/issues/7217
 const EXPERIMENTAL_RANGE = '>= 1.25.0'
+const MINIMUM_VERSION = '>= 1.23.0'
 
 export default Component.extend(ClusterDriver, {
   globalStore:          service(),
@@ -550,7 +551,7 @@ export default Component.extend(ClusterDriver, {
     } = this;
 
     // azure versions come in oldest to newest
-    return this.versionChoiceService.parseCloudProviderVersionChoices(( versions || [] ).reverse(), initialVersion, mode, null, false, EXPERIMENTAL_RANGE);
+    return this.versionChoiceService.parseCloudProviderVersionChoices(( versions || [] ).reverse(), initialVersion, mode, null, false, EXPERIMENTAL_RANGE, MINIMUM_VERSION);
   }),
 
   networkChoice: computed({

--- a/lib/shared/addon/components/cluster-driver/driver-gke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/component.js
@@ -14,6 +14,8 @@ import { DEFAULT_GKE_CONFIG, DEFAULT_GKE_NODE_POOL_CONFIG } from 'ui/models/clus
 import layout from './template';
 import Semver from 'semver';
 
+const MINIMUM_VERSION = '>= 1.23.0'
+
 export default Component.extend(ClusterDriver, {
   google:          service(),
   intl:            service(),
@@ -867,8 +869,7 @@ export default Component.extend(ClusterDriver, {
     }
 
     Semver.rsort(validMasterVersions, { includePrerelease: true });
-
-    const versionChoices = this.serviceVersions.parseCloudProviderVersionChoicesV2(validMasterVersions.slice(), initialVersion, mode);
+    const versionChoices = this.serviceVersions.parseCloudProviderVersionChoicesV2(validMasterVersions.slice(), initialVersion, mode, null, false, MINIMUM_VERSION);
 
     if (this.editing) {
       try {

--- a/lib/shared/addon/version-choices/service.js
+++ b/lib/shared/addon/version-choices/service.js
@@ -12,16 +12,17 @@ export default Service.extend({
 
   defaultK8sVersionRange: alias(`settings.${ C.SETTING.VERSION_SYSTEM_K8S_DEFAULT_RANGE }`),
 
-  parseCloudProviderVersionChoices(versions, providerVersion, mode, maxVersionRange = null, includePrerelease = false, experimentalRange = null) {
+  parseCloudProviderVersionChoices(versions, providerVersion, mode, maxVersionRange = null, _ = false, experimentalRange = null, minVersionRange = null) {
     let {
       intl,
       defaultK8sVersionRange
     } = this;
 
     maxVersionRange = maxVersionRange ? maxVersionRange : defaultK8sVersionRange.split(' ').pop();
+    minVersionRange = minVersionRange ? minVersionRange : defaultK8sVersionRange.split(' ').pop();
 
     return versions.map((version) => {
-      if (satisfies(coerceVersion(version), maxVersionRange, { includePrerelease })) {
+      if (satisfies(coerceVersion(version), maxVersionRange) && satisfies(coerceVersion(version), minVersionRange)) {
         const experimental = experimentalRange && satisfies(coerceVersion(version), experimentalRange) ? intl.t('generic.experimental')  : '';
         const out = {
           label: `${ version  } ${ experimental }`,
@@ -41,16 +42,17 @@ export default Service.extend({
       }
     }).filter((version) => version);
   },
-  parseCloudProviderVersionChoicesV2(versions, providerVersion, mode, maxVersionRange = null, includePrerelease = false) {
+  parseCloudProviderVersionChoicesV2(versions, providerVersion, mode, maxVersionRange = null, includePrerelease = false, minVersionRange = null) {
     let {
       intl,
       defaultK8sVersionRange
     } = this;
 
     maxVersionRange = maxVersionRange ? maxVersionRange : defaultK8sVersionRange.split(' ').pop();
+    minVersionRange = minVersionRange ? minVersionRange : defaultK8sVersionRange.split(' ').pop();
 
     return versions.map((version) => {
-      if (satisfies(version, maxVersionRange, { includePrerelease })) {
+      if (satisfies(version, maxVersionRange) && satisfies(version, minVersionRange)) {
         const out = {
           label: version,
           value: version,

--- a/lib/shared/addon/version-choices/service.js
+++ b/lib/shared/addon/version-choices/service.js
@@ -12,7 +12,7 @@ export default Service.extend({
 
   defaultK8sVersionRange: alias(`settings.${ C.SETTING.VERSION_SYSTEM_K8S_DEFAULT_RANGE }`),
 
-  parseCloudProviderVersionChoices(versions, providerVersion, mode, maxVersionRange = null, _ = false, experimentalRange = null, minVersionRange = null) {
+  parseCloudProviderVersionChoices(versions, providerVersion, mode, maxVersionRange = null, includePrerelease = false, experimentalRange = null, minVersionRange = null) {
     let {
       intl,
       defaultK8sVersionRange
@@ -22,7 +22,7 @@ export default Service.extend({
     minVersionRange = minVersionRange ? minVersionRange : defaultK8sVersionRange.split(' ').pop();
 
     return versions.map((version) => {
-      if (satisfies(coerceVersion(version), maxVersionRange) && satisfies(coerceVersion(version), minVersionRange)) {
+      if (satisfies(coerceVersion(version), maxVersionRange, { includePrerelease }) && satisfies(coerceVersion(version), minVersionRange)) {
         const experimental = experimentalRange && satisfies(coerceVersion(version), experimentalRange) ? intl.t('generic.experimental')  : '';
         const out = {
           label: `${ version  } ${ experimental }`,


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/7203 by setting a minimum value, 1.23, for AKS and GKE cluster provisioning.

K8s options for AKS are now these:
<img width="689" alt="Screen Shot 2022-10-20 at 1 05 05 PM" src="https://user-images.githubusercontent.com/20599230/197049851-6752f4cb-6689-4941-b2c3-bb1e490c3498.png">

K8s options for GKE are now these:
<img width="783" alt="Screen Shot 2022-10-20 at 1 14 19 PM" src="https://user-images.githubusercontent.com/20599230/197049941-416e3f0a-4fe1-4fa0-9306-6deb9f4cd6a5.png">
