### PR TITLE
rename pod security policies to pod security policy templates

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -431,23 +431,23 @@ alertPage:
 
 podSecurityPoliciesPage:
   index:
-    header: Pod Security Policies
+    header: Pod Security Policy Templates
     description: Apply Policies to Pods created by a user with this Role
     table:
       name: Name
       created: Created Time
-      noData: There are no pod security policies defined
-      noMatch: No pod security policies match the current search
-  addPodSecurityPolicy: Add Policy
-  editPodSecurityPolicy: Edit Policy
+      noData: There are no pod security policy templates defined
+      noMatch: No pod security policy templates match the current search
+  addPodSecurityPolicy: Add Policy Template
+  editPodSecurityPolicy: Edit Policy Template
   detail:
-    header: Policy
+    header: Policy Template
   saveEdit: Edit
   saveNew: Create
   new:
     errors:
       nameReq: Name is required.
-      nameInExists: Name is already exists. Please use a new pod security policy name.
+      nameInExists: Name is already exists. Please use a new pod security policy template name.
     form:
       name:
         labelText: Name


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/8225

This PR renames the pod security policy page to more accurately reflect the relevant resource name. 
![Screen Shot 2023-02-21 at 3 23 04 PM](https://user-images.githubusercontent.com/42977925/220472139-0cb824d9-5291-401a-aa8a-71c5e5da306e.png)
