### PR TITLE
Fix issue editing cluster with agent env vars

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -1113,6 +1113,21 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
     set(this, 'errors', null);
 
+    // Fix up agent env vars - remove any with empty 'valueFrom' properties
+    const agentEnvVars = get(this, 'cluster.agentEnvVars') || [];
+    let didChangeEnvVars = false;
+
+    agentEnvVars.forEach((envVar) => {
+      if (envVar.valueFrom && Object.getOwnPropertyNames(envVar.valueFrom).length === 0) {
+        delete envVar.valueFrom;
+        didChangeEnvVars = true;
+      }
+    });
+
+    if (didChangeEnvVars) {
+      set(this, 'cluster.agentEnvVars', agentEnvVars);
+    }
+
     ok = this.validate();
 
     if (ok) {


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/6582

When editing as Yaml, an empty `fromValue` key gets added which causes problems - this PR goes through the agent env vars before save and removes `fromValue` from each var if it is empty.