### PR TITLE
[2.6 forwardport]fix oauth redirect param duplicates

### DIFF
--- a/lib/shared/addon/azure-ad/service.js
+++ b/lib/shared/addon/azure-ad/service.js
@@ -28,11 +28,15 @@ export default Service.extend({
   login() {
     const provider     = get(this, 'access.providers').findBy('id', 'azuread');
     const authRedirect = get(provider, 'redirectUrl');
-    let redirect     = Util.addQueryParams(authRedirect, additionalRedirectParams);
+    let redirect = authRedirect;
+
+    Object.keys(additionalRedirectParams).forEach((key) => {
+      if (!authRedirect.includes(key)){
+        redirect = Util.addQueryParam(redirect, key, additionalRedirectParams[key])
+      }
+    })
 
     redirect = Util.addQueryParams(redirect, { state: this.oauth.encodeState(this.oauth.generateState('azuread')) });
-
-
     window.location.href = redirect;
   },
 
@@ -49,7 +53,11 @@ export default Service.extend({
       }
     };
 
-    url = Util.addQueryParams(url, additionalRedirectParams);
+    Object.keys(additionalRedirectParams).forEach((key) => {
+      if (!url.includes(key)){
+        url = Util.addQueryParam(url, key, additionalRedirectParams[key])
+      }
+    })
     const state = this.oauth.encodeState(this.oauth.generateState('azuread'))
 
     url = Util.addQueryParams(url, { state });


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/7330

Forwardport of https://github.com/rancher/ui/pull/4875

This bug can be reproduced by enabling then logging in via azuread auth. If you look at the redirect url the UI is using, you'll see there is a duplicated query param: apparently the microsoft graph api we've switched to does not like this and throws an error.