### PR TITLE
Fix issue where can not import multi-zone GKE cluster

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-import-gke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-import-gke/component.js
@@ -36,6 +36,7 @@ export default Component.extend(ClusterDriver, {
   config:                null,
   zones:                 null,
   locationType:          null,
+  allGKEClusters:        null,
 
   isEdit:       equal('mode', 'edit'),
   clusterState: alias('model.originalCluster.state'),
@@ -115,6 +116,8 @@ export default Component.extend(ClusterDriver, {
 
       try {
         allClusters = await this.google.fetchClusters(this.cluster, this.saved ?? false);
+
+        set(this, 'allGKEClusters', allClusters);
 
         setProperties(this, {
           allClusters: (allClusters || []).map((c) => {
@@ -235,6 +238,21 @@ export default Component.extend(ClusterDriver, {
 
     return cloudCredentials.filter((cc) => Object.prototype.hasOwnProperty.call(cc, 'googlecredentialConfig'));
   }),
+
+  willSave() {
+    // Ensure we include the locations from the cluster in the requst
+    const allGKEClusters = get(this, 'allGKEClusters');
+    const config = get(this, 'config');
+    const clusterConfig = allGKEClusters.find(c => c.name === config.clusterName);
+
+    if (clusterConfig) {
+      if (clusterConfig.locations) {
+        set(config, 'locations', clusterConfig.locations);
+      }
+    }
+
+    return true;
+  },
 
   doneSaving() {
     const {

--- a/lib/shared/addon/components/cluster-driver/driver-import-gke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-import-gke/component.js
@@ -243,7 +243,7 @@ export default Component.extend(ClusterDriver, {
     // Ensure we include the locations from the cluster in the requst
     const allGKEClusters = get(this, 'allGKEClusters');
     const config = get(this, 'config');
-    const clusterConfig = allGKEClusters.find(c => c.name === config.clusterName);
+    const clusterConfig = allGKEClusters.find((c) => c.name === config.clusterName);
 
     if (clusterConfig) {
       if (clusterConfig.locations) {


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/8256

Ensures we send the `location` configuration for the cluster when importing.