### PR TITLE
Dropdown menu for AZs is grayed out if empty

### DIFF
--- a/lib/nodes/addon/components/driver-azure/component.js
+++ b/lib/nodes/addon/components/driver-azure/component.js
@@ -233,6 +233,9 @@ export default Component.extend(NodeDriver, {
 
     return [];
   }),
+  availabilityZonesAreUnavailable: computed('availabilityZoneChoices', function() {
+    return get(this, 'availabilityZoneChoices').length === 0;
+  }),
   sizeChoices: computed('config.size', 'selectedVmSizeExistsInSelectedRegion', 'vmSizes', 'vmsWithAcceleratedNetworking', 'vmsWithoutAcceleratedNetworking', function() {
     // example vmSize option from backend:
     // {

--- a/lib/nodes/addon/components/driver-azure/template.hbs
+++ b/lib/nodes/addon/components/driver-azure/template.hbs
@@ -181,6 +181,7 @@
               optionLabelPath="name"
               optionValuePath="value"
               value=config.availabilityZone
+              disabled=availabilityZonesAreUnavailable
             }}
             {{#if showVmSizeAvailabilityWarning}}
               {{#banner-message color="bg-error"}}


### PR DESCRIPTION
This PR addresses a comment with QA feedback requesting that the AZ dropdown be disabled if empty. https://github.com/rancher/dashboard/issues/7753#issuecomment-1376002025

Before:
<img width="979" alt="Screenshot 2023-01-13 at 11 53 08 AM" src="https://user-images.githubusercontent.com/20599230/212421570-f96028be-2578-4bdc-8a36-5254fb1f0e87.png">

After:
<img width="797" alt="Screenshot 2023-01-13 at 2 18 32 PM" src="https://user-images.githubusercontent.com/20599230/212421587-3bebb8ce-dd5a-4d13-82f1-3a127783bb48.png">
