### PR TITLE
Eks custom node role

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-eks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-eks/component.js
@@ -604,7 +604,7 @@ export default Component.extend(ClusterDriver, {
         auth.endpoint = `iam.cn-north-1.amazonaws.com.cn`
       }
 
-      const awsRoles = await this.describeResource(['IAM', 'listRoles', 'Roles'], {}, auth);
+      const awsRoles = await this.describeResource(['IAM', 'listRoles', 'Roles'], { MaxItems: 1000 }, auth);
 
       const eksRoles = [];
       const ec2Roles = []
@@ -790,14 +790,28 @@ export default Component.extend(ClusterDriver, {
     const [awsClassName, awsSDKMethod, responseKey] = apiDescription;
     const klass = new AWS[awsClassName](authCreds);
 
-    return new Promise((resolve, reject) => {
-      klass[awsSDKMethod](params, (err, data) => {
-        if (err) {
-          return reject(err);
-        }
 
-        return resolve(data[responseKey]);
-      })
+
+    return new Promise((resolve, reject) => {
+      const fetchData = (params, allResponseData = []) => {
+        klass[awsSDKMethod](params, (err, data) => {
+          if (err){
+            return reject(err)
+          }
+          allResponseData.push(...data[responseKey])
+
+          if (data.IsTruncated && data.Marker){
+            fetchData({
+              ...params,
+              Marker: data.Marker
+            }, allResponseData)
+          } else {
+            resolve(allResponseData)
+          }
+        })
+      }
+
+      fetchData(params, [])
     })
   }
 });

--- a/lib/shared/addon/components/node-group-row/template.hbs
+++ b/lib/shared/addon/components/node-group-row/template.hbs
@@ -29,7 +29,7 @@
               class="form-control"
               @value={{model.nodeRole}}
               @content={{nodeRoleOptions}}
-              @optionValuePath="RoleId"
+              @optionValuePath="Arn"
               @optionLabelPath="RoleName"
             />
           {{/input-or-display}}


### PR DESCRIPTION
Fixes [#7755](https://github.com/rancher/dashboard/issues/7755) [#7756](https://github.com/rancher/dashboard/issues/7756) [#7754](https://github.com/rancher/dashboard/issues/7754)

The nodeRole field should use the Arn value, see comment [here](https://github.com/rancher/dashboard/issues/7754#issuecomment-1355822573). Additionally, aws role data may be paginated...afaict the `IsTruncated`/`Marker` pattern is used across this version of the aws sdk so making this change to the more general `describeResource` function seems safe. 

In addition to depaginating data when relevant, I've increased the max number of items that may be returned to the maximum allowed, 1000, which lets us fetch all our roles in one request; the easiest way to test the depagination code is probably to change MaxItems to a smaller number.