### PR TITLE
Add warning to explain why availability zone list is empty

### DIFF
--- a/lib/nodes/addon/components/driver-azure/template.hbs
+++ b/lib/nodes/addon/components/driver-azure/template.hbs
@@ -187,6 +187,11 @@
                 <p>{{vmSizeAvailabilityWarning}}</p>
               {{/banner-message}}
             {{/if}}
+            {{#if showVmAvailabilityZoneWarning}}
+              {{#banner-message color="bg-error"}}
+                <p>{{vmAvailabilityZoneWarning}}</p>
+              {{/banner-message}}
+            {{/if}}
           </div>
         {{/if}}
       </div>


### PR DESCRIPTION
This PR is intended to address QA feedback on RKE1 node templates for Azure. https://github.com/rancher/dashboard/issues/7753#issuecomment-1372704405

To test,

1. Go to Cluster Management > RKE1 Configuration > Node Templateo
2. Create an Azure node template
3. In the Placement section, click Select Availability Zone
4. When the West US region is selected, the availability zone dropdown menu is populated with options
5. When the East US region is selected (or any other that does not support AZs), the dropdown is empty and a warning message appears
6. The warning disappears if you switch back to East US or use availability sets
<img width="915" alt="Screenshot 2023-01-07 at 7 51 58 PM" src="https://user-images.githubusercontent.com/20599230/211178527-a23b5171-32ec-4c64-a473-a9e1e2f1fac7.png">

