### PR TITLE
Availability zones are sorted

### DIFF
--- a/lib/nodes/addon/components/driver-azure/component.js
+++ b/lib/nodes/addon/components/driver-azure/component.js
@@ -228,7 +228,10 @@ export default Component.extend(NodeDriver, {
           name:  zone,
           value: zone,
         };
-      });
+      })
+        .sort((a, b) => {
+          return a.value - b.value;
+        })
     }
 
     return [];


### PR DESCRIPTION
This PR addresses the RKE1 part of this issue https://github.com/rancher/dashboard/issues/7877

The Azure availability zones should always be in order now:

<img width="826" alt="Screenshot 2023-01-13 at 2 26 56 PM" src="https://user-images.githubusercontent.com/20599230/212422717-200b0943-39d4-4214-86fc-7ae5fdaf6a9a.png">
