### PR TITLE
Remove v1 tools from nav

### DIFF
--- a/app/instance-initializers/nav.js
+++ b/app/instance-initializers/nav.js
@@ -33,25 +33,6 @@ const rootNav = [
         resourceScope:  'project',
       },
       {
-        id:             'pipelines',
-        localizedLabel: 'nav.infra.pipelines',
-        route:          'authenticated.project.pipeline.pipelines',
-        ctx:            [getProjectId],
-        resource:       [],
-        resourceScope:  'project',
-      },
-      {
-        id:             'istio',
-        localizedLabel: 'nav.tools.istio',
-        route:          'authenticated.project.istio.index',
-        ctx:            [getProjectId],
-        resource:       [],
-        resourceScope:  'project',
-        currentWhen:    [
-          'authenticated.project.istio.project-istio',
-        ],
-      },
-      {
         id:             'infra-secrets',
         localizedLabel: 'nav.infra.secrets',
         route:          'authenticated.project.secrets',
@@ -279,25 +260,6 @@ const rootNav = [
           return get(this, 'cluster.isActive')
         },
       },
-      {
-        id:                       'cluster-tools-istio',
-        localizedLabel:           'nav.tools.istio',
-        route:                    'authenticated.cluster.istio.cluster-setting',
-        resourceScope:            'global',
-        resource:                 [],
-        ctx:                      [getClusterId],
-        condition() {
-          return get(this, 'cluster.isActive')
-        },
-      },
-      {
-        id:                       'cluster-tools-cis-scan',
-        localizedLabel:           'nav.tools.cisScans',
-        route:                    'authenticated.cluster.cis/scan',
-        resourceScope:            'global',
-        resource:                 [],
-        ctx:                      [getClusterId],
-      },
       { divider: true },
       {
         id:                       'cluster-tools-backup',
@@ -312,11 +274,6 @@ const rootNav = [
         localizedLabel:           'nav.tools.gatekeeper',
         dashboardLink:            '/gatekeeper',
       },
-      // {
-      //   id:                       'cluster-tools-rio',
-      //   localizedLabel:           'nav.tools.rio',
-      //   dashboardLink:            '/rio',
-      // },
     ],
   },
 
@@ -327,14 +284,6 @@ const rootNav = [
     localizedLabel: 'nav.admin.clusters.tab',
     route:          'global-admin.clusters',
     resource:       ['cluster'],
-    resourceScope:  'global',
-  },
-  {
-    scope:          'global',
-    id:             'multi-cluster-apps',
-    localizedLabel: 'nav.admin.multiClusterApps',
-    route:          'global-admin.multi-cluster-apps',
-    resource:       ['multiclusterapp'],
     resourceScope:  'global',
   },
   {


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/6874

Updates the nav to hide the v1 tools that have been removed in 2.7