### PR TITLE
Fix issue where standard user can not add cluster members

### DIFF
--- a/lib/shared/addon/components/form-members/component.js
+++ b/lib/shared/addon/components/form-members/component.js
@@ -25,6 +25,7 @@ export default Component.extend({
   showCreator:     true,
   toAddCustom:     null,
   _bindings:       null,
+  canAddMember:    false,
 
   init() {
     this._super(...arguments);
@@ -33,6 +34,19 @@ export default Component.extend({
 
     if (this.registerHook) {
       this.registerHook(this.saveMembers.bind(this), 'saveMembers');
+    }
+
+    // memberConfig.type indicates the membership type being used (e.g. cluserrolebinding);
+    const memberConfig = get(this, 'memberConfig');
+
+    if (memberConfig && memberConfig.type) {
+      const schema = get(this, 'globalStore').getById('schema', memberConfig.type.toLowerCase());
+
+      if (schema && schema.collectionMethods) {
+        const canAddMember = (schema.collectionMethods || []).includes('POST');
+
+        set(this, 'canAddMember', canAddMember);
+      }
     }
   },
 
@@ -70,6 +84,20 @@ export default Component.extend({
 
   filteredUsers: computed('users.@each.{id,state}', function() {
     return get(this, 'users').sortBy('displayName');
+  }),
+
+  // Look at whether the user can update the member type resource
+  // If not, fallback to previous mechanism - must be more than 1 local user
+  canAddUser: computed('filteredUsers', 'access.provider', function () {
+    const filteredUsers = get(this, 'filteredUsers') || [];
+    const provider = get(this, 'access.provider');
+    const canAddMember = get(this, 'canAddMember');
+
+    if (canAddMember || provider !== 'local') {
+      return true;
+    }
+
+    return filteredUsers.length > 1;
   }),
 
   buildUpdateList(resource) {

--- a/lib/shared/addon/components/form-members/component.js
+++ b/lib/shared/addon/components/form-members/component.js
@@ -88,7 +88,7 @@ export default Component.extend({
 
   // Look at whether the user can update the member type resource
   // If not, fallback to previous mechanism - must be more than 1 local user
-  canAddUser: computed('filteredUsers', 'access.provider', function () {
+  canAddUser: computed('filteredUsers', 'access.provider', 'canAddMember', function() {
     const filteredUsers = get(this, 'filteredUsers') || [];
     const provider = get(this, 'access.provider');
     const canAddMember = get(this, 'canAddMember');

--- a/lib/shared/addon/components/form-members/template.hbs
+++ b/lib/shared/addon/components/form-members/template.hbs
@@ -26,7 +26,7 @@
   </table>
 
   <div class="mt-10">
-    {{#if (and (lte filteredUsers.length 1) (eq access.provider "local"))}}
+    {{#if (not canAddUser)}}
       {{#tooltip-element
          type="tooltip-basic"
          model=(t "formMembers.members.noAddUser")


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/8266

This improves the check for whether a user can add members - used during cluster create/edit.

I have the kept the existing mechanism, but we first now check whether the user has POST permission on the collection for the given membership type - this is the same as what dashboard does.
