### PR TITLE
HARVESTER: exclude the network created by storage-network

### DIFF
--- a/lib/nodes/addon/components/driver-harvester/component.js
+++ b/lib/nodes/addon/components/driver-harvester/component.js
@@ -37,6 +37,8 @@ const PRIORITY = {
   PREFERRED: 'preferred'
 };
 
+const STORAGE_NETWORK = 'storage-network.settings.harvesterhci.io'
+
 export default Component.extend(NodeDriver, {
   growl:     service(),
   settings: service(),
@@ -189,7 +191,9 @@ export default Component.extend(NodeDriver, {
       });
 
       const networks = resp.networks.body.data || [];
-      const networkContent = networks.map((O) => {
+      const networkContent = networks.filter((O) => {
+        return O.metadata?.annotations?.[STORAGE_NETWORK] !== 'true'
+      }).map((O) => {
         let id = '';
 
         try {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

The network created by harvester storage-network should be excluded on harvester node driver page(RKE1)

Types of changes
======

Bugfix (non-breaking change which fixes an issue)

Linked Issues
======

- https://github.com/harvester/harvester/issues/3163

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
