### PR TITLE
RKE1 cluster create/edit forms no longer throw 404s

### DIFF
--- a/app/authenticated/cluster/route.js
+++ b/app/authenticated/cluster/route.js
@@ -30,7 +30,6 @@ export default Route.extend(Preload, {
         return get(this, 'scope').startSwitchToCluster(cluster).then(() => {
           if ( get(cluster, 'isReady') ) {
             const preloads = [
-              this.preload('clusterScan', 'globalStore'),
               this.preload('namespace', 'clusterStore'),
               this.preload('persistentVolume', 'clusterStore'),
               this.preload('storageClass', 'clusterStore'),

--- a/app/authenticated/route.js
+++ b/app/authenticated/route.js
@@ -117,7 +117,6 @@ export default Route.extend(Preload, {
             this.preload('globalRoleBinding', 'globalStore', { url: 'globalRoleBinding' }),
             this.preload('user', 'globalStore', { url: 'user' }),
             this.preload('features', 'globalStore', { url: 'features' }),
-            this.preload('clusterScan', 'globalStore'),
 
             globalStore.findAll('principal').then((principals) => {
               const me = principals.filter((p) => p.me === true);

--- a/lib/shared/addon/cis-helpers/service.js
+++ b/lib/shared/addon/cis-helpers/service.js
@@ -57,21 +57,16 @@ export default Service.extend({
     return this.profileToClusterScanConfig(this.defaultCisScanProfileOption);
   }),
 
-  cisScanConfigProfiles: computed(function() {
-    return this.globalStore.getById('schema', 'cisscanconfig').optionsFor('profile');
-  }),
+  // Fetching sicScanProfiles, cisConfigs, etc
+  // will now return 404 because the
+  // V1 CIS scan feature was removed.
 
-  cisConfigs: computed(function() {
-    return StatefulPromise.wrap(this.globalStore.findAll('cisConfig'), []);
-  }),
+  cisScanConfigProfiles: [],
 
-  benchmarkMapping: computed('cisConfigs.value', function() {
-    const configs = get(this, 'cisConfigs.value');
+  cisConfigs: [],
 
-    return configs.reduce((agg, config) => ({
-      ...agg,
-      [config.name]: config.params.benchmarkVersion
-    }), {})
+  benchmarkMapping: computed('cisConfigs.value', () => {
+    return []
   }),
 
   benchmarkMappingValues: computed('benchmarkMapping', function() {


### PR DESCRIPTION
This PR fixes three bugs:

## Creating a custom rke1 cluster switches UI to cluster list view instead of create/edit form
https://github.com/rancher/dashboard/issues/7699

To test, I went to create an RKE1 custom cluster and confirmed that the RKE1 custom cluster creation form appears instead of the old Ember cluster list view.

## Editing an active rancher provisioned rke1 cluster navigates to ember UI page
https://github.com/rancher/dashboard/issues/7688
To test, I created an RKE1 cluster, went to Edit Config, and confirmed that the cluster edit form appears instead of the old Ember cluster list view.

## vSphere Node Driver cluster goes back to old UI
https://github.com/rancher/dashboard/issues/7636

To test, I went to create all types of RKE1 node driver clusters, including vSphere, and confirmed that the correct form appears instead of the old Ember cluster list view.