### PR TITLE
Backport all EKS versions are in 2.6.x

### DIFF
--- a/lib/shared/addon/utils/amazon.js
+++ b/lib/shared/addon/utils/amazon.js
@@ -683,7 +683,7 @@ export const EKS_REGIONS = [
 ];
 
 // from https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-export const EKS_VERSIONS = ['1.24', '1.23']; // sort newest->oldest so we dont have to run any logic to sort like other provider versions
+export const EKS_VERSIONS = ['1.24', '1.23', '1.22', '1.21', '1.20']; // sort newest->oldest so we dont have to run any logic to sort like other provider versions
 
 export const nameFromResource = function(r, idField) {
   let id = r[idField];


### PR DESCRIPTION
[#7931](https://zube.io/rancher/dashboard-ui/c/7978)

Fixed - [Backport 2.6.x] - ensure all EKS versions are in 2.6.x branches