### PR TITLE
Add standard SKU checkbox and required defaults for azure availability zones

### DIFF
--- a/lib/nodes/addon/components/driver-azure/component.js
+++ b/lib/nodes/addon/components/driver-azure/component.js
@@ -177,7 +177,35 @@ export default Component.extend(NodeDriver, {
     if (get(this, 'useAvailabilitySet')) {
       set(this, 'config.availabilityZone', '');
     } else {
+      const choices = get(this, 'availabilityZoneChoices');
+      const selectedZone = get(this, 'config.availabilityZone')
+
+      if (choices.length && !choices.findBy('value', selectedZone)){
+        set(this, 'config.availabilityZone', choices[0].value)
+      }
       set(this, 'config.availabilitySet', '');
+    }
+  }),
+
+  // if the list of az options changes and no longer includes whatever az has been configured, select the first available az from the new list
+  availabilityZoneChoicesObserver: observer('availabilityZoneChoices', function(){
+    const choices = get(this, 'availabilityZoneChoices');
+    const isUsingZones = !get(this, 'useAvailabilitySet');
+    const selectedZone = get(this, 'config.availabilityZone')
+
+    if (choices.length && isUsingZones){
+      if (isUsingZones && !choices.findBy('value', selectedZone)){
+        set(this, 'config.availabilityZone', choices[0].value)
+      }
+    }
+  }),
+
+  // standard sku, public ip, managed disk must be set when using an availability zone
+  availabilityZoneObserver: observer('config.availabilityZone', function(){
+    if (get(this, 'config.availabilityZone')){
+      set(this, 'config.enablePublicIpStandardSku', true)
+      set(this, 'managedDisks', MANAGED)
+      set(this, 'publicIpChoice', IPCHOICES[0].value)
     }
   }),
 

--- a/lib/nodes/addon/components/driver-azure/template.hbs
+++ b/lib/nodes/addon/components/driver-azure/template.hbs
@@ -284,7 +284,18 @@
       </div>
       <div class="col span-6">
         <label class="acc-label">
-          {{t "nodeDriver.azure.staticPublicIp.label"}}
+          {{#tooltip-element
+            type="tooltip-basic"
+            model=(t "nodeDriver.azure.staticPublicIp.tooltip")
+            tooltipTemplate="tooltip-static"
+            aria-describedby="tooltip-base"
+            baseClass="text-left"
+          }}
+           <span>
+            {{t "nodeDriver.azure.staticPublicIp.label"}}
+            <i class="icon icon-help icon-blue"/>
+          </span>
+        {{/tooltip-element}}
         </label>
         {{new-select
           classNames="form-control"
@@ -292,6 +303,7 @@
           optionLabelPath="name"
           optionValuePath="value"
           value=publicIpChoice
+          disabled=config.availabilityZone
         }}
       </div>
     </div>
@@ -308,7 +320,7 @@
           placeholder=(t "nodeDriver.azure.privateIpAddress.placeholder")
         }}
       </div>
-      <div class="col span-6">
+      <div class="col span-3">
         <label class="acc-label">
           {{t "nodeDriver.azure.usePrivateIp.label"}}
         </label>
@@ -317,6 +329,29 @@
             type="checkbox"
             checked=config.usePrivateIp
             disabled=privateSet
+          }}
+        </div>
+      </div>
+      <div class="col span-3">
+        <label class="acc-label">
+          {{#tooltip-element
+            type="tooltip-basic"
+            model=(t "nodeDriver.azure.useStandardSKU.tooltip")
+            tooltipTemplate="tooltip-static"
+            aria-describedby="tooltip-base"
+            baseClass="text-left"
+          }}
+           <span>
+            {{t "nodeDriver.azure.useStandardSKU.label"}}
+            <i class="icon icon-help icon-blue"/>
+          </span>
+        {{/tooltip-element}}
+        </label>
+        <div>
+          {{input
+            type="checkbox"
+            checked=config.enablePublicIpStandardSku
+            disabled=config.availabilityZone
           }}
         </div>
       </div>
@@ -487,13 +522,25 @@
     <div class="row">
       <div class="col span-6">
         <label class="acc-label">
-          {{t "nodeDriver.azure.managedDisks.label"}}
+          {{#tooltip-element
+            type="tooltip-basic"
+            model=(t "nodeDriver.azure.managedDisks.tooltip")
+            tooltipTemplate="tooltip-static"
+            aria-describedby="tooltip-base"
+            baseClass="text-left"
+          }}
+           <span>
+            {{t "nodeDriver.azure.managedDisks.label"}}
+            <i class="icon icon-help icon-blue"/>
+          </span>
+        {{/tooltip-element}}
         </label>
         {{new-select
           classNames="form-control"
           content=diskChoices
           localizedLabel=true
           value=managedDisks
+          disabled=config.availabilityZone
         }}
         <p class="help-block">
           {{t "nodeDriver.azure.managedDisks.helpText" type=managedDisks}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -9531,6 +9531,7 @@ nodeDriver:
       placeholder: e.g. 30
     managedDisks:
       warning: StandardSSD_LRS requires managed disks. Please change the Disk Type to Managed Disk or select another storage type.
+      tooltip: The Disk Type must be Managed when using an Availability Zone
       label: Disk Type
       unmanaged: Unmanaged Disk
       managed: Managed Disk
@@ -9600,8 +9601,12 @@ nodeDriver:
       placeholder: 127.0.0.1
     usePrivateIp:
       label: Use Private IP To Connect
+    useStandardSKU:
+      label: Use a Standard SKU for the Public IP
+      tooltip: The Standard Public IP SKU must be enabled when using an Availability Zone
     staticPublicIp:
       label: Public IP
+      tooltip: The Public IP must be Static when using an Availability Zone
     noPublicIp:
       label: No Public IP
     clientId:


### PR DESCRIPTION
For is for the rke1 side of this issue; rancher/dashboard will have a similar PR https://github.com/rancher/dashboard/issues/8014

* add checkbox for `enablePublicIpStandardSku`
* when az is selected, automatically set standard sku, public ip, and managed disk options to the values required when availability zones are used, and disable those form controls
* fix a bug where an availability zone appears to be selected when the dropdown options initialize, but is not actually set in the config

