### PR TITLE
update rke1 psp banner

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -765,6 +765,13 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     }
   }),
 
+  pspInfoBanner: computed('supportsPSP', function(){
+    const { supportsPSP } = this;
+    const intl = get(this, 'intl')
+
+    return supportsPSP ? intl.t('clusterNew.psp.deprecatedInfoBanner') : intl.t('clusterNew.psp.removedInfoBanner')
+  }),
+
   monitoringProvider: computed('config.monitoring', {
     get() {
       let monitoringConfig = get(this, 'config.monitoring');

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -239,14 +239,7 @@
            expandAll=al.expandAll
            expand=(action expandFn)
         }}
-        <div class="row">
-            <section>
-              <BannerMessage
-                  @color="bg-info m-0"
-                  @message={{t "clusterNew.psp.supportRemoved"}}
-                />
-              </section>
-          </div>
+
           <div class="row">
             <div class="col span-3">
               <label class="acc-label">
@@ -412,9 +405,16 @@
           <div class="row">
             {{#if disablePSPWarning}}
               <section>
-              <BannerMessage
+                <BannerMessage
                   @color="bg-error m-0"
                   @message={{t "clusterNew.psp.unsupported"}}
+                />
+              </section>
+            {{else}}
+              <section>
+                <BannerMessage
+                  @color="bg-info m-0"
+                  @message={{pspInfoBanner}}
                 />
               </section>
             {{/if}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4477,9 +4477,10 @@ clusterNew:
     none: No policies are defined
     prompt: Select a Pod Security Policy...
     required: A Default Pod Security Policy is required when support is enabled.
-    unsupported: Pod security policies are not supported in the version selected; please disable PSP support and consider using the built-in Pod Security Admission Controller instead.
+    unsupported: Pod security policies are not supported in the version selected; please disable PSP support and use PodSecurity Admission instead.
     deleteBeforeUpgrade: The PSP resources in this cluster will be unreachable upon upgrade; please delete them before proceeding.
-    supportRemoved: Pod Security Policy support has been deprecated as of kubernetes version v1.21.0 and removed as of v1.25.0.
+    deprecatedInfoBanner: Pod Security Policies are deprecated as of Kubernetes v1.21, and have been removed in Kubernetes v1.25.
+    removedInfoBanner: Pod Security Policies have been removed in Kubernetes v1.25, use PodSecurity Admission instead.
   rancherd:
     shortLabel: RancherD
   register:


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/8174

This PR moves the psp deprecation/removal banner closer to the psp/psa inputs and changes the text for versions >= 1.25

<1.25 with or without psp support enabled:
![Screen Shot 2023-02-16 at 9 02 05 AM](https://user-images.githubusercontent.com/42977925/219421081-67c9286b-761f-499b-8597-3b05a088232e.png)

\>=1.25 without psp support previously enabled:
![Screen Shot 2023-02-16 at 9 02 22 AM](https://user-images.githubusercontent.com/42977925/219421075-6125867e-7e1d-4821-9383-67431c8cdff4.png)

Upgrading to >=1.25 with psp support previously enabled:
![Screen Shot 2023-02-16 at 9 02 14 AM](https://user-images.githubusercontent.com/42977925/219421079-91cb6b91-98a8-4e94-a7c0-ef401ae10492.png)

