### PR TITLE
Psa rke1 fixes

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -718,38 +718,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
           }),
         }));
       } else {
-        set(this, 'config.services.kubeApi.podSecurityPolicy', value );
-      }
-
-      return value;
-    }
-  }),
-
-  kubeApiPSAC: computed('config.services.kubeApi.podSecurityConfiguration', {
-    get() {
-      let psaConfig = get(this, 'config.services.kubeApi');
-
-      if (typeof  psaConfig === 'undefined') {
-        return undefined;
-      }
-
-      return get(psaConfig, 'podSecurityConfiguration');
-    },
-    set(key, value) {
-      if (!value){
-        delete this.config.services.kubeApi.podSecurityConfiguration
-      } else {
-        if (typeof get(this, 'config.services') === 'undefined') {
-          set(this, 'config.services', get(this, 'globalStore').createRecord({
-            type:     'rkeConfigServices',
-            kubeApi: get(this, 'globalStore').createRecord({
-              type:                              'kubeAPIService',
-              podSecurityConfiguration: value,
-            }),
-          }));
-        } else {
-          set(this, 'config.services.kubeApi.podSecurityConfiguration', value);
-        }
+        set(this, 'config.services', { kubeApi: { podSecurityPolicy: value } });
       }
 
       return value;
@@ -761,7 +730,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     const intl     = get(this, 'intl');
 
     return [
-      { displayName: intl.t('clusterNew.psa.default'), },
+      { displayName: intl.t('generic.none'), },
       ...psacs]
   }),
 

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -718,7 +718,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
           }),
         }));
       } else {
-        set(this, 'config.services', { kubeApi: { podSecurityPolicy: value } });
+        set(this, 'config.services.kubeApi.podSecurityPolicy', value );
       }
 
       return value;
@@ -727,13 +727,13 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
 
   kubeApiPSAC: computed('config.services.kubeApi.podSecurityConfiguration', {
     get() {
-      let pspConfig = get(this, 'config.services.kubeApi');
+      let psaConfig = get(this, 'config.services.kubeApi');
 
-      if (typeof  pspConfig === 'undefined') {
+      if (typeof  psaConfig === 'undefined') {
         return undefined;
       }
 
-      return get(pspConfig, 'podSecurityConfiguration');
+      return get(psaConfig, 'podSecurityConfiguration');
     },
     set(key, value) {
       if (!value){
@@ -748,12 +748,21 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
             }),
           }));
         } else {
-          set(this, 'config.services', { kubeApi: { podSecurityConfiguration: value } });
+          set(this, 'config.services.kubeApi.podSecurityConfiguration', value);
         }
       }
 
       return value;
     }
+  }),
+
+  psaOpts: computed('model.psacs.[]', function(){
+    let psacs = get(this, 'model.psacs').toArray()
+    const intl     = get(this, 'intl');
+
+    return [
+      { displayName: intl.t('clusterNew.psa.default'), },
+      ...psacs]
   }),
 
 

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -543,11 +543,11 @@
                     value=config.services.kubeApi.podSecurityConfiguration
                 }}
                   {{new-select
-                    content=model.psacs
+                    content=psaOpts
                     optionLabelPath="displayName"
                     optionValuePath="id"
                     localizedPrompt=true
-                    value=config.services.kubeApi.podSecurityConfiguration
+                    value=kubeApiPSAC
                   }}
                 {{/input-or-display}}
               </CheckOverrideAllowed>

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -525,29 +525,29 @@
                 {{t "clusterNew.psa.label"}}
                 {{#if clusterTemplateCreate}}
                   <ClusterTemplateOverrideToggle
-                    @path="rancherKubernetesEngineConfig.services.kubeApi.podSecurityConfiguration"
-                    @configVariable={{config.services.kubeApi.podSecurityConfiguration}}
+                    @path="defaultPodSecurityAdmissionConfigurationTemplateName"
+                    @configVariable={{cluster.defaultPodSecurityAdmissionConfigurationTemplateName}}
                     @addOverride={{action "addOverride"}}
                     @questions={{model.clusterTemplateRevision.questions}}
                   />
                 {{/if}}
               </label>
               <CheckOverrideAllowed
-                @paramName="rancherKubernetesEngineConfig.services.kubeApi.podSecurityConfiguration"
+                @paramName="defaultPodSecurityAdmissionConfigurationTemplateName"
                 @applyClusterTemplate={{applyClusterTemplate}}
                 @clusterTemplateRevision={{model.clusterTemplateRevision.clusterConfig}}
                 @questions={{model.clusterTemplateRevision.questions}}
               >
                 {{#input-or-display
                     editable=notView
-                    value=config.services.kubeApi.podSecurityConfiguration
+                    value=cluster.defaultPodSecurityAdmissionConfigurationTemplateName
                 }}
                   {{new-select
                     content=psaOpts
                     optionLabelPath="displayName"
                     optionValuePath="id"
                     localizedPrompt=true
-                    value=kubeApiPSAC
+                    value=cluster.defaultPodSecurityAdmissionConfigurationTemplateName
                   }}
                 {{/input-or-display}}
               </CheckOverrideAllowed>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4472,6 +4472,7 @@ clusterNew:
     shortLabel: Open Telekom Cloud CCE
   psa:
     label: Pod Security Admission Configuration Template
+    default: Default
   psp:
     label: Default Pod Security Policy
     none: No policies are defined

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4472,7 +4472,6 @@ clusterNew:
     shortLabel: Open Telekom Cloud CCE
   psa:
     label: Pod Security Admission Configuration Template
-    default: Default
   psp:
     label: Default Pod Security Policy
     none: No policies are defined


### PR DESCRIPTION
[#7575](https://github.com/rancher/dashboard/issues/7575)

* add default (empty) option
* set the correct field, `spec.defaultPodSecurityAdmissionConfigurationTemplateName` (`default_pod_security_admission_configuration_template_name` in yaml)
* remove unused `kubeApiPSAC` computed prop