### PR TITLE
Fix confirmation dialog for multiple deactivation

### DIFF
--- a/app/models/kontainerdriver.js
+++ b/app/models/kontainerdriver.js
@@ -21,7 +21,7 @@ var KontainerDriver = Resource.extend({
       {
         label:     'action.deactivate',
         icon:      'icon icon-pause',
-        action:    'promotDeactivate',
+        action:    'promptDeactivate',
         enabled:   !!a.deactivate,
         bulkable:  true,
         altAction: 'deactivate',
@@ -69,7 +69,7 @@ var KontainerDriver = Resource.extend({
       get(this, 'modalService').toggleModal('modal-edit-driver', this);
     },
 
-    promotDeactivate() {
+    promptDeactivate() {
       get(this, 'modalService').toggleModal('modal-confirm-deactivate', {
         originalModel: this,
         action:        'deactivate'

--- a/app/models/nodedriver.js
+++ b/app/models/nodedriver.js
@@ -125,7 +125,7 @@ export default Resource.extend({
       {
         label:     'action.deactivate',
         icon:      'icon icon-pause',
-        action:    'promotDeactivate',
+        action:    'promptDeactivate',
         enabled:   !!a.deactivate && get(this, 'state') === 'active',
         bulkable:  true,
         altAction: 'deactivate',
@@ -146,7 +146,7 @@ export default Resource.extend({
       return this.doAction('deactivate');
     },
 
-    promotDeactivate() {
+    promptDeactivate() {
       get(this, 'modalService').toggleModal('modal-confirm-deactivate', {
         originalModel: this,
         action:        'deactivate'

--- a/lib/nodes/addon/custom-drivers/cluster-drivers/controller.js
+++ b/lib/nodes/addon/custom-drivers/cluster-drivers/controller.js
@@ -60,7 +60,7 @@ export default Controller.extend({
           originalModel: models[0],
           batchModels:   models,
           action:        'deactivate'
-        });        
+        });
       }
     };
   }),

--- a/lib/nodes/addon/custom-drivers/cluster-drivers/controller.js
+++ b/lib/nodes/addon/custom-drivers/cluster-drivers/controller.js
@@ -53,6 +53,18 @@ export default Controller.extend({
     },
   },
 
+  bulkActionHandler: computed(function() {
+    return {
+      promptDeactivate: (models) => {
+        get(this, 'modalService').toggleModal('modal-confirm-deactivate', {
+          originalModel: models[0],
+          batchModels:   models,
+          action:        'deactivate'
+        });        
+      }
+    };
+  }),
+
   rows: computed('model.drivers.@each.{externalId,id,state,version}', 'model.drivers.content', function() {
     // possibly add some search here
     let drivers    = get(this, 'model.drivers.content');

--- a/lib/nodes/addon/custom-drivers/cluster-drivers/template.hbs
+++ b/lib/nodes/addon/custom-drivers/cluster-drivers/template.hbs
@@ -32,6 +32,7 @@
    body=rows
    searchText=searchText
    sortBy=sortBy
+   bulkActionHandler=bulkActionHandler
    descending=descending
    bulkActions=true
    pagingLabel="pagination.driver"

--- a/lib/nodes/addon/custom-drivers/node-drivers/controller.js
+++ b/lib/nodes/addon/custom-drivers/node-drivers/controller.js
@@ -66,9 +66,6 @@ export default Controller.extend({
   bulkActionHandler: computed(function() {
     return {
       promptDeactivate: (models) => {
-        console.log('YES!!!!!!!!!!!!1');
-        console.log(models);
-
         get(this, 'modalService').toggleModal('modal-confirm-deactivate', {
           originalModel: models[0],
           batchModels:   models,

--- a/lib/nodes/addon/custom-drivers/node-drivers/controller.js
+++ b/lib/nodes/addon/custom-drivers/node-drivers/controller.js
@@ -70,7 +70,7 @@ export default Controller.extend({
           originalModel: models[0],
           batchModels:   models,
           action:        'deactivate'
-        });        
+        });
       }
     };
   }),

--- a/lib/nodes/addon/custom-drivers/node-drivers/controller.js
+++ b/lib/nodes/addon/custom-drivers/node-drivers/controller.js
@@ -1,4 +1,4 @@
-import { computed } from '@ember/object';
+import { get, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import C from 'ui/utils/constants';
@@ -62,6 +62,21 @@ export default Controller.extend({
       });
     }
   },
+
+  bulkActionHandler: computed(function() {
+    return {
+      promptDeactivate: (models) => {
+        console.log('YES!!!!!!!!!!!!1');
+        console.log(models);
+
+        get(this, 'modalService').toggleModal('modal-confirm-deactivate', {
+          originalModel: models[0],
+          batchModels:   models,
+          action:        'deactivate'
+        });        
+      }
+    };
+  }),
 
   rows: computed('model.drivers.@each.{externalId,id,state,version}', 'model.drivers.content', function() {
     // possibly add some search here

--- a/lib/nodes/addon/custom-drivers/node-drivers/template.hbs
+++ b/lib/nodes/addon/custom-drivers/node-drivers/template.hbs
@@ -19,6 +19,7 @@
     body=rows
     searchText=searchText
     sortBy=sortBy
+    bulkActionHandler=bulkActionHandler
     descending=descending
     bulkActions=true
     pagingLabel="pagination.driver"

--- a/lib/shared/addon/components/modal-confirm-deactivate/component.js
+++ b/lib/shared/addon/components/modal-confirm-deactivate/component.js
@@ -14,6 +14,7 @@ export default Component.extend(ModalBase, {
   classNames:     ['medium-modal', 'modal-logs'],
   alternateLabel,
   originalModel:  alias('modalService.modalOpts.originalModel'),
+  batchModels:    alias('modalService.modalOpts.batchModels'),
   action:         alias('modalService.modalOpts.action'),
   didRender() {
     setTimeout(() => {
@@ -26,10 +27,29 @@ export default Component.extend(ModalBase, {
   actions:        {
 
     confirm() {
-      this.get('originalModel').send(this.get('action'));
+      const multi = this.get('batchModels');
+
+      // If there are multiple items, go through each
+      if (multi && multi.length) {
+        multi.forEach((model) => {
+          model.send(this.get('action'));
+        });
+      } else {
+        this.get('originalModel').send(this.get('action'));
+      }
       this.send('cancel');
     },
   },
+
+  list: computed('originalModel', 'batchModels', function() {
+    const multi = this.get('batchModels');
+
+    if (multi && multi.length) {
+      return multi.map(v => v.displayName).sort().join(', ');
+    }
+
+    return this.get('originalModel').displayName;
+  }),
 
   isNodeDriver: computed('originalModel.type', function() {
     return get(this, 'originalModel.type') === 'nodeDriver';

--- a/lib/shared/addon/components/modal-confirm-deactivate/component.js
+++ b/lib/shared/addon/components/modal-confirm-deactivate/component.js
@@ -45,7 +45,7 @@ export default Component.extend(ModalBase, {
     const multi = this.get('batchModels');
 
     if (multi && multi.length) {
-      return multi.map(v => v.displayName).sort().join(', ');
+      return multi.map((v) => v.displayName).sort().join(', ');
     }
 
     return this.get('originalModel').displayName;

--- a/lib/shared/addon/components/modal-confirm-deactivate/template.hbs
+++ b/lib/shared/addon/components/modal-confirm-deactivate/template.hbs
@@ -24,7 +24,7 @@
 <div class="container-header-text">
   {{t 'modalConfirmDeactivate.header'}} {{isService.message}}:
   <div class="display-name">
-    {{originalModel.displayName}}
+    {{list}}
   </div>
 </div>
 


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/7762

The 'deactivate' dialog and the way it is wired into the drivers does not support multiple resources - we dispatch the confirmation dialog for each resource individually, so if you have 2 drivers selected, we dispatch twice - the 2nd time closes the dialog from the first. Thus, if you select 3 drivers, you will see the confirmation, but only that 3rd driver will be deactivated if you proceed. 

This PR updates the dialog to show multiple driver names and to deactivate multiple when invoked as such.

It then updates the two driver lists to override the bulk action handler so that we can open the dialog once and pass it multiple items. This is a pattern already used elsewhere in the code.

Finally, I corrected a typo in the action name: `promotDeactivate`.

Example with multiple selected:

![image](https://user-images.githubusercontent.com/1955897/210829171-22bbb004-817f-4cac-bafd-cb4d26380d1d.png)

 