### PR TITLE
Current GKE/AKS version is shown even if below min version

### DIFF
--- a/lib/shared/addon/version-choices/service.js
+++ b/lib/shared/addon/version-choices/service.js
@@ -22,7 +22,10 @@ export default Service.extend({
     minVersionRange = minVersionRange ? minVersionRange : defaultK8sVersionRange.split(' ').pop();
 
     return versions.map((version) => {
-      if (satisfies(coerceVersion(version), maxVersionRange, { includePrerelease }) && satisfies(coerceVersion(version), minVersionRange)) {
+      // Only show versions between the max and min allowed versions, except if the cluster
+      // is already at a version below the minimum. In that case, the existing version still
+      // needs to be included as the default value when editing the cluster.
+      if (satisfies(coerceVersion(version), maxVersionRange, { includePrerelease }) && (version === providerVersion || satisfies(coerceVersion(version), minVersionRange))) {
         const experimental = experimentalRange && satisfies(coerceVersion(version), experimentalRange) ? intl.t('generic.experimental')  : '';
         const out = {
           label: `${ version  } ${ experimental }`,
@@ -52,7 +55,10 @@ export default Service.extend({
     minVersionRange = minVersionRange ? minVersionRange : defaultK8sVersionRange.split(' ').pop();
 
     return versions.map((version) => {
-      if (satisfies(version, maxVersionRange) && satisfies(version, minVersionRange)) {
+      // Only show versions between the max and min allowed versions, except if the cluster
+      // is already at a version below the minimum. In that case, the existing version still
+      // needs to be included as the default value when editing the cluster.
+      if (satisfies(version, maxVersionRange) && (version === providerVersion || satisfies(version, minVersionRange))) {
         const out = {
           label: version,
           value: version,


### PR DESCRIPTION
This PR fixes https://github.com/rancher/dashboard/issues/7276 by changing the logic for hiding unsupported GKE and AKS versions.

Previously, K8s versions 1.22 and below were always hidden. This change creates an exception for the edit form if the AKS or GKE cluster is already 1.22, in which case it shows the current version as the default.