### PR TITLE
Add StandardSSD as a storage option for Azure cluster provisioning

### DIFF
--- a/lib/shared/addon/utils/azure-choices.js
+++ b/lib/shared/addon/utils/azure-choices.js
@@ -454,6 +454,10 @@ export let storageTypes = [
   {
     name:  'Premium LRS',
     value: 'Premium_LRS',
+  },
+  {
+    name:  'Standard SSD LRS',
+    value: 'StandardSSD_LRS'
   }
 ];
 


### PR DESCRIPTION
This PR partly addresses https://github.com/rancher/dashboard/issues/7177 by adding StandardSSD to Azure storage options.

To test this PR,

1. Went to Cluster Management > RKE1 Configuration > Node Templates
2. Clicked Add Template
3. Clicked Azure
4. Went to the Instance section
5. Went to the Storage Type dropdown menu
6. Selected Standard SSD LRS, the new storage option

<img width="1100" alt="Screen Shot 2022-10-27 at 6 09 20 PM" src="https://user-images.githubusercontent.com/20599230/198431760-c22592ac-42a1-48d1-b34e-ee71581ca41f.png">



8. Added a name for the node template
9. Clicked Create
10. Created an RKE1 Kubernetes cluster in Azure using the new node template
11. Confirm that `StandardSSD_LRS` is sent in the network request

