### PR TITLE
Fix image option of Harvester Node Template

### DIFF
--- a/lib/nodes/addon/components/driver-harvester/component.js
+++ b/lib/nodes/addon/components/driver-harvester/component.js
@@ -177,7 +177,7 @@ export default Component.extend(NodeDriver, {
     }).then((resp) => {
       const images = resp.images.body.data || [];
       const imageContent = images.filter((O) => {
-        return !O.spec.url.endsWith('.iso') && this.isReady.call(O);
+        return O.spec.url.endsWith('.iso') && this.isReady.call(O);
       }).map((O) => {
         const value = O.id;
         const label = `${ O.spec.displayName } (${ value })`;


### PR DESCRIPTION
Proposed changes
======
I tried to create Node Template of a imported Harvester via Rancher UI. I could see Namespace options and Network Name options. But I could not see any Image option even when I have uploaded iso image on Harvester. This PR fixes image option of Harvester Node Template.


Types of changes
======
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
SURE-5517

Further comments
======

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>

