### PR TITLE
Allow labels to be edited on k3s imported clusters

### DIFF
--- a/lib/shared/addon/components/cru-cluster/component.js
+++ b/lib/shared/addon/components/cru-cluster/component.js
@@ -415,8 +415,18 @@ export default Component.extend(ViewNewEdit, ChildHook, {
     };
   }),
 
+  // If this is a k3s cluster, then prevent editing of two 'system' labels
+  readonlyLabels: computed('isK3sCluster', function() {
+    const isK3sCluster = get(this, 'isK3sCluster');
+
+    return isK3sCluster ? [
+      'provider.cattle.io',
+      'objectset.rio.cattle.io/hash'
+    ] : [];
+  }),
+
   isImportedOther: computed('isK3sCluster', 'provider', 'router.currentRoute.queryParams.importProvider', function() {
-    // This is a special case because k3s is treated as a special cluster and no longer looks imported by the time it's actve
+    // This is a special case because k3s is treated as a special cluster and no longer looks imported by the time it's active
     if (get(this, 'isK3sCluster')) {
       return true;
     }

--- a/lib/shared/addon/components/cru-cluster/template.hbs
+++ b/lib/shared/addon/components/cru-cluster/template.hbs
@@ -87,7 +87,8 @@
       expandFn=expandFn
       initialLabels=model.cluster.labels
       model=model.cluster
-      editing=(and (and notView (not (or isK3sCluster isRke2Cluster))) (not isEksClusterPending))
+      readonlyLabels=readonlyLabels
+      editing=(and (and notView (not isRke2Cluster)) (not isEksClusterPending))
     }}
   {{/accordion-list}}
   {{#if isImportedOther}}


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/7658

This PR changes the logic to allow labels on importde k3s clusters to be edited - in addition, in this case it also makes the 2 labels that should probably not be changed readonly.