### PR TITLE
[2.6] azuread migration warning

### DIFF
--- a/app/authenticated/controller.js
+++ b/app/authenticated/controller.js
@@ -3,20 +3,41 @@ import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Controller, { inject as controller } from '@ember/controller';
 import C from 'ui/utils/constants';
-import { computed } from '@ember/object';
+import { computed, get } from '@ember/object';
 import { on } from '@ember/object/evented';
 
 export default Controller.extend({
   settings:    service(),
   prefs:       service(),
   scope:       service(),
+  intl:        service(),
+
   application: controller(),
   error:       null,
+  azureAd:     null,
 
   isPopup:     alias('application.isPopup'),
   pageScope:   alias('scope.currentPageScope'),
 
   hasHosts: computed.gt('model.hosts.length', 0),
+
+  init(){
+    this._super(...arguments)
+    get(this, 'globalStore').find('authconfig', 'azuread', { forceReload: true }).then((config) => {
+      this.set('azureAd', config)
+    })
+  },
+
+  azureNeedsUpdate: computed('azureAd.enabled', 'azureAd.annotations', function(){
+    const azureAd = get(this, 'azureAd')
+
+    if (!azureAd){
+      return false
+    }
+    const isEnabled = get(azureAd, 'enabled')
+
+    return isEnabled && (get(azureAd, 'annotations') || {})[C.AZURE_AD.ANNOTATION_MIGRATED] !== 'true'
+  }),
 
   bootstrap: on('init', function() {
     schedule('afterRender', this, () => {

--- a/app/authenticated/template.hbs
+++ b/app/authenticated/template.hbs
@@ -1,4 +1,9 @@
 {{#unless isPopup}}
+{{#if azureNeedsUpdate}}
+  <div class="bg-warning" id ='azuread-warning-banner'>
+    {{t 'authPage.azuread.updateEndpoint.banner.message' htmlSafe=true}}
+  </div>
+{{/if}}
   {{page-header
     pageScope=pageScope
     goToPrevious="goToPrevious"

--- a/app/styles/layout/_layout.scss
+++ b/app/styles/layout/_layout.scss
@@ -96,3 +96,19 @@ MAIN {
     }
   }
 }
+	
+.with-ui-header-banner {
+  #azuread-warning-banner {
+    margin-top: 0px;
+  }
+}
+
+#azuread-warning-banner {
+  margin-top: -10px;
+  margin-left: -20px;
+  margin-right: -20px;
+  height: 25px;
+  text-align: center;
+  z-index: 1501;
+  line-height: 1.6rem;
+}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -710,6 +710,7 @@ authPage:
       shibboleth: Shibboleth
     authError: 'Access was not authorized'
     popupError: 'Please disable your pop-up blocker and click "Authenticate" again.'
+  
   ping:
     buttonText:
       pre: 'Authenticate with Ping'
@@ -942,6 +943,9 @@ authPage:
       post: Waiting to hear back from Azure
       authError: 'Azure access was not authorized'
       popupError: 'Please disable your pop-up blocker and click "Authenticate" again.'
+    updateEndpoint:
+      banner:
+        message: 'Azure AD Authentication is using the Azure Graph API, which will be deprecated at the end of 2022. <a href="/dashboard/auth">Update it here.</a>'
   localAuth:
     warning: "When enabling external authentication, {appName} will associate the external principal with the current user's local identity.  The associated principal will receive all global permissions, as well as the project and cluster roles bindings of the current user."
     header:


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/7330#issuecomment-1424855747

This PR adds a warning banner when azure ad is enabled with the old (soon to be deprecated) endpoint configuration, taken from this 2.5 PR: https://github.com/rancher/ui/pull/4873/files The changes to ember azure ad auth configuration are not included here; it needs to be configured through the dash in 2.6.11



![Screen Shot 2023-02-09 at 3 06 37 PM](https://user-images.githubusercontent.com/42977925/217951062-ec630d92-5ac7-4048-9e11-8ced1076b339.png)
