### PR TITLE
Show VMs that support AN first

### DIFF
--- a/lib/nodes/addon/components/driver-azure/component.js
+++ b/lib/nodes/addon/components/driver-azure/component.js
@@ -248,18 +248,20 @@ export default Component.extend(NodeDriver, {
     const vmsWithoutAn = get(this, 'vmsWithoutAcceleratedNetworking');
     let out = [{
       kind:     'group',
-      name:     noAnLabel,
-      value:    noAnLabel,
+      name:     withAnLabel,
+      value:    withAnLabel,
       disabled: true
     }]
-      .concat(vmsWithoutAn)
-      .concat({
-        kind:     'group',
-        name:     withAnLabel,
-        value:    withAnLabel,
-        disabled: true
-      })
       .concat(vmsWithAn)
+      .concat(
+        {
+          kind:     'group',
+          name:     noAnLabel,
+          value:    noAnLabel,
+          disabled: true
+        }
+      )
+      .concat(vmsWithoutAn)
 
     out = out.map((vmData) => {
       const { Name } = vmData;


### PR DESCRIPTION
This PR addresses the RKE1 portion of https://github.com/rancher/dashboard/issues/7878

The VMs that support AN now appear first in the dropdown:
<img width="403" alt="Screenshot 2023-01-13 at 2 57 30 PM" src="https://user-images.githubusercontent.com/20599230/212426946-c8ec81bc-0c5e-4e89-978c-85630e58c43b.png">

