### PR TITLE
Backport: Bump `rancher/dapper` to v0.6.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ platform:
 steps:
 - name: test
   pull: default
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.6.0
   commands:
   - dapper ci
   privileged: true
@@ -24,7 +24,7 @@ steps:
 
 - name: build
   pull: default
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.6.0
   commands:
   - BUILD_LATEST=true dapper ci
   privileged: true
@@ -60,7 +60,7 @@ steps:
 
 - name: build-release
   pull: default
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.6.0
   commands:
   - dapper ci
   environment:


### PR DESCRIPTION
This bumps `rancher/dapper` to v0.6.0. 

There is a potential bug between drone and the `rancher/dapper` version that might be causing CI to fail. It is recommended to bump the version number and test builds again.

### Example

https://drone-publish.rancher.io/rancher/ui/2688/1/1

backports #4957

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->

Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
