### PR TITLE
RKE1 pod security admission support

### DIFF
--- a/app/authenticated/cluster/edit/route.js
+++ b/app/authenticated/cluster/edit/route.js
@@ -19,6 +19,22 @@ export default Route.extend({
 
     const cluster     = this.modelFor('authenticated.cluster');
 
+    const projects = cluster.projects
+
+    const hasPSPResources = async() => {
+      for (const p of projects){
+        const bindings = await p.followLink('podSecurityPolicyTemplateProjectBindings')
+
+        if (bindings.length){
+          return true
+        }
+      }
+
+      return false
+    }
+
+
+
     let modelOut      = {
       originalCluster:            cluster,
       cluster:                    cluster.clone(),
@@ -32,7 +48,7 @@ export default Route.extend({
       users:                      globalStore.findAll('user'),
       clusterRoleTemplateBinding: globalStore.findAll('clusterRoleTemplateBinding'),
       me:                         get(this, 'access.principal'),
-      projects:                   globalStore.findAll('project'),
+      hasPSPResources:            hasPSPResources(),
     };
 
     if (cluster.driver === 'k3s' || cluster.driver === 'rke2') {

--- a/app/authenticated/cluster/edit/route.js
+++ b/app/authenticated/cluster/edit/route.js
@@ -16,6 +16,7 @@ export default Route.extend({
 
   model() {
     const globalStore = this.get('globalStore');
+
     const cluster     = this.modelFor('authenticated.cluster');
 
     let modelOut      = {
@@ -26,10 +27,12 @@ export default Route.extend({
       nodeTemplates:              globalStore.findAll('nodeTemplate'),
       nodeDrivers:                globalStore.findAll('nodeDriver'),
       psps:                       globalStore.findAll('podSecurityPolicyTemplate'),
+      psacs:                      globalStore.findAll('podSecurityAdmissionConfigurationTemplate'),
       roleTemplates:              get(this, 'roleTemplateService').get('allFilteredRoleTemplates'),
       users:                      globalStore.findAll('user'),
       clusterRoleTemplateBinding: globalStore.findAll('clusterRoleTemplateBinding'),
       me:                         get(this, 'access.principal'),
+      projects:                   globalStore.findAll('project'),
     };
 
     if (cluster.driver === 'k3s' || cluster.driver === 'rke2') {

--- a/lib/global-admin/addon/cluster-templates/detail/route.js
+++ b/lib/global-admin/addon/cluster-templates/detail/route.js
@@ -20,6 +20,7 @@ export default Route.extend({
         clusterTemplate,
         clusterTemplateRevision:   revision,
         psps:                      this.globalStore.findAll('podSecurityPolicyTemplate'),
+        psacs:                      this.globalStore.findAll('podSecurityAdmissionConfigurationTemplate'),
         clusterTemplateRevisionId: revision.id,
       });
     });

--- a/lib/global-admin/addon/cluster-templates/detail/template.hbs
+++ b/lib/global-admin/addon/cluster-templates/detail/template.hbs
@@ -9,5 +9,5 @@
 
 <CruClusterTemplate @clusterTemplate={{model.clusterTemplate}}
   @clusterTemplateRevision={{model.clusterTemplateRevision}}
-  @clusterTemplateRevisionId={{model.clusterTemplateRevisionId}} @psps={{model.psps}} @mode="view"
+  @clusterTemplateRevisionId={{model.clusterTemplateRevisionId}} @psps={{model.psps}} @psacs={{model.psacs}} @mode="view"
   @cancel={{action "cancel" }} @done={{action "done" }} />

--- a/lib/global-admin/addon/cluster-templates/new-revision/route.js
+++ b/lib/global-admin/addon/cluster-templates/new-revision/route.js
@@ -31,6 +31,7 @@ export default Route.extend({
             clusterTemplate:           template,
             clusterTemplateRevision:   tempRevision,
             psps:                      this.globalStore.findAll('podSecurityPolicyTemplate'),
+            psacs:                      this.globalStore.findAll('podSecurityAdmissionConfigurationTemplate'),
             clusterTemplateRevisionId: tempId,
           });
         } else {
@@ -50,6 +51,7 @@ export default Route.extend({
             clusterTemplate:           template,
             clusterTemplateRevision:   tempRevision,
             psps:                      this.globalStore.findAll('podSecurityPolicyTemplate'),
+            psacs:                     this.globalStore.findAll('podSecurityAdmissionConfigurationTemplate'),
             clusterTemplateRevisionId: tempId,
           });
         }

--- a/lib/global-admin/addon/cluster-templates/new-revision/template.hbs
+++ b/lib/global-admin/addon/cluster-templates/new-revision/template.hbs
@@ -6,5 +6,5 @@
 
 <CruClusterTemplate @clusterTemplate={{model.clusterTemplate}}
   @clusterTemplateRevision={{model.clusterTemplateRevision}} @updateTemplateId={{action "updateTemplateId" }}
-  @clusterTemplateRevisionId={{model.clusterTemplateRevisionId}} @psps={{model.psps}} @mode="edit"
+  @clusterTemplateRevisionId={{model.clusterTemplateRevisionId}} @psps={{model.psps}} @psacs={{model.psacs}} @mode="edit"
   @cancel={{action "cancel" }} @done={{action "done" }} />

--- a/lib/global-admin/addon/cluster-templates/new/route.js
+++ b/lib/global-admin/addon/cluster-templates/new/route.js
@@ -20,6 +20,7 @@ export default Route.extend({
         })
       }),
       psps:  this.globalStore.findAll('podSecurityPolicyTemplate'),
+      psacs: this.globalStore.findAll('podSecurityAdmissionConfigurationTemplate'),
       users: this.globalStore.findAll('user'),
     });
   },

--- a/lib/global-admin/addon/cluster-templates/new/template.hbs
+++ b/lib/global-admin/addon/cluster-templates/new/template.hbs
@@ -5,5 +5,5 @@
 </div>
 
 <CruClusterTemplate @clusterTemplate={{model.clusterTemplate}}
-  @clusterTemplateRevision={{model.clusterTemplateRevision}} @users={{model.users}} @psps={{model.psps}} @mode="new"
+  @clusterTemplateRevision={{model.clusterTemplateRevision}} @users={{model.users}} @psps={{model.psps}} @psacs={{model.psacs}} @mode="new"
   @forceExpandOnInit={{false}} @cancel={{action "cancel" }} @done={{action "done" }} />

--- a/lib/global-admin/addon/clusters/new/launch/route.js
+++ b/lib/global-admin/addon/clusters/new/launch/route.js
@@ -39,6 +39,7 @@ export default Route.extend({
 
   model(params) {
     const gs                                    = this.globalStore;
+
     const {
       kontainerDrivers,
       nodeDrivers,
@@ -93,6 +94,7 @@ export default Route.extend({
       clusterRoleTemplateBinding: gs.findAll('clusterRoleTemplateBinding'),
       nodeTemplates:              gs.findAll('nodeTemplate'),
       psps:                       gs.findAll('podSecurityPolicyTemplate'),
+      psacs:                      gs.findAll('podSecurityAdmissionConfigurationTemplate'),
       users:                      gs.findAll('user'),
       clusterTemplates,
       clusterTemplateRevisions

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -7,16 +7,18 @@ import { next, once, scheduleOnce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { isEmpty, typeOf } from '@ember/utils';
 import { validateHostname } from '@rancher/ember-api-store/utils/validate';
+import { cluster } from 'd3';
 import deepSet from 'ember-deep-set';
 import jsyaml from 'js-yaml';
 import moment from 'moment';
 import { resolve } from 'rsvp';
 import Semver, { major, minor } from 'semver';
+import { hasMany } from '@rancher/ember-api-store/utils/denormalize';
 import { azure as AzureInfo } from 'shared/components/cru-cloud-provider/cloud-provider-info';
 import ClusterDriver from 'shared/mixins/cluster-driver';
 import ManageLabels from 'shared/mixins/manage-labels';
 import C from 'shared/utils/constants';
-import { coerceVersion, maxSatisfying } from 'shared/utils/parse-version';
+import { coerceVersion, maxSatisfying, satisfies } from 'shared/utils/parse-version';
 import {
   keysToCamel, keysToDecamelize, randomStr, removeEmpty, ucFirst, validateCertWeakly
 } from 'shared/utils/util';
@@ -481,6 +483,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
   }),
 
 
+
   enforcementChanged: on('init', observer('settings.clusterTemplateEnforcement', function() {
     let {
       access:   { me: { hasAdmin: globalAdmin = null } },
@@ -723,6 +726,62 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       return value;
     }
   }),
+
+  supportsPSA: computed('config.kubernetesVersion', function() {
+    // TODO nb config supports PSA if version >= 1.24.0
+    const selectedVersion = coerceVersion(get(this, 'config.kubernetesVersion'))
+
+    return selectedVersion ? satisfies(selectedVersion, '>=1.25.0') : true
+  }),
+
+  supportsPSP: computed('config.kubernetesVersion', function() {
+    // TODO nb config supports PSP if version < 1.25.0
+    const selectedVersion = coerceVersion(get(this, 'config.kubernetesVersion'))
+
+    return selectedVersion ? satisfies(selectedVersion, '<1.25.0') : true
+  }),
+
+  removePSPWarning: computed('supportsPSP', 'kubeApiPodSecurityPolicy', 'isEdit', function() {
+    if (!get(this, 'kubeApiPodSecurityPolicy')){
+      return false
+    }
+
+    // TODO nb warn if cluster has psp set but upgrading to version >=1.25.0
+    return !get(this, 'supportsPSP') && get(this, 'kubeApiPodSecurityPolicy')
+  }),
+
+  PSPInClusterWarning: computed('model.originalCluster.version.gitVersion', 'pspBindings', 'supportsPSP', function() {
+    const originalVersion = get(this, 'model.originalCluster.version.gitVersion')
+
+    if (satisfies(originalVersion, '<1.25.0')){
+      return !!get(this, 'pspBindings')
+    } else {
+      return false
+    }
+    // TODO nb fetch psp resources (?) IN cluster and warn if new version >=1.25.0
+  }),
+
+  pspBindings: computed('isEdit', 'model.cluster.id', 'model.projects',  function(){
+    // TODO nb actually do
+    console.log('projects changed')
+    if (!get(this, 'isEdit')){
+      return
+    }
+    const bindings = []
+    const allProjects = get(this, 'model.projects')
+
+    allProjects.forEach((p) => {
+      if (p.clusterId === get(this, 'model.cluster.id')){
+        const projectPSPBindings = hasMany('id', 'projectRoleTemplateBinding', 'projectId')
+
+        console.log('project psp bindings: ', projectPSPBindings)
+        bindings.push(...projectPSPBindings)
+      }
+    })
+
+    return bindings
+  }),
+
 
   monitoringProvider: computed('config.monitoring', {
     get() {

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -758,15 +758,17 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
 
   supportsPSA: computed('config.kubernetesVersion', function() {
-    // rke config supports PSA if version >= 1.25.0 - this is also when PSP support ends
+    // rke config supports PSA if version >= 1.23.0 - this is also when PSP support ends
     const selectedVersion = coerceVersion(get(this, 'config.kubernetesVersion'))
 
-    return selectedVersion ? satisfies(selectedVersion, '>=1.25.0') : true
+    return selectedVersion ? satisfies(selectedVersion, '>=1.23.0') : true
   }),
 
-  supportsPSP: computed('supportsPSA', function() {
-    // rke config supports PSP on versions prior to PSA support
-    return !get(this, 'supportsPSA')
+  supportsPSP: computed('config.kubernetesVersion', function() {
+    // rke config supports PSP if version <= 1.25.0
+    const selectedVersion = coerceVersion(get(this, 'config.kubernetesVersion'))
+
+    return selectedVersion ? satisfies(selectedVersion, '<=1.25.0') : true
   }),
 
   disablePSPWarning: computed('supportsPSP', 'kubeApiPodSecurityPolicy', 'isEdit', 'PSPInClusterWarning', function() {

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -727,18 +727,48 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     }
   }),
 
+  kubeApiPSAC: computed('config.services.kubeApi.podSecurityAdmissionConfiguration', {
+    get() {
+      let pspConfig = get(this, 'config.services.kubeApi');
+
+      if (typeof  pspConfig === 'undefined') {
+        return undefined;
+      }
+
+      return get(pspConfig, 'podSecurityAdmissionConfiguration');
+    },
+    set(key, value) {
+      if (!value){
+        delete this.config.services.kubeApi.podSecurityAdmissionConfiguration
+      } else {
+        if (typeof get(this, 'config.services') === 'undefined') {
+          set(this, 'config.services', get(this, 'globalStore').createRecord({
+            type:     'rkeConfigServices',
+            kubeApi: get(this, 'globalStore').createRecord({
+              type:                              'kubeAPIService',
+              podSecurityAdmissionConfiguration: value,
+            }),
+          }));
+        } else {
+          set(this, 'config.services', { kubeApi: { podSecurityAdmissionConfiguration: value } });
+        }
+      }
+
+      return value;
+    }
+  }),
+
+
   supportsPSA: computed('config.kubernetesVersion', function() {
-    // TODO nb config supports PSA if version >= 1.24.0
+    // rke config supports PSA if version >= 1.25.0 - this is also when PSP support ends
     const selectedVersion = coerceVersion(get(this, 'config.kubernetesVersion'))
 
     return selectedVersion ? satisfies(selectedVersion, '>=1.25.0') : true
   }),
 
-  supportsPSP: computed('config.kubernetesVersion', function() {
-    // TODO nb config supports PSP if version < 1.25.0
-    const selectedVersion = coerceVersion(get(this, 'config.kubernetesVersion'))
-
-    return selectedVersion ? satisfies(selectedVersion, '<1.25.0') : true
+  supportsPSP: computed('supportsPSA', function() {
+    // rke config supports PSP on versions prior to PSA support
+    return !get(this, 'supportsPSA')
   }),
 
   removePSPWarning: computed('supportsPSP', 'kubeApiPodSecurityPolicy', 'isEdit', function() {
@@ -746,23 +776,23 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       return false
     }
 
-    // TODO nb warn if cluster has psp set but upgrading to version >=1.25.0
+    // TODO nb warn either to disable psp OR to disable psp and remove existing psp resources before proceeding
+    // TODO nb diable create button conditional on this
     return !get(this, 'supportsPSP') && get(this, 'kubeApiPodSecurityPolicy')
   }),
 
   PSPInClusterWarning: computed('model.originalCluster.version.gitVersion', 'pspBindings', 'supportsPSP', function() {
     const originalVersion = get(this, 'model.originalCluster.version.gitVersion')
 
-    if (satisfies(originalVersion, '<1.25.0')){
+    if (originalVersion && satisfies(originalVersion, '<1.25.0')){
       return !!get(this, 'pspBindings')
     } else {
       return false
     }
-    // TODO nb fetch psp resources (?) IN cluster and warn if new version >=1.25.0
+    // TODO nb if editing, selected version does not support PSP, and PSP support is enabled warn without checking if they even exist
   }),
 
-  pspBindings: computed('isEdit', 'model.cluster.id', 'model.projects',  function(){
-    // TODO nb actually do
+  pspBindings: computed('isEdit', 'model.cluster.id', 'model.projects',  function() {
     console.log('projects changed')
     if (!get(this, 'isEdit')){
       return
@@ -772,7 +802,8 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
     allProjects.forEach((p) => {
       if (p.clusterId === get(this, 'model.cluster.id')){
-        const projectPSPBindings = hasMany('id', 'projectRoleTemplateBinding', 'projectId')
+        // TODO nb get bindings from projects' link
+        const projectPSPBindings = []
 
         console.log('project psp bindings: ', projectPSPBindings)
         bindings.push(...projectPSPBindings)
@@ -780,6 +811,16 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     })
 
     return bindings
+  }),
+
+  psacOptions: computed('model.psacs.[]', function() {
+    const opts = get(this, 'model.psacs')
+
+    // TODO nb no psac?
+    return [{
+      displayName: 'None',
+      id:          undefined
+    }, ...opts.toArray()]
   }),
 
 
@@ -1636,13 +1677,15 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
         type:     'monitoringConfig',
         provider: 'metrics-server',
       }),
+      // TODO nb no psp default if >=1.25.0
       services: globalStore.createRecord({
         type:    'rkeConfigServices',
         kubeApi: globalStore.createRecord({
-          type:                    'kubeAPIService',
-          podSecurityPolicy:       false,
-          serviceNodePortRange:    '30000-32767',
-          secretsEncryptionConfig: globalStore.createRecord({ type: 'secretsEncryptionConfig' })
+          type:                              'kubeAPIService',
+          podSecurityPolicy:                 false,
+          serviceNodePortRange:              '30000-32767',
+          secretsEncryptionConfig:           globalStore.createRecord({ type: 'secretsEncryptionConfig' }),
+          // TODO nb default value?
         }),
         etcd: globalStore.createRecord({
           type:         'etcdService',

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -725,7 +725,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     }
   }),
 
-  kubeApiPSAC: computed('config.services.kubeApi.podSecurityAdmissionConfiguration', {
+  kubeApiPSAC: computed('config.services.kubeApi.podSecurityConfiguration', {
     get() {
       let pspConfig = get(this, 'config.services.kubeApi');
 
@@ -733,22 +733,22 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
         return undefined;
       }
 
-      return get(pspConfig, 'podSecurityAdmissionConfiguration');
+      return get(pspConfig, 'podSecurityConfiguration');
     },
     set(key, value) {
       if (!value){
-        delete this.config.services.kubeApi.podSecurityAdmissionConfiguration
+        delete this.config.services.kubeApi.podSecurityConfiguration
       } else {
         if (typeof get(this, 'config.services') === 'undefined') {
           set(this, 'config.services', get(this, 'globalStore').createRecord({
             type:     'rkeConfigServices',
             kubeApi: get(this, 'globalStore').createRecord({
               type:                              'kubeAPIService',
-              podSecurityAdmissionConfiguration: value,
+              podSecurityConfiguration: value,
             }),
           }));
         } else {
-          set(this, 'config.services', { kubeApi: { podSecurityAdmissionConfiguration: value } });
+          set(this, 'config.services', { kubeApi: { podSecurityConfiguration: value } });
         }
       }
 
@@ -784,21 +784,6 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       return false
     }
   }),
-
-
-  psacOptions: computed('model.psacs.[]', function() {
-    const opts = get(this, 'model.psacs')
-
-    if (!opts){
-      return []
-    }
-
-    return [{
-      displayName: 'None',
-      id:          undefined
-    }, ...opts.toArray()]
-  }),
-
 
   monitoringProvider: computed('config.monitoring', {
     get() {

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -7,13 +7,11 @@ import { next, once, scheduleOnce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { isEmpty, typeOf } from '@ember/utils';
 import { validateHostname } from '@rancher/ember-api-store/utils/validate';
-import { cluster } from 'd3';
 import deepSet from 'ember-deep-set';
 import jsyaml from 'js-yaml';
 import moment from 'moment';
 import { resolve } from 'rsvp';
 import Semver, { major, minor } from 'semver';
-import { hasMany } from '@rancher/ember-api-store/utils/denormalize';
 import { azure as AzureInfo } from 'shared/components/cru-cloud-provider/cloud-provider-info';
 import ClusterDriver from 'shared/mixins/cluster-driver';
 import ManageLabels from 'shared/mixins/manage-labels';
@@ -771,52 +769,30 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     return !get(this, 'supportsPSA')
   }),
 
-  removePSPWarning: computed('supportsPSP', 'kubeApiPodSecurityPolicy', 'isEdit', function() {
+  disablePSPWarning: computed('supportsPSP', 'kubeApiPodSecurityPolicy', 'isEdit', 'PSPInClusterWarning', function() {
     if (!get(this, 'kubeApiPodSecurityPolicy')){
       return false
     }
 
-    // TODO nb warn either to disable psp OR to disable psp and remove existing psp resources before proceeding
-    // TODO nb diable create button conditional on this
     return !get(this, 'supportsPSP') && get(this, 'kubeApiPodSecurityPolicy')
   }),
 
-  PSPInClusterWarning: computed('model.originalCluster.version.gitVersion', 'pspBindings', 'supportsPSP', function() {
-    const originalVersion = get(this, 'model.originalCluster.version.gitVersion')
-
-    if (originalVersion && satisfies(originalVersion, '<1.25.0')){
-      return !!get(this, 'pspBindings')
+  PSPInClusterWarning: computed('model.hasPSPResources', 'supportsPSP', function() {
+    if (!get(this, 'supportsPSP')){
+      return !!get(this, 'model.hasPSPResources')
     } else {
       return false
     }
-    // TODO nb if editing, selected version does not support PSP, and PSP support is enabled warn without checking if they even exist
   }),
 
-  pspBindings: computed('isEdit', 'model.cluster.id', 'model.projects',  function() {
-    console.log('projects changed')
-    if (!get(this, 'isEdit')){
-      return
-    }
-    const bindings = []
-    const allProjects = get(this, 'model.projects')
-
-    allProjects.forEach((p) => {
-      if (p.clusterId === get(this, 'model.cluster.id')){
-        // TODO nb get bindings from projects' link
-        const projectPSPBindings = []
-
-        console.log('project psp bindings: ', projectPSPBindings)
-        bindings.push(...projectPSPBindings)
-      }
-    })
-
-    return bindings
-  }),
 
   psacOptions: computed('model.psacs.[]', function() {
     const opts = get(this, 'model.psacs')
 
-    // TODO nb no psac?
+    if (!opts){
+      return []
+    }
+
     return [{
       displayName: 'None',
       id:          undefined
@@ -1342,6 +1318,15 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
       errors.push(intl.t('clusterNew.psp.required'));
     }
 
+    if ( get(config, 'services.kubeApi.podSecurityPolicy') ){
+      if (!get(this, 'primaryResource.defaultPodSecurityPolicyTemplateId') ) {
+        errors.push(intl.t('clusterNew.psp.required'));
+      }
+      if (!get(this, 'supportsPSP')){
+        errors.push(intl.t('clusterNew.psp.unsupported'));
+      }
+    }
+
     if (get(this, 'config.services.etcd.snapshot')) {
       errors = this.validateEtcdService(errors);
     }
@@ -1646,6 +1631,17 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     const satisfying                       = maxSatisfying(versionChoices, defaultVersion);
     const out                              = {};
 
+    const kubeApiDefaults =  {
+      type:                              'kubeAPIService',
+      serviceNodePortRange:              '30000-32767',
+      secretsEncryptionConfig:           globalStore.createRecord({ type: 'secretsEncryptionConfig' }),
+    }
+
+    if (satisfies(defaultVersion, '<1.25.0')){
+      kubeApiDefaults.podSecurityPolicy = false
+    }
+
+
     const rkeConfig = globalStore.createRecord({
       type:                'rancherKubernetesEngineConfig',
       ignoreDockerVersion: true,
@@ -1677,17 +1673,10 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
         type:     'monitoringConfig',
         provider: 'metrics-server',
       }),
-      // TODO nb no psp default if >=1.25.0
       services: globalStore.createRecord({
         type:    'rkeConfigServices',
-        kubeApi: globalStore.createRecord({
-          type:                              'kubeAPIService',
-          podSecurityPolicy:                 false,
-          serviceNodePortRange:              '30000-32767',
-          secretsEncryptionConfig:           globalStore.createRecord({ type: 'secretsEncryptionConfig' }),
-          // TODO nb default value?
-        }),
-        etcd: globalStore.createRecord({
+        kubeApi: globalStore.createRecord(kubeApiDefaults),
+        etcd:    globalStore.createRecord({
           type:         'etcdService',
           snapshot:     false,
           backupConfig: globalStore.createRecord({

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -239,6 +239,17 @@
            expandAll=al.expandAll
            expand=(action expandFn)
         }}
+        {{#if (not supportsPSP)}}
+        <div class="row">
+            <section>
+                {{!-- TODO nb localization --}}
+              <BannerMessage
+                  @color="bg-info m-0"
+                  @message={{"Pod Security Policy support has been removed as of v1.25.0 "}}
+                />
+              </section>
+          </div>
+          {{/if}}
           <div class="row">
             <div class="col span-3">
               <label class="acc-label">
@@ -402,134 +413,142 @@
             </div>
           </div>
           <div class="row">
-            <div class="col span-4">
-              <label class="acc-label">
-                {{t "clusterNew.rke.podSecurityPolicy.label"}}
-                {{#if clusterTemplateCreate}}
-                  <ClusterTemplateOverrideToggle
-                    @path="rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy"
-                    @configVariable={{config.services.kubeApi.podSecurityPolicy}}
-                    @addOverride={{action "addOverride"}}
-                    @questions={{model.clusterTemplateRevision.questions}}
-                  />
-                {{/if}}
-              </label>
-              {{#if pspInClusterWarning}}
-              {{!-- TODO nb localization --}}
-              <span> you have psp bindings in this cluster that will not work upon upgrade</span>
-              {{/if}}
-              {{#if (or supportsPSP removePSPWarning)}}
-              
-              {{#if removePSPWarning}}
-              {{!-- TODO nb localization --}}
-              <span>You have PSP enabled and shouldn't</span>
-              {{else}}
-              <CheckOverrideAllowed
-                @paramName="rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy"
-                @applyClusterTemplate={{applyClusterTemplate}}
-                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-                @questions={{model.clusterTemplateRevision.questions}}
-              >
-              {{!-- TODO NB conditionally hide this if k8s version >= 1.24 --}}
-                {{#input-or-display
-                   editable=(and notView supportsPSP)
-                   value=config.services.kubeApi.podSecurityPolicy
-                }}
-                  <div class="radio">
-                    <label class={{unless model.psps.length "text-muted"}}>
-                      {{radio-button
-                        selection=config.services.kubeApi.podSecurityPolicy
-                        value=true
-                        disabled=(not model.psps.length)
-                      }}
-                      {{t "generic.enabled"}}
-                      {{#unless model.psps.length}}
-                        &mdash; {{t "clusterNew.psp.none"}}
-                      {{/unless}}
-                    </label>
-                  </div>
-                  <div class="radio">
-                    <label>
-                      {{radio-button
-                        selection=config.services.kubeApi.podSecurityPolicy
-                        value=false
-                        disabled=(not model.psps.length)
-                      }}
-                      {{t "generic.disabled"}}
-                    </label>
-                  </div>
-                {{/input-or-display}}
-              </CheckOverrideAllowed>
-              {{/if}}
-              {{else}}
-              {{!-- //TODO nb localization --}}
-              <span>No PSP allowed</span>
-              {{/if}}
-            </div>
-            <div class="col span-4">
-              {{#if config.services.kubeApi.podSecurityPolicy}}
+            {{#if removePSPWarning}}
+              <section>
+                {{!-- TODO nb localization --}}
+              <BannerMessage
+                  @color="bg-warning m-0"
+                  @message={{"You have PSP support enabled and should not"}}
+                />
+              </section>
+            {{/if}}
+            {{#if (or supportsPSP config.services.kubeApi.podSecurityPolicy)}}
+              <div class="col span-4">
                 <label class="acc-label">
-                  {{t "clusterNew.psp.label"}}{{field-required}}
+                  {{t "clusterNew.rke.podSecurityPolicy.label"}}
                   {{#if clusterTemplateCreate}}
                     <ClusterTemplateOverrideToggle
-                      @path="defaultPodSecurityPolicyTemplateId"
-                      @configVariable={{cluster.defaultPodSecurityPolicyTemplateId}}
+                      @path="rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy"
+                      @configVariable={{config.services.kubeApi.podSecurityPolicy}}
                       @addOverride={{action "addOverride"}}
                       @questions={{model.clusterTemplateRevision.questions}}
                     />
                   {{/if}}
                 </label>
                 <CheckOverrideAllowed
-                  @paramName="defaultPodSecurityPolicyTemplateId"
+                  @paramName="rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy"
                   @applyClusterTemplate={{applyClusterTemplate}}
                   @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
                   @questions={{model.clusterTemplateRevision.questions}}
                 >
+                {{!-- TODO NB conditionally hide this if k8s version >= 1.24 --}}
                   {{#input-or-display
-                     editable=notView
-                     value=cluster.defaultPodSecurityPolicyTemplateId
+                    editable=(or (and notView supportsPSP) config.services.kubeApi.podSecurityPolicy)
+                    value=config.services.kubeApi.podSecurityPolicy
                   }}
-                    {{new-select
-                      content=model.psps
-                      optionLabelPath="displayName"
-                      optionValuePath="id"
-                      prompt="clusterNew.psp.prompt"
-                      localizedPrompt=true
-                      value=cluster.defaultPodSecurityPolicyTemplateId
-                      disabled=(not config.services.kubeApi.podSecurityPolicy)
-                    }}
+                    <div class="radio">
+                      <label class={{unless model.psps.length "text-muted"}}>
+                        {{radio-button
+                          selection=config.services.kubeApi.podSecurityPolicy
+                          value=true
+                          disabled=(not model.psps.length)
+                        }}
+                        {{t "generic.enabled"}}
+                        {{#unless model.psps.length}}
+                          &mdash; {{t "clusterNew.psp.none"}}
+                        {{/unless}}
+                      </label>
+                    </div>
+                    <div class="radio">
+                      <label>
+                        {{radio-button
+                          selection=config.services.kubeApi.podSecurityPolicy
+                          value=false
+                          disabled=(not model.psps.length)
+                        }}
+                        {{t "generic.disabled"}}
+                      </label>
+                    </div>
                   {{/input-or-display}}
                 </CheckOverrideAllowed>
-              {{else}}
-                <label class="acc-label">
-                  {{t "clusterNew.psp.label"}}
-                </label>
-                <div class="form-control-static">{{t "generic.none"}}</div>
-              {{/if}}
-            </div>
+              </div>
+              <div class="col span-4">
+                {{#if config.services.kubeApi.podSecurityPolicy}}
+                  <label class="acc-label">
+                    {{t "clusterNew.psp.label"}}{{field-required}}
+                    {{#if clusterTemplateCreate}}
+                      <ClusterTemplateOverrideToggle
+                        @path="defaultPodSecurityPolicyTemplateId"
+                        @configVariable={{cluster.defaultPodSecurityPolicyTemplateId}}
+                        @addOverride={{action "addOverride"}}
+                        @questions={{model.clusterTemplateRevision.questions}}
+                      />
+                    {{/if}}
+                  </label>
+                  <CheckOverrideAllowed
+                    @paramName="defaultPodSecurityPolicyTemplateId"
+                    @applyClusterTemplate={{applyClusterTemplate}}
+                    @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                    @questions={{model.clusterTemplateRevision.questions}}
+                  >
+                    {{#input-or-display
+                      editable=notView
+                      value=cluster.defaultPodSecurityPolicyTemplateId
+                    }}
+                      {{new-select
+                        content=model.psps
+                        optionLabelPath="displayName"
+                        optionValuePath="id"
+                        prompt="clusterNew.psp.prompt"
+                        localizedPrompt=true
+                        value=cluster.defaultPodSecurityPolicyTemplateId
+                        disabled=(not config.services.kubeApi.podSecurityPolicy)
+                      }}
+                    {{/input-or-display}}
+                  </CheckOverrideAllowed>
+                {{else}}
+                  <label class="acc-label">
+                    {{t "clusterNew.psp.label"}}
+                  </label>
+                  <div class="form-control-static">{{t "generic.none"}}</div>
+                {{/if}}
+              </div>
+            {{/if}}
           </div>
           <div class="row">
+            {{!-- TODO nb localization --}}
             {{#if supportsPSA}}
             <div class="col span-4">
-                <CheckOverrideAllowed
-                  @paramName="podSecurityAdmissionConfiguration"
-                  @applyClusterTemplate={{applyClusterTemplate}}
-                  @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
-                  @questions={{model.clusterTemplateRevision.questions}}
-                >
-                  {{#input-or-display
-                     editable=notView
-                     value=config.services.kubeApi.podSecurityAdmissionConfiguration
+              <label class="acc-label">
+                Pod Security Admission Configuration Template
+                {{#if clusterTemplateCreate}}
+                  <ClusterTemplateOverrideToggle
+                    @path="rancherKubernetesEngineConfig.services.kubeApi.podSecurityAdmissionConfiguration"
+                    @configVariable={{config.services.kubeApi.podSecurityAdmissionConfiguration}}
+                    @addOverride={{action "addOverride"}}
+                    @questions={{model.clusterTemplateRevision.questions}}
+                  />
+                {{/if}}
+              </label>
+              <CheckOverrideAllowed
+                @paramName="podSecurityAdmissionConfiguration"
+                @applyClusterTemplate={{applyClusterTemplate}}
+                @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                @questions={{model.clusterTemplateRevision.questions}}
+              >
+                {{#input-or-display
+                    editable=notView
+                    value=config.services.kubeApi.podSecurityAdmissionConfiguration
+                }}
+                  {{new-select
+                    content=psacOptions
+                    optionLabelPath="displayName"
+                    optionValuePath="id"
+                    localizedPrompt=true
+                    value=config.services.kubeApi.podSecurityAdmissionConfiguration
                   }}
-                    {{new-select
-                      content=model.psacs
-                      optionLabelPath="displayName"
-                      optionValuePath="id"
-                      localizedPrompt=true
-                      value=config.services.kubeApi.podSecurityAdmissionConfiguration
-                    }}
-                  {{/input-or-display}}
-                </CheckOverrideAllowed>
+                {{/input-or-display}}
+              </CheckOverrideAllowed>
             </div>
             {{/if}}
             </div>

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -235,21 +235,18 @@
         {{#accordion-list-item
            title=(t "clusterNew.rke.advanced.label")
            detail=(t "clusterNew.rke.advanced.detail")
-           expandOnInit=(or (or (eq mode "edit" true false) forceExpandOnInit) applyClusterTemplate)
+           expandOnInit=(or (or (eq mode "edit" true false) forceExpandOnInit) applyClusterTemplate )
            expandAll=al.expandAll
            expand=(action expandFn)
         }}
-        {{#if (not supportsPSP)}}
         <div class="row">
             <section>
-                {{!-- TODO nb localization --}}
               <BannerMessage
                   @color="bg-info m-0"
-                  @message={{"Pod Security Policy support has been removed as of v1.25.0 "}}
+                  @message={{t "clusterNew.psp.supportRemoved"}}
                 />
               </section>
           </div>
-          {{/if}}
           <div class="row">
             <div class="col span-3">
               <label class="acc-label">
@@ -413,12 +410,19 @@
             </div>
           </div>
           <div class="row">
-            {{#if removePSPWarning}}
+            {{#if disablePSPWarning}}
               <section>
-                {{!-- TODO nb localization --}}
               <BannerMessage
-                  @color="bg-warning m-0"
-                  @message={{"You have PSP support enabled and should not"}}
+                  @color="bg-error m-0"
+                  @message={{t "clusterNew.psp.unsupported"}}
+                />
+              </section>
+            {{/if}}
+            {{#if PSPInClusterWarning}}
+              <section>
+              <BannerMessage
+                  @color="bg-error m-0 mt-10"
+                  @message={{t "clusterNew.psp.deleteBeforeUpgrade"}}
                 />
               </section>
             {{/if}}
@@ -441,7 +445,6 @@
                   @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
                   @questions={{model.clusterTemplateRevision.questions}}
                 >
-                {{!-- TODO NB conditionally hide this if k8s version >= 1.24 --}}
                   {{#input-or-display
                     editable=(or (and notView supportsPSP) config.services.kubeApi.podSecurityPolicy)
                     value=config.services.kubeApi.podSecurityPolicy
@@ -516,11 +519,10 @@
             {{/if}}
           </div>
           <div class="row">
-            {{!-- TODO nb localization --}}
             {{#if supportsPSA}}
             <div class="col span-4">
               <label class="acc-label">
-                Pod Security Admission Configuration Template
+                {{t "clusterNew.psa.label"}}
                 {{#if clusterTemplateCreate}}
                   <ClusterTemplateOverrideToggle
                     @path="rancherKubernetesEngineConfig.services.kubeApi.podSecurityAdmissionConfiguration"
@@ -531,7 +533,7 @@
                 {{/if}}
               </label>
               <CheckOverrideAllowed
-                @paramName="podSecurityAdmissionConfiguration"
+                @paramName="rancherKubernetesEngineConfig.services.kubeApi.podSecurityAdmissionConfiguration"
                 @applyClusterTemplate={{applyClusterTemplate}}
                 @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
                 @questions={{model.clusterTemplateRevision.questions}}

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -414,14 +414,25 @@
                   />
                 {{/if}}
               </label>
+              {{#if pspInClusterWarning}}
+              {{!-- TODO nb localization --}}
+              <span> you have psp bindings in this cluster that will not work upon upgrade</span>
+              {{/if}}
+              {{#if (or supportsPSP removePSPWarning)}}
+              
+              {{#if removePSPWarning}}
+              {{!-- TODO nb localization --}}
+              <span>You have PSP enabled and shouldn't</span>
+              {{else}}
               <CheckOverrideAllowed
                 @paramName="rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy"
                 @applyClusterTemplate={{applyClusterTemplate}}
                 @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
                 @questions={{model.clusterTemplateRevision.questions}}
               >
+              {{!-- TODO NB conditionally hide this if k8s version >= 1.24 --}}
                 {{#input-or-display
-                   editable=notView
+                   editable=(and notView supportsPSP)
                    value=config.services.kubeApi.podSecurityPolicy
                 }}
                   <div class="radio">
@@ -449,6 +460,11 @@
                   </div>
                 {{/input-or-display}}
               </CheckOverrideAllowed>
+              {{/if}}
+              {{else}}
+              {{!-- //TODO nb localization --}}
+              <span>No PSP allowed</span>
+              {{/if}}
             </div>
             <div class="col span-4">
               {{#if config.services.kubeApi.podSecurityPolicy}}
@@ -492,6 +508,31 @@
               {{/if}}
             </div>
           </div>
+          <div class="row">
+            {{#if supportsPSA}}
+            <div class="col span-4">
+                <CheckOverrideAllowed
+                  @paramName="podSecurityAdmissionConfiguration"
+                  @applyClusterTemplate={{applyClusterTemplate}}
+                  @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
+                  @questions={{model.clusterTemplateRevision.questions}}
+                >
+                  {{#input-or-display
+                     editable=notView
+                     value=config.services.kubeApi.podSecurityAdmissionConfiguration
+                  }}
+                    {{new-select
+                      content=model.psacs
+                      optionLabelPath="displayName"
+                      optionValuePath="id"
+                      localizedPrompt=true
+                      value=config.services.kubeApi.podSecurityAdmissionConfiguration
+                    }}
+                  {{/input-or-display}}
+                </CheckOverrideAllowed>
+            </div>
+            {{/if}}
+            </div>
           <div class="row">
             <div class="col span-4">
               <label class="acc-label">

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -525,29 +525,29 @@
                 {{t "clusterNew.psa.label"}}
                 {{#if clusterTemplateCreate}}
                   <ClusterTemplateOverrideToggle
-                    @path="rancherKubernetesEngineConfig.services.kubeApi.podSecurityAdmissionConfiguration"
-                    @configVariable={{config.services.kubeApi.podSecurityAdmissionConfiguration}}
+                    @path="rancherKubernetesEngineConfig.services.kubeApi.podSecurityConfiguration"
+                    @configVariable={{config.services.kubeApi.podSecurityConfiguration}}
                     @addOverride={{action "addOverride"}}
                     @questions={{model.clusterTemplateRevision.questions}}
                   />
                 {{/if}}
               </label>
               <CheckOverrideAllowed
-                @paramName="rancherKubernetesEngineConfig.services.kubeApi.podSecurityAdmissionConfiguration"
+                @paramName="rancherKubernetesEngineConfig.services.kubeApi.podSecurityConfiguration"
                 @applyClusterTemplate={{applyClusterTemplate}}
                 @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
                 @questions={{model.clusterTemplateRevision.questions}}
               >
                 {{#input-or-display
                     editable=notView
-                    value=config.services.kubeApi.podSecurityAdmissionConfiguration
+                    value=config.services.kubeApi.podSecurityConfiguration
                 }}
                   {{new-select
-                    content=psacOptions
+                    content=model.psacs
                     optionLabelPath="displayName"
                     optionValuePath="id"
                     localizedPrompt=true
-                    value=config.services.kubeApi.podSecurityAdmissionConfiguration
+                    value=config.services.kubeApi.podSecurityConfiguration
                   }}
                 {{/input-or-display}}
               </CheckOverrideAllowed>

--- a/lib/shared/addon/components/cru-cluster-template/template.hbs
+++ b/lib/shared/addon/components/cru-cluster-template/template.hbs
@@ -77,7 +77,7 @@
 </div>
 
 <div class="row">
-  {{cluster-driver/driver-rke
+  {{cluster-driver/driver-rke 
     advanced=true
     mode=mode
     nodeWhich="custom"
@@ -91,6 +91,7 @@
     cluster=(mut cluster)
     originalCluster=originalCluster
     psps=psps
+    psacs=psacs
     clusterTemplateRevision=clusterTemplateRevision
     )
     otherErrors=memberErrors

--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -955,6 +955,7 @@ C.CLUSTER_TEMPLATE_IGNORED_OVERRIDES = [
   'rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.secretKey',
   'rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.folder',
   'rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy',
+  'rancherKubernetesEngineConfig.services.kubeApi.podSecurityAdmissionConfiguration',
   'rancherKubernetesEngineConfig.services.kubeApi.serviceNodePortRange',
 ]
 

--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -955,7 +955,7 @@ C.CLUSTER_TEMPLATE_IGNORED_OVERRIDES = [
   'rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.secretKey',
   'rancherKubernetesEngineConfig.services.etcd.backupConfig.s3BackupConfig.folder',
   'rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy',
-  'rancherKubernetesEngineConfig.services.kubeApi.podSecurityAdmissionConfiguration',
+  'rancherKubernetesEngineConfig.services.kubeApi.podSecurityConfiguration',
   'rancherKubernetesEngineConfig.services.kubeApi.serviceNodePortRange',
 ]
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4470,11 +4470,16 @@ clusterNew:
       required: Kubernetes Version is required
   otccce:
     shortLabel: Open Telekom Cloud CCE
+  psa:
+    label: Pod Security Admission Configuration Template
   psp:
     label: Default Pod Security Policy
     none: No policies are defined
     prompt: Select a Pod Security Policy...
     required: A Default Pod Security Policy is required when support is enabled.
+    unsupported: Pod security policies are not supported in the version selected; please disable PSP support and consider using the built-in Pod Security Admission Controller instead.
+    deleteBeforeUpgrade: The PSP resources in this cluster will be unreachable upon upgrade; please delete them before proceeding.
+    supportRemoved: Pod Security Policy support has been deprecated as of kubernetes version v1.21.0 and removed as of v1.25.0.
   rancherd:
     shortLabel: RancherD
   register:


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/7575

This PR adds PSA support during RKE1 configuration. This is only available for  kubernetes versions >=1.23.0. Users creating clusters with versions <1.25 should have the same experience as before, with the addition of a banner informing them that psp support will be disabled in later versions. 

### Creating a >=1.25.0 cluster
* no psp options and a banner explaining why
* psa dropdown with a default of 'privileged'
* field being set is `rancherKubernetesEngineConfig.services.kubeApi.podSecurityConfiguration`

### Upgrading to >=1.25.0 from a version with PSP support
* if psp support is enabled, there should be a banner warning to disable it and an error on attempting to create
* if there are psp resources within the cluster (one or more projects with a psp set) there should be a banner asking the user to delete these psp resources
* psa dropdown as with creating a >=1.23.0 cluster

### rke1 templates
* users should be able to configure the psa config template field

### testing
When I run the ember UI locally websockets do not work correctly: this makes testing cluster provisioning difficult (the ui waits for a message saying the cluster resource is created before creating node pools; this wont work without websockt support). I got around this by building the ember UI and running rancher-in-docker with that custom-built UI replacing the one bundled in the rancher/rancher image using the --mount command. If you don't want to go throught hat ping on slack and I'll give you login details for a testing setup.