### PR TITLE
display node role name on eks edit/view

### DIFF
--- a/lib/shared/addon/components/node-group-row/component.js
+++ b/lib/shared/addon/components/node-group-row/component.js
@@ -499,6 +499,15 @@ export default Component.extend({
     }, ...nodeInstanceRoles]
   }),
 
+  selectedNodeRoleName: computed('model.nodeRole', 'nodeInstanceRoles.[]', function(){
+    const { nodeInstanceRoles } = this;
+    const { nodeRole } = this.model
+
+    const selected = nodeInstanceRoles.findBy('Arn', nodeRole )
+
+    return selected ? selected.RoleName : null
+  } ),
+
   async loadTemplateVersionInfo() {
     if (!this.clusterSaving && !this.clusterSaved) {
       const { launchTemplate = {} } = this.model;

--- a/lib/shared/addon/components/node-group-row/template.hbs
+++ b/lib/shared/addon/components/node-group-row/template.hbs
@@ -23,7 +23,7 @@
           </label>
           {{#input-or-display
             editable=creating
-            value=nodeRole
+            value=selectedNodeRoleName
           }}
             <NewSelect
               class="form-control"


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/4568#issuecomment-1381051958

`input-or-display` referenced a nonexistent value (`nodeRole` vs `model.nodeRole` in the select) - I've also added a computed prop to get a better display value (`<role>.Arn` is not very human-readable)
