### PR TITLE
Fix labels not being saved on hosted providers

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -1075,6 +1075,21 @@ export default Resource.extend(Grafana, ResourceUsage, {
     return true;
   },
 
+  compareStringArrays(a, b) {
+    let aStr = '';
+    let bStr = '';
+
+    Object.keys(a || {}).forEach((key) => {
+      aStr += `${ key }=${ a[key] },`;
+    });
+
+    Object.keys(b || {}).forEach((key) => {
+      bStr += `${ key }=${ b[key] },`;
+    });
+
+    return aStr !== bStr;
+  },
+
   save(opt, originalModel) {
     const {
       eksConfig, gkeConfig, aksConfig
@@ -1091,24 +1106,14 @@ export default Resource.extend(Grafana, ResourceUsage, {
 
     if (!isEmpty(options)) {
       if (originalModel && originalModel.model && originalModel.model.originalCluster) {
-        const originalLabels = originalModel.model.originalCluster.labels;
-
         // Check to see if the labels have changed and send them, if they have
-        let currentLabels = '';
-
-        Object.keys(originalLabels).forEach((key) => {
-          currentLabels += `${ key }=${ originalLabels[key] },`;
-        });
-
-        let newLabels = '';
-
-        Object.keys(this.labels).forEach((key) => {
-          newLabels += `${ key }=${ this.labels[key] },`;
-        });
-
-        if (currentLabels !== newLabels) {
-          // Labels changed
+        if (this.compareStringArrays(originalModel.model.originalCluster.labels, this.labels)) {
           options.data.labels = this.labels;
+        }
+
+        // Check to see if the annotations have changed and send them, if they have
+        if (this.compareStringArrays(originalModel.model.originalCluster.annotations, this.annotations)) {
+          options.data.annotations = this.annotations;
         }
       }
 

--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -1075,7 +1075,7 @@ export default Resource.extend(Grafana, ResourceUsage, {
     return true;
   },
 
-  save(opt) {
+  save(opt, originalModel) {
     const {
       eksConfig, gkeConfig, aksConfig
     } = this;
@@ -1090,6 +1090,28 @@ export default Resource.extend(Grafana, ResourceUsage, {
     }
 
     if (!isEmpty(options)) {
+      if (originalModel && originalModel.model && originalModel.model.originalCluster) {
+        const originalLabels = originalModel.model.originalCluster.labels;
+
+        // Check to see if the labels have changed and send them, if they have
+        let currentLabels = '';
+
+        Object.keys(originalLabels).forEach((key) => {
+          currentLabels += `${ key }=${ originalLabels[key] },`;
+        });
+
+        let newLabels = '';
+
+        Object.keys(this.labels).forEach((key) => {
+          newLabels += `${ key }=${ this.labels[key] },`;
+        });
+
+        if (currentLabels !== newLabels) {
+          // Labels changed
+          options.data.labels = this.labels;
+        }
+      }
+
       return this._super(options);
     }
 

--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -1079,11 +1079,11 @@ export default Resource.extend(Grafana, ResourceUsage, {
     let aStr = '';
     let bStr = '';
 
-    Object.keys(a || {}).forEach((key) => {
+    Object.keys(a || {}).sort().forEach((key) => {
       aStr += `${ key }=${ a[key] },`;
     });
 
-    Object.keys(b || {}).forEach((key) => {
+    Object.keys(b || {}).sort().forEach((key) => {
       bStr += `${ key }=${ b[key] },`;
     });
 

--- a/lib/shared/addon/mixins/new-or-edit.js
+++ b/lib/shared/addon/mixins/new-or-edit.js
@@ -91,7 +91,8 @@ export default Mixin.create({
   },
 
   doSave(opt) {
-    return get(this, 'primaryResource').save(opt).then((newData) => {
+    // Pass this in case we need to check the previous model when saving
+    return get(this, 'primaryResource').save(opt, this).then((newData) => {
       return this.mergeResult(newData);
     });
   },


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/7631

This PR fixes the above issue.

We are not sending the labels or annotations for hosted providers.

This PR adds an extra arg to the save method, so that we can determine if the labels or annotations have changed, and only send those it they have.

Tested with an Azure AKS cluster.