### PR TITLE
RKE1 Azure node templates have accelerated networking and availability zones

### DIFF
--- a/lib/nodes/addon/components/driver-azure/component.js
+++ b/lib/nodes/addon/components/driver-azure/component.js
@@ -175,9 +175,9 @@ export default Component.extend(NodeDriver, {
     // If the user switches between availability sets and availability zones,
     // the other value should be cleared out.
     if (get(this, 'useAvailabilitySet')) {
-      set(this, 'config.availabilityZone', null);
+      set(this, 'config.availabilityZone', '');
     } else {
-      set(this, 'config.availabilitySet', null);
+      set(this, 'config.availabilitySet', '');
     }
   }),
 

--- a/lib/nodes/addon/components/driver-azure/component.js
+++ b/lib/nodes/addon/components/driver-azure/component.js
@@ -246,7 +246,7 @@ export default Component.extend(NodeDriver, {
     const withAnLabel = intl.t('nodeDriver.azure.size.supportsAcceleratedNetworking');
     const vmsWithAn = get(this, 'vmsWithAcceleratedNetworking');
     const vmsWithoutAn = get(this, 'vmsWithoutAcceleratedNetworking');
-    const out = [{
+    let out = [{
       kind:     'group',
       name:     noAnLabel,
       value:    noAnLabel,
@@ -261,15 +261,7 @@ export default Component.extend(NodeDriver, {
       })
       .concat(vmsWithAn)
 
-    if (!get(this, 'selectedVmSizeExistsInSelectedRegion')) {
-      out.push({
-        label:     get(this, 'config.size'),
-        value:    get(this, 'config.size'),
-        disabled: true
-      });
-    }
-
-    return out.map((vmData) => {
+    out = out.map((vmData) => {
       const { Name } = vmData;
 
       if (vmData.kind === 'group') {
@@ -282,6 +274,16 @@ export default Component.extend(NodeDriver, {
         disabled: vmData.disabled || false,
       };
     });
+
+    if (!get(this, 'selectedVmSizeExistsInSelectedRegion')) {
+      return out.concat({
+        label:    get(this, 'config.size'),
+        value:    get(this, 'config.size'),
+        disabled: true
+      });
+    }
+
+    return out
   }),
   privateSet: computed('publicIpChoice', 'publicIpChoices', function() {
     let publicIpChoice = get(this, 'publicIpChoice');
@@ -349,12 +351,9 @@ export default Component.extend(NodeDriver, {
       // Don't show the warning until the VM sizes are loaded
       return '';
     }
-    const selectedVmIsAvailableInSelectedRegion = this.vmSizes.filter((vmData) => {
-      return vmData.Name === get(this, 'config.size');
-    }).length > 0;
     const intl = window.l('service:intl')
 
-    if (!selectedVmIsAvailableInSelectedRegion) {
+    if (!get(this, 'selectedVmSizeExistsInSelectedRegion')) {
       return intl.t('nodeDriver.azure.size.availabilityWarning');
     }
 

--- a/lib/nodes/addon/components/driver-azure/component.js
+++ b/lib/nodes/addon/components/driver-azure/component.js
@@ -6,9 +6,11 @@ import { scheduleOnce } from '@ember/runloop';
 import Component from '@ember/component';
 import NodeDriver from 'shared/mixins/node-driver';
 import layout from './template';
-import { regions, sizes, storageTypes, environments } from 'ui/utils/azure-choices';
+import { storageTypes, environments } from 'ui/utils/azure-choices';
 import { inject as service } from '@ember/service';
 import { randomStr } from 'shared/utils/util';
+import { addQueryParams } from 'shared/utils/util';
+import { hash } from 'rsvp';
 
 const DRIVER = 'azure';
 const CONFIG = 'azureConfig';
@@ -47,18 +49,27 @@ export default Component.extend(NodeDriver, {
 
   layout,
   environments,
-  driverName:         DRIVER,
-  publicIpChoices:    IPCHOICES,
-  diskChoices:        DISK_CHOICES,
-  sizeChoices:        sizes,
-  managedDisks:       UNMANAGED,
-
-  model:              null,
-  openPorts:          null,
-  publicIpChoice:     null,
-  tags:               null,
-  config:             alias(`model.${ CONFIG }`),
-  storageTypeChoices: storageTypes.sortBy('name'),
+  driverName:                             DRIVER,
+  publicIpChoices:                        IPCHOICES,
+  diskChoices:                            DISK_CHOICES,
+  managedDisks:                           UNMANAGED,
+  model:                                  null,
+  openPorts:                              null,
+  publicIpChoice:                         null,
+  tags:                                   null,
+  step:                                   1,
+  useAvailabilitySet:                     true,
+  azureCredentialSecret:                  null,
+  regions:                                [],
+  regionsLoading:                         true,
+  vmSizes:                                [],
+  vmSizesLoading:                         true,
+  cloudCredentialId:                      '',
+  config:                                 alias(`model.${ CONFIG }`),
+  storageTypeChoices:                     storageTypes.sortBy('name'),
+  showVmAvailabilityZoneWarning:          computed.gt('vmAvailabilityZoneWarning.length', 0),
+  showVmSizeAvailabilityWarning:          computed.gt('vmSizeAvailabilityWarning.length', 0),
+  showVmSizeAcceleratedNetworkingWarning: computed.gt('vmSizeAcceleratedNetworkingWarning.length', 0),
 
   init() {
     this._super(...arguments);
@@ -76,17 +87,44 @@ export default Component.extend(NodeDriver, {
       set(this, 'tags', tags);
     }
 
+    const availabilityZone = get(this, 'config.availabilityZone');
+
+    if ( availabilityZone ) {
+      set(this, 'useAvailabilitySet', false);
+    }
+
     scheduleOnce('afterRender', this, this.setupComponent);
   },
-
   actions: {
-    finishAndSelectCloudCredential(credential) {
-      set(this, 'model.cloudCredentialId', get(credential, 'id'))
-    }
-  },
+    finishAndSelectCloudCredential(cred) {
+      if (cred) {
+        set(this, 'primaryResource.cloudCredentialId', get(cred, 'id'));
+      }
+    },
 
+    initAzureData(cb) {
+      const cloudCredentialId = get(this, 'primaryResource.cloudCredentialId')
+
+      set(this, 'cloudCredentialId', cloudCredentialId)
+
+      this.fetchVmSizes()
+      this.fetchRegions()
+      setProperties(this, { 'step': 2, });
+
+      if (cb && typeof cb === 'function') {
+        cb();
+      }
+    },
+  },
   diskTypeChanged: observer('managedDisks', function() {
     set(this, 'config.managedDisks', get(this, 'managedDisks') === MANAGED);
+  }),
+
+  locationObserver: observer('config.location', function(){
+    // When the location changes, the VM sizes should
+    // be refetched because not all sizes are available
+    // in all regions.
+    this.fetchVmSizes()
   }),
 
   tagsObserver: observer('tags', function() {
@@ -99,12 +137,6 @@ export default Component.extend(NodeDriver, {
     });
 
     set(this, 'config.tags', array.join(','));
-  }),
-
-  evironmentChoiceObserver: observer('config.environment', function() {
-    let environment = get(this, 'config.environment');
-
-    set(this, 'config.location', regions[environment][0].name);
   }),
 
   ipChoiceObserver: observer('publicIpChoice', function() {
@@ -139,12 +171,118 @@ export default Component.extend(NodeDriver, {
     set(this, 'config.openPort', ary);
   }),
 
-  regionChoices: computed('config.environment', function() {
-    const environment = get(this, 'config.environment');
-
-    return regions[environment];
+  useAvailabilitySetObserver: observer('useAvailabilitySet', function() {
+    // If the user switches between availability sets and availability zones,
+    // the other value should be cleared out.
+    if (get(this, 'useAvailabilitySet')) {
+      set(this, 'config.availabilityZone', null);
+    } else {
+      set(this, 'config.availabilitySet', null);
+    }
   }),
 
+  vmsWithAcceleratedNetworking: computed('vmSizes', function() {
+    return get(this, 'vmSizes').filter((vmData) => {
+      return vmData.AcceleratedNetworkingSupported;
+    });
+  }),
+
+  vmsWithoutAcceleratedNetworking: computed('vmSizes', function() {
+    return get(this, 'vmSizes').filter((vmData) => {
+      return !vmData.AcceleratedNetworkingSupported;
+    });
+  }),
+
+  selectedVmSizeExistsInSelectedRegion: computed('config.{location,size}', 'vmSizes', function() {
+    // If the user selects a region and then a VM size
+    // that does not exist in the region, the list of VM
+    // sizes will update, causing the selected VM size
+    // to disappear. A disappearing VM size seems like a
+    // bad UX, so this value allows the value to be
+    // added to the VM size dropdown, while an error message
+    // indicates that the size is invalid.
+    if (get(this, 'vmSizes').find((size) => {
+      return size.Name === get(this, 'config.size');
+    })) {
+      return true;
+    }
+
+    return false;
+  }),
+
+  vmsWithAvailabilityZones: computed('vmSizes', function() {
+    return get(this, 'vmSizes').filter((vmData) => {
+      return vmData.AvailabilityZones.length > 0;
+    });
+  }),
+
+
+  availabilityZoneChoices: computed('config.{location,size}', 'regions', 'vmSizes', function() {
+    const vmData = get(this, 'vmSizes').find((vm) => {
+      return vm.Name === get(this, 'config.size')
+    })
+
+    if (vmData) {
+      return vmData.AvailabilityZones.map((zone) => {
+        return {
+          name:  zone,
+          value: zone,
+        };
+      });
+    }
+
+    return [];
+  }),
+  sizeChoices: computed('config.size', 'selectedVmSizeExistsInSelectedRegion', 'vmSizes', 'vmsWithAcceleratedNetworking', 'vmsWithoutAcceleratedNetworking', function() {
+    // example vmSize option from backend:
+    // {
+    //   AcceleratedNetworkingSupported: false,
+    //   AvailabilityZones: [],
+    //   Name: "Basic_A0"
+    // }
+    const intl = window.l('service:intl');
+
+    const noAnLabel = intl.t('nodeDriver.azure.size.doesNotSupportAcceleratedNetworking');
+    const withAnLabel = intl.t('nodeDriver.azure.size.supportsAcceleratedNetworking');
+    const vmsWithAn = get(this, 'vmsWithAcceleratedNetworking');
+    const vmsWithoutAn = get(this, 'vmsWithoutAcceleratedNetworking');
+    const out = [{
+      kind:     'group',
+      name:     noAnLabel,
+      value:    noAnLabel,
+      disabled: true
+    }]
+      .concat(vmsWithoutAn)
+      .concat({
+        kind:     'group',
+        name:     withAnLabel,
+        value:    withAnLabel,
+        disabled: true
+      })
+      .concat(vmsWithAn)
+
+    if (!get(this, 'selectedVmSizeExistsInSelectedRegion')) {
+      out.push({
+        label:     get(this, 'config.size'),
+        value:    get(this, 'config.size'),
+        disabled: true
+      });
+    }
+
+    return out.map((vmData) => {
+      const { Name } = vmData;
+
+      if (vmData.kind === 'group') {
+        return vmData;
+      }
+
+      return {
+        label:    Name,
+        value:    Name,
+        disabled: vmData.disabled || false,
+      };
+    });
+  }),
   privateSet: computed('publicIpChoice', 'publicIpChoices', function() {
     let publicIpChoice = get(this, 'publicIpChoice');
 
@@ -164,6 +302,151 @@ export default Component.extend(NodeDriver, {
 
     return false;
   }),
+
+  selectedVmSizeHasZones: computed('config.{location,size}', 'value.size', 'vmSizes', 'vmsWithAvailabilityZones', function() {
+    const dataForSelectedSize = this.vmsWithAvailabilityZones.filter((vmData) => {
+      const { Name } = vmData;
+
+      return Name === get(this, 'config.size');
+    });
+
+    if (dataForSelectedSize.length > 0) {
+      return dataForSelectedSize[0].AvailabilityZones.length > 0;
+    }
+
+    return false;
+  }),
+
+  selectedVmSizeSupportsAN: computed('config.{location,size}', 'vmSizes', 'vmsWithAcceleratedNetworking', function() {
+    const selectedSizeIsValid = !!this.vmsWithAcceleratedNetworking.find((vmData) => {
+      return get(this, 'config.size') === vmData.Name;
+    });
+
+    return selectedSizeIsValid;
+  }),
+
+  vmSizeAcceleratedNetworkingWarning: computed('config.{acceleratedNetworking,location,size}', 'selectedVmSizeSupportsAN', 'vmSizes.length', function() {
+    if (get(this, 'vmSizes.length') === 0) {
+      // Don't show the warning until the VM sizes are loaded
+      return '';
+    }
+
+    const intl = window.l('service:intl')
+
+    if (!this.selectedVmSizeSupportsAN && get(this, 'config.acceleratedNetworking')) {
+      return intl.t('nodeDriver.azure.size.selectedSizeAcceleratedNetworkingWarning');
+    }
+
+    return '';
+  }),
+
+  vmSizeAvailabilityWarning: computed('config.{location,size}', 'regions.length', 'selectedVmSizeExistsInSelectedRegion', 'vmSizes.length', function() {
+    if (get(this, 'regions.length') === 0) {
+      // Don't show the warning until the regions are loaded
+      return '';
+    }
+    if (get(this, 'vmSizes.length') === 0) {
+      // Don't show the warning until the VM sizes are loaded
+      return '';
+    }
+    const selectedVmIsAvailableInSelectedRegion = this.vmSizes.filter((vmData) => {
+      return vmData.Name === get(this, 'config.size');
+    }).length > 0;
+    const intl = window.l('service:intl')
+
+    if (!selectedVmIsAvailableInSelectedRegion) {
+      return intl.t('nodeDriver.azure.size.availabilityWarning');
+    }
+
+    return ''
+  }),
+
+  vmAvailabilityZoneWarning: computed('config.{location,size}', 'selectedVmSizeHasZones', 'useAvailabilitySet', 'value.size', 'vmSizes.length', 'vmsWithAvailabilityZones.length', function() {
+    if (this.useAvailabilitySet) {
+      return '';
+    }
+    if (get(this, 'vmSizes.length') === 0) {
+      // Don't show the warning until the VM sizes are loaded
+      return '';
+    }
+
+    const intl = window.l('service:intl')
+
+    if (this.vmsWithAvailabilityZones.length === 0) {
+      /**
+       * Show UI warning: Availability zones are not supported in the selected
+       * region. Please select a different region or use an
+       * availability set instead.
+       */
+      return intl.t('nodeDriver.azure.size.regionDoesNotSupportAzs');
+    }
+
+    if (this.vmsWithAvailabilityZones.length > 0 && !this.selectedVmSizeHasZones) {
+      /**
+       * Show UI warning: The selected region does not support availability
+       * zones for the selected VM size. Please select a
+       * different region or VM size.
+       */
+      return intl.t('nodeDriver.azure.size.regionSupportsAzsButNotThisSize');
+    }
+
+    return '';
+  }),
+
+  fetchRegions(){
+    const store = get(this, 'globalStore')
+
+    const regions = addQueryParams('/meta/aksLocations', { cloudCredentialId: this.cloudCredentialId })
+
+    const aksRequest = {
+      regions: store.rawRequest({
+        url:    regions,
+        method: 'GET',
+      })
+    }
+
+    hash(aksRequest).then((resp) => {
+      const { regions } = resp;
+
+      setProperties(this, {
+        regions:        regions?.body || [],
+        regionsLoading: false
+      });
+    }).catch((xhr) => {
+      const err = xhr.body?.message || xhr.body?.code || xhr.body?.error;
+
+      setProperties(this, { errors: [err], });
+    })
+  },
+
+  fetchVmSizes(){
+    const store = get(this, 'globalStore')
+
+    const vmSizes = addQueryParams('/meta/aksVMSizesV2', {
+      cloudCredentialId: this.cloudCredentialId,
+      region:            get(this, 'config.location'),
+    });
+
+    const aksRequest = {
+      vmSizes: store.rawRequest({
+        url:    vmSizes,
+        method: 'GET',
+      }),
+    }
+
+    hash(aksRequest).then((resp) => {
+      const { vmSizes } = resp;
+
+      setProperties(this, {
+        vmSizes:        vmSizes?.body || [],
+        vmSizesLoading: false
+      });
+    }).catch((xhr) => {
+      const err = xhr.body.message || xhr.body.code || xhr.body.error;
+
+      setProperties(this, { errors: [err], });
+    });
+  },
 
   bootstrap() {
     let config = get(this, 'globalStore').createRecord({
@@ -211,6 +494,9 @@ export default Component.extend(NodeDriver, {
 
     return true;
   },
+
+
+
 
   setupComponent() {
     setProperties(this, {

--- a/lib/nodes/addon/components/driver-azure/template.hbs
+++ b/lib/nodes/addon/components/driver-azure/template.hbs
@@ -182,9 +182,9 @@
               optionValuePath="value"
               value=config.availabilityZone
             }}
-            {{#if showVmAvailabilityZoneWarning}}
+            {{#if showVmSizeAvailabilityWarning}}
               {{#banner-message color="bg-error"}}
-                <p>{{vmAvailabilityZoneWarning}}</p>
+                <p>{{vmSizeAvailabilityWarning}}</p>
               {{/banner-message}}
             {{/if}}
           </div>

--- a/lib/nodes/addon/components/driver-azure/template.hbs
+++ b/lib/nodes/addon/components/driver-azure/template.hbs
@@ -5,26 +5,33 @@
     </span>
   </div>
 
-  {{#accordion-list-item
-    title=(t "nodeDriver.azure.access.title")
-    detail=(t "nodeDriver.azure.access.detail")
-    expandAll=expandAll
-    expand=(action expandFn)
-    expandOnInit=true
-  }}
+  
+
+  {{#if (eq step 1)}}
+    {{#accordion-list-item
+      title=(t "nodeDriver.azure.access.title")
+      detail=(t "nodeDriver.azure.access.detail")
+      expandAll=expandAll
+      expand=(action expandFn)
+      expandOnInit=true
+    }}
     {{form-auth-cloud-credential
       driverName=driverName
       parseAndCollectErrors=(action "errorHandler")
       primaryResource=primaryResource
       cloudCredentials=cloudCredentials
+      createLabel="nodeDriver.amazonec2.access.next"
+      region=config.location
       finishAndSelectCloudCredential=(action "finishAndSelectCloudCredential")
-      progressStep=(action "finishAndSelectCloudCredential")
+      progressStep=(action "initAzureData")
       cancel=(action "cancel")
-      hideSave=true
     }}
+    {{top-errors errors=errors}}
+    {{/accordion-list-item}}
+  {{/if}}
+  
 
-  {{/accordion-list-item}}
-
+<div class="{{unless (gte step 2) "hide"}}">
   {{#accordion-list-item
      title=(t "nodeDriver.azure.placement.title")
      detail=(t "nodeDriver.azure.placement.detail")
@@ -33,79 +40,47 @@
      expandOnInit=true
   }}
     <div class="row">
-      <div class="col span-6">
-        <label class="acc-label">
-          {{t "nodeDriver.azure.environment.label"}}
-        </label>
-        {{new-select
-          classNames="form-control"
-          content=environments
-          optionLabelPath="value"
-          value=config.environment
-        }}
-      </div>
+
       <div class="col span-6">
         <label class="acc-label">
           {{t "nodeDriver.azure.region.label"}}
         </label>
-        {{new-select
+        {{#if regionsLoading}}
+          <i class="icon icon-spinner icon-spin"></i>
+        {{else}}
+          {{new-select
           classNames="form-control"
-          content=regionChoices
+          content=regions
           optionLabelPath="displayName"
           optionValuePath="name"
           value=config.location
         }}
+          {{#if showVmSizeAvailabilityWarning}}
+            {{#banner-message color="bg-error"}}
+              <p>{{vmSizeAvailabilityWarning}}</p>
+            {{/banner-message}}
+          {{/if}}
+        {{/if}}
       </div>
     </div>
 
     <div class="row">
       <div class="col span-6">
         <label class="acc-label">
-          {{t "nodeDriver.azure.availabilitySet.label" type=managedDisks}}
+          {{t "clusterNew.googlegke.serviceAccount.label"}}
         </label>
-        {{input
-          type="text"
-          value=config.availabilitySet
+        {{searchable-select
+          content=serviceAccountContent
           classNames="form-control"
-          placeholder=(t "nodeDriver.azure.availabilitySet.placeholder")
+          value=config.serviceAccount
+          optionLabelPath="displayName"
+          optionValuePath="uniqueId"
+          readOnly=editing
         }}
-      </div>
-
-      <div class="col span-6">
-        <label class="acc-label" for="input-fault-domain-count">
-          {{t "nodeDriver.azure.faultDomainCount.label"}}
-        </label>
-        {{input-number
-          id="input-fault-domain-count"
-          value=config.faultDomainCount
-          min=1
-          max=3
-          classNames="form-control"
-          placeholder=(t "nodeDriver.azure.faultDomainCount.placeholder")
-        }}
-        <p class="help-block">
-          {{t "nodeDriver.azure.faultDomainCount.helpText"}}
-        </p>
       </div>
     </div>
 
     <div class="row">
-      <div class="col span-6">
-        <label class="acc-label" for="input-update-domain-count">
-          {{t "nodeDriver.azure.updateDomainCount.label"}}
-        </label>
-        {{input-number
-          value=config.updateDomainCount
-          id="input-update-domain-count"
-          min=1
-          classNames="form-control"
-          placeholder=(t "nodeDriver.azure.updateDomainCount.placeholder")
-        }}
-        <p class="help-block">
-          {{t "nodeDriver.azure.updateDomainCount.helpText"}}
-        </p>
-      </div>
-
       <div class="col span-6">
         <label class="acc-label" for="input-resource-group">
           {{t "nodeDriver.azure.resourceGroup.label"}}
@@ -134,6 +109,127 @@
         }}
       </div>
     </div>
+    <div class="row">
+       
+        <div class="col span-6">
+          <div class="radio">
+            <label>
+              {{radio-button
+                selection=useAvailabilitySet
+                value=true
+              }}
+
+               {{#tooltip-element
+                  type="tooltip-basic"
+                  model=(t "nodeDriver.azure.availabilitySet.description")
+                  tooltipTemplate="tooltip-static"
+                  aria-describedby="tooltip-base"
+                  baseClass="text-left"
+                }}
+                <span>
+                  {{t "nodeDriver.azure.availabilitySet.label" type=managedDisks }}
+                  <i class="icon icon-help icon-blue"/>
+                </span>
+              {{/tooltip-element}}
+
+              
+            </label>
+          </div>
+          <div class="radio">
+            <label>
+              {{radio-button
+                selection=useAvailabilitySet
+                value=false
+              }}
+               {{#tooltip-element
+                  type="tooltip-basic"
+                  model=(t "nodeDriver.azure.availabilityZone.description")
+                  tooltipTemplate="tooltip-static"
+                  aria-describedby="tooltip-base"
+                  baseClass="text-left"
+                }}
+                <span>
+                  {{t "nodeDriver.azure.availabilityZone.label" }}
+                  <i class="icon icon-help icon-blue"/>
+                </span>
+              {{/tooltip-element}}
+            </label>
+          </div>
+        </div>
+
+        {{#if (eq useAvailabilitySet true)}}
+          <div class="col span-6">
+            <label class="acc-label">
+              {{t "nodeDriver.azure.availabilitySet.label" type=managedDisks}}
+            </label>
+            {{input
+              type="text"
+              value=config.availabilitySet
+              classNames="form-control"
+              placeholder=(t "nodeDriver.azure.availabilitySet.placeholder")
+            }}
+          </div>
+        {{/if}}
+        {{#if (eq useAvailabilitySet false)}}
+          <div class="col span-6">
+            <label class="acc-label">
+              {{t "nodeDriver.azure.availabilityZone.label" }}
+            </label>
+            {{new-select
+              classNames="form-control"
+              content=availabilityZoneChoices
+              optionLabelPath="name"
+              optionValuePath="value"
+              value=config.availabilityZone
+            }}
+            {{#if showVmAvailabilityZoneWarning}}
+              {{#banner-message color="bg-error"}}
+                <p>{{vmAvailabilityZoneWarning}}</p>
+              {{/banner-message}}
+            {{/if}}
+          </div>
+        {{/if}}
+      </div>
+     
+      {{#if (eq useAvailabilitySet true)}}
+      <hr/>
+      <div class="row" >
+          <h3>{{t "nodeDriver.azure.availabilitySet.sectionTitle" }}</h3>
+          <div class="col span-6">
+            <label class="acc-label" for="input-fault-domain-count">
+              {{t "nodeDriver.azure.faultDomainCount.label"}}
+            </label>
+            {{input-number
+              id="input-fault-domain-count"
+              value=config.faultDomainCount
+              min=1
+              max=3
+              classNames="form-control"
+              placeholder=(t "nodeDriver.azure.faultDomainCount.placeholder")
+            }}
+            <p class="help-block">
+              {{t "nodeDriver.azure.faultDomainCount.helpText"}}
+            </p>
+          </div>
+          <div class="col span-6">
+            <label class="acc-label" for="input-update-domain-count">
+              {{t "nodeDriver.azure.updateDomainCount.label"}}
+            </label>
+            {{input-number
+              id="input-update-domain-count"
+              value=config.updateDomainCount
+              min=1
+              max=3
+              classNames="form-control"
+              placeholder=(t "nodeDriver.azure.updateDomainCount.placeholder")
+            }}
+            <p class="help-block">
+              {{t "nodeDriver.azure.updateDomainCount.helpText"}}
+            </p>
+          </div>
+      </div>
+      {{/if}}
+      
   {{/accordion-list-item}}
 
   {{#accordion-list-item
@@ -235,6 +331,22 @@
           {{t "nodeDriver.azure.nsg.helpText"}}
         </p>
       </div>
+      <div class="col span-6">
+        <label class="acc-label">
+          {{t "nodeDriver.azure.acceleratedNetworking.label"}}
+        </label>
+        <div>
+          {{input
+            type="checkbox"
+            checked=config.acceleratedNetworking
+          }}
+        </div>
+        {{#if showVmSizeAcceleratedNetworkingWarning}}
+          {{#banner-message color="bg-error"}}
+            <p>{{vmSizeAcceleratedNetworkingWarning}}</p>
+          {{/banner-message}}
+        {{/if}}
+      </div>
     </div>
   {{/accordion-list-item}}
 
@@ -264,13 +376,35 @@
         <label class="acc-label">
           {{t "nodeDriver.azure.size.label"}}
         </label>
-        {{new-select
-          classNames="form-control"
-          content=sizeChoices
-          optionLabelPath="value"
-          optionGroupPath="group"
-          value=config.size
-        }}
+        {{#if vmSizesLoading}}
+          <i class="icon icon-spinner icon-spin"></i>
+        {{else}}
+          {{new-select
+            classNames="form-control"
+            content=sizeChoices
+            optionLabelPath="value"
+            optionGroupPath="group"
+            value=config.size
+          }}
+          {{#if showVmSizeAvailabilityWarning}}
+            {{#banner-message color="bg-error"}}
+              <p>{{vmSizeAvailabilityWarning}}</p>
+            {{/banner-message}}
+          {{/if}}
+          {{#if showVmAvailabilityZoneWarning}}
+            {{#banner-message color="bg-error"}}
+              <p>{{vmAvailabilityZoneWarning}}</p>
+            {{/banner-message}}
+          {{/if}}
+          {{#if showVmSizeAcceleratedNetworkingWarning}}
+            {{#banner-message color="bg-error"}}
+              <p>{{vmSizeAcceleratedNetworkingWarning}}</p>
+            {{/banner-message}}
+          {{/if}}
+
+        {{/if}}
+        
+    
       </div>
     </div>
 
@@ -415,4 +549,5 @@
     cancel=(action "cancel")
     editing=editing
   }}
+  </div>
 {{/accordion-list}}

--- a/lib/nodes/addon/components/driver-azure/template.hbs
+++ b/lib/nodes/addon/components/driver-azure/template.hbs
@@ -333,12 +333,24 @@
       </div>
       <div class="col span-6">
         <label class="acc-label">
-          {{t "nodeDriver.azure.acceleratedNetworking.label"}}
+          {{#tooltip-element
+            type="tooltip-basic"
+            model=(t "nodeDriver.azure.acceleratedNetworking.tooltip")
+            tooltipTemplate="tooltip-static"
+            aria-describedby="tooltip-base"
+            baseClass="text-left"
+          }}
+           <span>
+            {{t "nodeDriver.azure.acceleratedNetworking.label"}}
+            <i class="icon icon-help icon-blue"/>
+          </span>
+        {{/tooltip-element}}
         </label>
         <div>
           {{input
             type="checkbox"
             checked=config.acceleratedNetworking
+            disabled=(and (not config.acceleratedNetworking) (not selectedVmSizeSupportsAN))
           }}
         </div>
         {{#if showVmSizeAcceleratedNetworkingWarning}}
@@ -386,11 +398,6 @@
             optionGroupPath="group"
             value=config.size
           }}
-          {{#if showVmSizeAvailabilityWarning}}
-            {{#banner-message color="bg-error"}}
-              <p>{{vmSizeAvailabilityWarning}}</p>
-            {{/banner-message}}
-          {{/if}}
           {{#if showVmAvailabilityZoneWarning}}
             {{#banner-message color="bg-error"}}
               <p>{{vmAvailabilityZoneWarning}}</p>

--- a/lib/shared/addon/components/sortable-table/component.js
+++ b/lib/shared/addon/components/sortable-table/component.js
@@ -586,8 +586,8 @@ export default Component.extend(Sortable, StickyHeader, {
       for ( let j = 0 ; j < items.get('length') ; j++ ) {
         if ( items.objectAt(j) === node ) {
           return {
-            group: i,
-            item:  j
+            i,
+            item: j
           };
         }
       }

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -9542,7 +9542,14 @@ nodeDriver:
       label: Purchase Plan
       placeholder: publisher:product:plan
     size:
-      label: Size
+      label: VM Size
+      tooltip: When accelerated networking is enabled, not all sizes are available.
+      supportsAcceleratedNetworking: Sizes that Support Accelerated Networking
+      doesNotSupportAcceleratedNetworking: Sizes Without Accelerated Networking
+      availabilityWarning: The selected VM size is not available in the selected region.
+      regionDoesNotSupportAzs: Availability zones are not supported in the selected region. Please select a different region or use an availability set instead.
+      regionSupportsAzsButNotThisSize: The selected region does not support availability zones for the selected VM size. Please select a different region or VM size.
+      selectedSizeAcceleratedNetworkingWarning: The selected VM size does not support accelerated networking. Please select another VM size or disable accelerated networking.
     dockerPort:
       label: Docker Port
       placeholder: '2376'
@@ -9569,9 +9576,16 @@ nodeDriver:
     subnetPrefix:
       label: Subnet Prefix
       placeholder: 128.42.0.0/21
+    acceleratedNetworking:
+      label: Accelerated Networking
     availabilitySet:
       label: "Availability Set ({type})"
       placeholder: availability-set-name
+      description: Availability sets are used to protect applications from hardware failures within an Azure data center.
+      sectionTitle: Availability Set Config
+    availabilityZone:
+      label: Availability Zone
+      description: Availability zones protect applications from complete Azure data center failures.
     openPort:
       label: Open Port
       placeholder: 'Comma-separated, e.g. 80,443'

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -9578,6 +9578,7 @@ nodeDriver:
       placeholder: 128.42.0.0/21
     acceleratedNetworking:
       label: Accelerated Networking
+      tooltip: Accelerated networking is only supported for certain VM sizes.
     availabilitySet:
       label: "Availability Set ({type})"
       placeholder: availability-set-name


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/7753 and https://github.com/rancher/dashboard/issues/7752

This PR is functionally the same as https://github.com/rancher/dashboard/pull/7687, but for RKE1 node templates.

### New options
- Can select an availability zone.
- Can enable accelerated networking.
- The VM size dropdown is grouped so that you can see which VMs support accelerated networking and which do not.

### Refetching
- VMs are refetched when the region changes because different sizes are available per region.

### Error messages
- Warn the user when the selected VM size is not in the selected region.
- Warn the user if they have selected availability zones, but that is not supported for the region or VM size.
	- For example, South Africa North has availability zones for some sizes but not others. So `Standard_A2_v2` in that region has three AZs and that works, but if you change the size to `Standard_A2_v2` you see an error.
- Warn the user if they wanted availability zones, but availability zones are not supported in the selected region.
- Warn the user if accelerated networking is enabled but the selected VM size does not support accelerated networking. Show the warning by the vm sizes and by the AN checkbox.

### Notes
- Replaced the hardcoded VM size list with V2 API call to get VM sizes.
- Replaced the hardcoded region list with the API call to get regions, to show the full list and be consistent with AKS and RKE2/K3s provisioning.
- I deleted the "environment" choice dropdown because it was last updated five years ago, and while I assume it worked at the time, it doesn't work like that anymore. Now the environment, such as Azure public cloud or the government cloud, is configured in the cloud credentials, and the credentials are used to fetch the regions, so the environment should not be able to be configured in this form. If you want to create nodes in a different environment, you should use a different cloud credential. We may want to call that out in the release notes.
- Because the form now needs to call the Azure API with the user's credentials, I have changed the form so that you can't see it until valid credentials are selected.
- I think there is a backend bug where if you first create a node template with an availability zone, then change it to an availability set, the change does not get persisted. Edit: Fixed by clearing out values using empty string instead of null.