### PR TITLE
Redirect /login to /dashboard

### DIFF
--- a/lib/login/addon/login/controller.js
+++ b/lib/login/addon/login/controller.js
@@ -34,9 +34,18 @@ export default Controller.extend({
   resetPassword:       false,
   code:                null,
   showLocal:           null,
+  showLogin:           false,
 
   promptPasswordReset: alias('resetPassword'),
   isForbidden:         equal('errorCode', '403'),
+
+  init() {
+    this._super(...arguments);
+
+    const isDevelopment = get(this, 'app.environment') === 'development';
+
+    this.set('showLogin', isDevelopment);
+  },
 
   actions: {
     started() {

--- a/lib/login/addon/login/route.js
+++ b/lib/login/addon/login/route.js
@@ -85,7 +85,14 @@ export default Route.extend({
   },
 
   activate() {
-    $('BODY').addClass('container-farm'); // eslint-disable-line
+    // Redirect to /dashboard in a production build
+    if (get(this, 'app.environment') !== 'development') {
+      const url = `${ window.location.origin }/dashboard`;
+
+      window.location.replace(url);
+    } else {
+      $('BODY').addClass('container-farm'); // eslint-disable-line
+    }
   },
 
   deactivate() {

--- a/lib/login/addon/login/template.hbs
+++ b/lib/login/addon/login/template.hbs
@@ -1,3 +1,4 @@
+{{#if showLogin}}
 <div class="login">
   <h1>
     {{t
@@ -148,3 +149,4 @@
     {{/if}}
   </section>
 </div>
+{{/if}}


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/7293

For a production deployment, redirect `/login` to `/dashboard`.

This PR ensures that the Ember UI's login page is not shown when redirecting.

See Issue above - some users bookmark the old login page, so we want to redirect them to the new dashboard UI.