### PR TITLE
Add warning modal when upgrading imported k3s or rke2 clusters from <1.25.x to >=1.25.x

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-import/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-import/component.js
@@ -6,12 +6,16 @@ import { isEmpty } from '@ember/utils';
 import { resolve } from 'rsvp';
 import ClusterDriver from 'shared/mixins/cluster-driver';
 import layout from './template';
+import { coerceVersion, satisfies } from 'shared/utils/parse-version';
+
 
 export default Component.extend(ClusterDriver, {
-  globalStore: service(),
-  growl:       service(),
-  settings:    service(),
-  intl:        service(),
+  globalStore:  service(),
+  growl:        service(),
+  settings:     service(),
+  intl:         service(),
+  modalService: service('modal'),
+
 
   layout,
   configField:     'importedConfig',
@@ -62,6 +66,23 @@ export default Component.extend(ClusterDriver, {
 
       set(this, 'nodeForInfo', node);
     },
+
+    promptUpgradeWarning(cb){
+      if (!get(this, 'needsUpgradeWarning')){
+        this.driverSave(cb)
+
+        return
+      }
+      const { modalService } = this;
+      const { isK3sCluster, isRke2Cluster } = this;
+
+      modalService.toggleModal('modal-confirm-imported-upgrade', {
+        finish: this.confirmUpgrade.bind(this),
+        btnCB:  cb,
+        isK3sCluster,
+        isRke2Cluster
+      });
+    },
   },
 
   clusterChanged: observer('originalCluster.state', function() {
@@ -105,11 +126,42 @@ export default Component.extend(ClusterDriver, {
     } ));
   }),
 
+  // warn the user about manual PSP migration if upgrading from rke2/k3s <1.25 to >=1.25
+  needsUpgradeWarning: computed('config.kubernetesVersion', 'configField', 'isEdit', 'isK3sCluster', 'isRke2Cluster', 'model.originalCluster', function() {
+    const isEdit = get(this, 'isEdit')
+    const isK3sCluster = get(this, 'isK3sCluster')
+    const isRke2Cluster = get(this, 'isRke2Cluster')
+
+
+    if (!isEdit){
+      return
+    }
+    const configField = get(this, 'configField')
+    const originalCluster = get(this, 'model.originalCluster')
+    const originalVersion = coerceVersion(originalCluster[configField]?.kubernetesVersion);
+    const currentVersion = coerceVersion(get(this, 'config.kubernetesVersion'))
+
+    return satisfies(currentVersion, '>=1.25.0') && satisfies(originalVersion, '<1.25.0') && (isK3sCluster || isRke2Cluster)
+  }),
+
+  confirmUpgrade(cbToCloseModal, canceled = false, btnCB){
+    if (cbToCloseModal) {
+      cbToCloseModal();
+    }
+
+    if (canceled){
+      btnCB(false)
+    } else {
+      this.driverSave(btnCB);
+    }
+  },
+
   willSave() {
     const {
       configField: field,
       config
     } = this;
+
     let errors = [];
 
     if (field === 'k3sConfig' && !isEmpty(config)) {

--- a/lib/shared/addon/components/cluster-driver/driver-import/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-import/component.js
@@ -74,13 +74,12 @@ export default Component.extend(ClusterDriver, {
         return
       }
       const { modalService } = this;
-      const { isK3sCluster, isRke2Cluster } = this;
+      const { isK3sCluster } = this;
 
       modalService.toggleModal('modal-confirm-imported-upgrade', {
         finish: this.confirmUpgrade.bind(this),
         btnCB:  cb,
         isK3sCluster,
-        isRke2Cluster
       });
     },
   },

--- a/lib/shared/addon/components/cluster-driver/driver-import/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-import/template.hbs
@@ -34,7 +34,7 @@
   </div>
 {{else}}
   <SaveCancel
-    @save={{"driverSave"}}
+    @save={{"promptUpgradeWarning"}}
     @editing={{isEdit}}
     @cancel={{action "close"}}
   />

--- a/lib/shared/addon/components/modal-confirm-imported-upgrade/component.js
+++ b/lib/shared/addon/components/modal-confirm-imported-upgrade/component.js
@@ -1,0 +1,29 @@
+import { alias } from '@ember/object/computed';
+import Component from '@ember/component';
+import ModalBase from 'shared/mixins/modal-base';
+import layout from './template';
+
+export default Component.extend(ModalBase, {
+  layout,
+  classNames: ['medium-modal'],
+  // model:      alias('modalService.modalOpts.propertiesGoingToBeLost'),
+  btnCB:      alias('modalService.modalOpts.btnCB'),
+
+
+  actions: {
+    confirm() {
+      const { btnCB } = this;
+
+      this.modalService.modalOpts.finish(this.close.bind(this), false, btnCB);
+    },
+    cancel() {
+      const { btnCB } = this;
+
+      this.modalService.modalOpts.finish(this.close.bind(this), true, btnCB);
+    },
+  },
+
+  close() {
+    this.send('close');
+  }
+});

--- a/lib/shared/addon/components/modal-confirm-imported-upgrade/component.js
+++ b/lib/shared/addon/components/modal-confirm-imported-upgrade/component.js
@@ -6,7 +6,6 @@ import layout from './template';
 export default Component.extend(ModalBase, {
   layout,
   classNames: ['medium-modal'],
-  // model:      alias('modalService.modalOpts.propertiesGoingToBeLost'),
   btnCB:      alias('modalService.modalOpts.btnCB'),
 
 

--- a/lib/shared/addon/components/modal-confirm-imported-upgrade/template.hbs
+++ b/lib/shared/addon/components/modal-confirm-imported-upgrade/template.hbs
@@ -1,0 +1,22 @@
+<div class="container-header-text">
+  <h3>
+    {{t "managedImportClusterInfo.pspUpgradeWarning.modalTitle"}}
+  </h3>
+  <hr/>
+  <div>
+  {{#if isK3sCluster}}
+    {{t "managedImportClusterInfo.pspUpgradeWarning.k3sWarning" htmlSafe=true}}
+  {{else}}
+    {{t "managedImportClusterInfo.pspUpgradeWarning.rke2Warning" htmlSafe=true}}
+  {{/if}}
+  </div>
+</div>
+
+<div class="footer-actions">
+  <button class="btn bg-primary" type="button" {{action "confirm"}}>
+    {{t "managedImportClusterInfo.pspUpgradeWarning.proceed"}}
+  </button>
+  <button class="btn bg-transparent" type="button" {{action "cancel"}}>
+    {{t "generic.cancel"}}
+  </button>
+</div>

--- a/lib/shared/app/components/modal-confirm-imported-upgrade/component.js
+++ b/lib/shared/app/components/modal-confirm-imported-upgrade/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/modal-confirm-imported-upgrade/component';

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -7922,6 +7922,11 @@ managedImportClusterInfo:
   drainWorkerNodes: Drain Worker Nodes
   error:
     int: Concurrency values must be integer values
+  pspUpgradeWarning:
+    modalTitle: 'Are you sure?'
+    k3sWarning: 'Kubernetes has removed support for Pod Security Policies (PSPs) starting with version 1.25. If you proceed with the upgrade, any PSPs that may be present in the cluster will no longer be available/enforced. If this is a hardened k3s cluster (or PodSecurityPolicy admission controller is enabled), please follow the instructions <a aria-label="documentation for hardened k3s cluster upgrades" href="https://docs.k3s.io/known-issues" target="_blank" rel="nofollow noreferrer noopener">here</a> before you proceed with saving the changes to the cluster.'
+    rke2Warning: 'Kubernetes has removed support for Pod Security Policies (PSPs) starting with version 1.25. Please follow the instructions <a aria-label="documentation for hardened rke2 cluster upgrades" href="https://docs.rke2.io/known_issues" target="_blank" rel="nofollow noreferrer noopener">here</a> to manually prepare the cluster for the upgrade before you proceed with saving the changes to the cluster.'
+    proceed: Proceed
 
 k3sNodeEnvVarSection:
   title: K3S Node Environment Variables


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/8126
https://github.com/rancher/dashboard/issues/8124
