### PR TITLE
RKE Templates: Fix issue with 'value_from' being added to agent env vars

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -884,6 +884,12 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
         }
       }
 
+      // Remove any empty 'value_from' keys from agent env vars
+      (config.agent_env_vars || []).forEach((envVar) => {
+        if (envVar.value_from && Object.getOwnPropertyNames(envVar.value_from).length === 0) {
+          delete envVar.value_from;
+        }
+      });
 
       let yaml  = jsyaml.safeDump(config, { sortKeys: true });
       let lines = yaml.split('\n');


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/8188

This ensures that when 'Edit as YAML" is used within the RKE template, that we ensure empty `value_from` keys are removed from the agent env vars.