### PR TITLE
Add missing constant

### DIFF
--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -753,7 +753,7 @@ C.AZURE_AD = {
     ENDPOINT:       'https://login.chinacloudapi.cn/',
     GRAPH_ENDPOINT: 'https://graph.chinacloudapi.cn/'
   },
-  CUSTOM: { KEY: 'custom' },
+  CUSTOM:              { KEY: 'custom' },
   ANNOTATION_MIGRATED: 'auth.cattle.io/azuread-endpoint-migrated'
 };
 

--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -753,7 +753,8 @@ C.AZURE_AD = {
     ENDPOINT:       'https://login.chinacloudapi.cn/',
     GRAPH_ENDPOINT: 'https://graph.chinacloudapi.cn/'
   },
-  CUSTOM: { KEY: 'custom' }
+  CUSTOM: { KEY: 'custom' },
+  ANNOTATION_MIGRATED: 'auth.cattle.io/azuread-endpoint-migrated'
 };
 
 C.AZURE_DEFAULTS = [


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/8299

This PR was added in 2.6.11 to add the warning banner: https://github.com/rancher/ui/pull/4962/files

If references the constant `AZURE_AD.ANNOTATION_MIGRATED` - but that is not defined in `constants.js`, so the banner is always shown when azuerad is enabled.

This PR fixes this by adding the missing constant:

```
ANNOTATION_MIGRATED: 'auth.cattle.io/azuread-endpoint-migrated'
```

Validated with a test AzureAD auth provider.
