### PR TITLE
Allow Authorization endpoint FQDN to accept port

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -1250,8 +1250,23 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       }
     }
 
+    // FQDN here can include port number
     if (fqdn) {
-      errors = validateHostname(fqdn, 'FQDN', get(this, 'intl'), { restricted: true }, errors);
+      const fqdnParts = fqdn.split(':');
+
+      if (fqdnParts.length > 2) {
+        errors.push(this.intl.t('authorizedEndpoint.fqdn.invalid'));
+      }
+
+      errors = validateHostname(fqdnParts[0], 'FQDN', get(this, 'intl'), { restricted: true }, errors);
+
+      if (fqdnParts.length === 2) {
+        const port = parseInt(fqdnParts[1], 10);
+
+        if (isNaN(port) || port < 1 || port > 65535) {
+          errors.push(this.intl.t('authorizedEndpoint.fqdn.invalid'));
+        }
+      }
     }
 
     return errors;

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3142,7 +3142,8 @@ authorizedEndpoint:
   enabled:
     label: Authorized Cluster Endpoint
   fqdn:
-    label: FQDN
+    label: Endpoint
+    invalid: Authorized Cluster Endpoint is invalid
 
 taintsSection:
   title: Taints


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/7235

- Renames FQDN to Endpoint.
- Accepts port number and validates