### PR TITLE
GKE inputs no longer look disabled

### DIFF
--- a/lib/shared/addon/components/gke-node-pool-row/template.hbs
+++ b/lib/shared/addon/components/gke-node-pool-row/template.hbs
@@ -1,4 +1,4 @@
-<div class="gke-node-pool-row box mt-20">
+<div class="gke-node-pool-row mt-20">
   <div class="row">
     <div class="pull-right">
       <button


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/3774

It seems that the `box` CSS class was adding colors to the form inputs that makes them look disabled. I removed this class, so now this section looks like the rest of the form.

Before:

<img width="1338" alt="Screenshot 2022-11-08 at 5 55 37 PM" src="https://user-images.githubusercontent.com/20599230/200710462-9d908514-307c-44be-a1ed-0c0cc2d72cda.png">

After:

<img width="1325" alt="Screenshot 2022-11-08 at 5 56 32 PM" src="https://user-images.githubusercontent.com/20599230/200710538-b4449d02-a402-4aba-ba70-b819a555f32a.png">
