### PR TITLE
If Azure storage type StandardSSD_LRS is selected, show managed disks warning

### DIFF
--- a/lib/nodes/addon/components/driver-azure/template.hbs
+++ b/lib/nodes/addon/components/driver-azure/template.hbs
@@ -328,6 +328,12 @@
           optionValuePath="value"
           value=config.storageType
         }}
+        {{#if (and (eq config.storageType 'StandardSSD_LRS') (eq managedDisks 'unmanaged'))}}
+          {{#banner-message color="bg-error"}}
+          <p>{{t 'nodeDriver.azure.managedDisks.warning'}}</p>
+          {{/banner-message}}
+        {{/if}}
+        
       </div>
     </div>
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -9525,6 +9525,7 @@ nodeDriver:
       label: Disk Size
       placeholder: e.g. 30
     managedDisks:
+      warning: StandardSSD_LRS requires managed disks. Please change the Disk Type to Managed Disk or select another storage type.
       label: Disk Type
       unmanaged: Unmanaged Disk
       managed: Managed Disk


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/7743

The StandardSSD_LRS storage option requires managed disks to work. So if StandardSSD_LRS is selected, and managed disks are not selected, there should now be an error message:
<img width="976" alt="Screenshot 2022-12-16 at 10 35 09 AM" src="https://user-images.githubusercontent.com/20599230/208159020-8fd4955c-f4c1-4229-bfbc-2596c4c45381.png">

If managed disks are enabled, the error message disappears:
<img width="985" alt="Screenshot 2022-12-16 at 10 46 55 AM" src="https://user-images.githubusercontent.com/20599230/208159073-1d6bbefb-0451-439b-b078-f2cd66bb4440.png">

This change applies to Azure RKE1 node templates. I'll be creating a similar PR for RKE2
