### PR TITLE
update debian version in ci

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 RUN apt-get -qq update \
   && apt-get install -y curl gnupg2 apt-transport-https \
@@ -6,11 +6,10 @@ RUN apt-get -qq update \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
-  && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+  && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
   && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends \
   git ca-certificates nodejs yarn  \
   hicolor-icon-theme g++ google-chrome-stable \
-  && update-alternatives --install /usr/bin/node node /usr/bin/nodejs 12 \
   && yarn config set cache-folder /var/cache/yarn \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The drone pr test runs are failing with the error:  `Unable to correct problems, you have held broken packages.`

I poked around a bit and it seems we're using a version of Debian that hasn't been supported since June (and an outdated node version). Updating the debian version caused another error with the  `update-alternatives` command, but I couldn't work out why it was there in the first place and removing that command altogether doesn't appear to break anything. Just to be sure, I altered the CI script to build the ui from this PR (then reverted that change). 