### PR TITLE
Disable "import host" for local cluster

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -430,11 +430,14 @@ export default Resource.extend(Grafana, ResourceUsage, {
     return false;
   }),
 
-  canShowAddHost: computed('clusterProvider', 'hasPrivateAccess', 'hasPublicAccess', 'imported', 'nodes', function() {
+  canShowAddHost: computed('clusterProvider', 'hasPrivateAccess', 'hasPublicAccess', 'imported', 'nodes', 'internal', function() {
     const { clusterProvider } = this;
     const compatibleProviders = ['custom', 'import', 'amazoneksv2', 'googlegkev2', 'azureaksv2'];
 
-    if (!compatibleProviders.includes(clusterProvider)) {
+    // 'internal' indicates the local cluster - can't add host to the local cluster
+    const internal = get(this, 'internal');
+
+    if (!compatibleProviders.includes(clusterProvider) || internal) {
       return false;
     }
 

--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -434,7 +434,7 @@ export default Resource.extend(Grafana, ResourceUsage, {
     const { clusterProvider } = this;
     const compatibleProviders = ['custom', 'import', 'amazoneksv2', 'googlegkev2', 'azureaksv2'];
 
-    // 'internal' indicates the local cluster - can't add host to the local cluster
+    // internal indicates the local cluster. Rancher does not manage the local cluster, so nodes can not be added via the UI
     const internal = get(this, 'internal');
 
     if (!compatibleProviders.includes(clusterProvider) || internal) {


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/4964

Rancher does not manage the local cluster, so the 'Import Host' option should not be shown - currently it is:

![image](https://user-images.githubusercontent.com/1955897/213395894-01c1b9b6-2826-41da-86df-676e4838111f.png)

With this PR it is now not shown:

![image](https://user-images.githubusercontent.com/1955897/213396333-6cbdfab1-4195-4603-8690-629c8d93f3ca.png)

This PR adds an additional check for the local (internal) cluster.