### PR TITLE
Fix imported AKS empty banner

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-import-aks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-import-aks/component.js
@@ -121,7 +121,7 @@ export default Component.extend(ClusterDriver, {
         });
 
         if (cb) {
-          cb()
+          cb(true);
         }
       } catch (err) {
         errors.pushObject(`Failed to load Clusters from Azure: ${ err.message }`);


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/7781

This PR fixes the above issue.

Simple fix - we are calling the callback with no parameters in the success case, where the callback is expecting a first argument to indicate success - thus undefined is passed in which is treated as an error. The 2nd error argument is also not specified, so we end up pushing `undefined` to the list of errors which results in the empty banner.