### PR TITLE
BACKPORT: Update default image for gke nodes

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -79,7 +79,7 @@ export const DEFAULT_GKE_NODE_POOL_CONFIG = {
   config: {
     diskSizeGb:    100,
     diskType:      'pd-standard',
-    imageType:     'COS',
+    imageType:     'COS_CONTAINERD',
     labels:        null,
     localSsdCount: 0,
     machineType:   'n1-standard-2',


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Fixes https://github.com/rancher/dashboard/issues/6769

Proposed changes
======
<!-- 

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->
This changes the default image type for gke nodes to `Container-Optimized OS with Containerd`

The image options can be located [here](https://github.com/rancher/ui/blob/be0c5d60c0941ad8e6b5a8dcbbcc357ab2fb7f51/lib/shared/addon/google/service.js#L58-L83).

![defaultimage](https://user-images.githubusercontent.com/40806497/189744342-7c8df8e3-99ef-425c-8b02-9489166f01cf.png)

backports #4891
references rancher/dashboard#8183