### PR TITLE
clear defaultPodSecurityPolicyTemplateId when disable psp support is selected during rke1 provisioning

### DIFF
--- a/app/authenticated/cluster/edit/route.js
+++ b/app/authenticated/cluster/edit/route.js
@@ -19,22 +19,6 @@ export default Route.extend({
 
     const cluster     = this.modelFor('authenticated.cluster');
 
-    const projects = cluster.projects
-
-    const hasPSPResources = async() => {
-      for (const p of projects){
-        const bindings = await p.followLink('podSecurityPolicyTemplateProjectBindings')
-
-        if (bindings.length){
-          return true
-        }
-      }
-
-      return false
-    }
-
-
-
     let modelOut      = {
       originalCluster:            cluster,
       cluster:                    cluster.clone(),
@@ -48,7 +32,6 @@ export default Route.extend({
       users:                      globalStore.findAll('user'),
       clusterRoleTemplateBinding: globalStore.findAll('clusterRoleTemplateBinding'),
       me:                         get(this, 'access.principal'),
-      hasPSPResources:            hasPSPResources(),
     };
 
     if (cluster.driver === 'k3s' || cluster.driver === 'rke2') {

--- a/lib/shared/addon/components/cluster-driver/driver-rke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/component.js
@@ -111,6 +111,7 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
   worker:                    true,
   defaultDockerRootDir:      null,
   nodePoolErrors:            null,
+  hasPSPResources:           false,
 
   windowsEnable:             false,
   isLinux:                   true,
@@ -200,6 +201,17 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     });
     // This needs to be scheduled after render in order to wait for initTemplateCluster to setup the rkeconfig defaults.
     scheduleOnce('afterRender', this, this.setupComponent);
+
+    if (this.isEdit && this.supportsPSP){
+      const { globalStore, originalCluster } = this;
+      const k8sUrl =  `/k8s/clusters/${ originalCluster.id }/v1/`
+
+      globalStore.request({ url: `${ k8sUrl }policy.podsecuritypolicies` }).then((res) => {
+        const hasPSPs = (res.content || []).length
+
+        set(this, 'hasPSPResources', hasPSPs)
+      })
+    }
   },
 
   didReceiveAttrs() {
@@ -480,7 +492,13 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     this.initScheduledClusterScan();
   }),
 
+  pspSupportChanged: observer('config.services.kubeApi.podSecurityPolicy', function(){
+    const pspEnabled = get(this, 'kubeApiPodSecurityPolicy')
 
+    if (!pspEnabled && get(this, 'cluster.defaultPodSecurityPolicyTemplateId')){
+      set(this, 'cluster.defaultPodSecurityPolicyTemplateId', '')
+    }
+  }),
 
   enforcementChanged: on('init', observer('settings.clusterTemplateEnforcement', function() {
     let {
@@ -757,9 +775,9 @@ export default InputTextFile.extend(ManageLabels, ClusterDriver, {
     return !get(this, 'supportsPSP') && get(this, 'kubeApiPodSecurityPolicy')
   }),
 
-  PSPInClusterWarning: computed('model.hasPSPResources', 'supportsPSP', function() {
+  PSPInClusterWarning: computed('hasPSPResources', 'supportsPSP', function() {
     if (!get(this, 'supportsPSP')){
-      return !!get(this, 'model.hasPSPResources')
+      return !!get(this, 'hasPSPResources')
     } else {
       return false
     }

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -446,7 +446,7 @@
                   @questions={{model.clusterTemplateRevision.questions}}
                 >
                   {{#input-or-display
-                    editable=(or (and notView supportsPSP) config.services.kubeApi.podSecurityPolicy)
+                    editable=(or (and notView supportsPSP) config.services.kubeApi.podSecurityPolicy cluster.defaultPodSecurityPolicyId)
                     value=config.services.kubeApi.podSecurityPolicy
                   }}
                     <div class="radio">


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/8304

Changing the 'pod security policy support' radio to 'disabled' changes `rancherKubernetesEngineConfig.services.kubeApi.podSecurityPolicy` - to fully disable PSP support we also need to clear out the `defaultPodSecurityPolicyTemplateId`

I also noticed a problem with one of the warning banners around upgrading while working on this; previously I was checking for the presence of `podSecurityPolicyTemplateProjectBindings` in the cluster: the actual resource that causes issues on attempting to upgrade to >=1.25 is policy.podSecurityPolicy. Not sure if I've implemented this correctly: that resource doesn't appear to be available via norman so I've queried the relevant cluster's kubernetes api endpoint instead.