### PR TITLE
Can add Azure tags to RKE1 node template

### DIFF
--- a/lib/nodes/addon/components/driver-azure/component.js
+++ b/lib/nodes/addon/components/driver-azure/component.js
@@ -56,11 +56,25 @@ export default Component.extend(NodeDriver, {
   model:              null,
   openPorts:          null,
   publicIpChoice:     null,
+  tags:               null,
   config:             alias(`model.${ CONFIG }`),
   storageTypeChoices: storageTypes.sortBy('name'),
 
   init() {
     this._super(...arguments);
+
+    const tagsString = get(this, 'config.tags');
+
+    if ( tagsString ) {
+      const array = tagsString.split(',');
+      const tags = {};
+
+      for (let i = 0; i < array.length - 1; i = i + 2) {
+        tags[array[i]] = array[i + 1];
+      }
+
+      set(this, 'tags', tags);
+    }
 
     scheduleOnce('afterRender', this, this.setupComponent);
   },
@@ -73,6 +87,18 @@ export default Component.extend(NodeDriver, {
 
   diskTypeChanged: observer('managedDisks', function() {
     set(this, 'config.managedDisks', get(this, 'managedDisks') === MANAGED);
+  }),
+
+  tagsObserver: observer('tags', function() {
+    const array = [];
+    const tags = get(this, 'tags') || {};
+
+    Object.keys(tags).forEach((key) => {
+      array.push(key);
+      array.push(tags[key]);
+    });
+
+    set(this, 'config.tags', array.join(','));
   }),
 
   evironmentChoiceObserver: observer('config.environment', function() {
@@ -143,6 +169,7 @@ export default Component.extend(NodeDriver, {
     let config = get(this, 'globalStore').createRecord({
       type:           CONFIG,
       subscriptionId: '',
+      tags:           '',
       openPort:       ['6443/tcp', '2379/tcp', '2380/tcp', '8472/udp', '4789/udp', '9796/tcp', '10256/tcp', '10250/tcp', '10251/tcp', '10252/tcp'],
     });
 

--- a/lib/nodes/addon/components/driver-azure/template.hbs
+++ b/lib/nodes/addon/components/driver-azure/template.hbs
@@ -361,6 +361,15 @@
         }}
       </div>
     </div>
+    <div class="row">
+      <div class="col span-12">
+        {{form-key-value
+        addActionLabel="nodeDriver.azure.tags.addActionLabel"
+        initialMap=tags
+        changed=(action (mut tags))
+        }}
+      </div>
+    </div>
   {{/accordion-list-item}}
 
   <div class="over-hr">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -9587,6 +9587,8 @@ nodeDriver:
       placeholder: "e.g. AllowVnetOutBound"
       helpText: When using a Rancher managed or providing an existing NSG, all nodes using this template will use the supplied NSG. If no NSG is provided, a new NSG will be created for each node.
       openPorts: When using an existing NSG, Open Ports are ignored.
+    tags:
+      addActionLabel: Add Azure Tags
   aliyunecs:
     accountSection:
       label: 1. Account Access


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/7164



This PR adds the "Azure Tags" button for RKE1 Azure node templates:
<img width="757" alt="Screen Shot 2022-10-26 at 9 12 39 PM" src="https://user-images.githubusercontent.com/20599230/198190926-7f7a6931-4518-484c-acf9-4c03be29b50f.png">

<img width="1406" alt="Screen Shot 2022-10-26 at 9 12 49 PM" src="https://user-images.githubusercontent.com/20599230/198190901-8951fb2d-9f09-4836-b8dd-ef51712f6554.png">

