### PR TITLE
Fix Digital Ocean request pagination

### DIFF
--- a/lib/shared/addon/digital-ocean/service.js
+++ b/lib/shared/addon/digital-ocean/service.js
@@ -43,7 +43,7 @@ export default Service.extend({
       if ( body && body.links && body.links.pages && body.links.pages.next ) {
         opt.url = body.links.pages.next;
 
-        return this.apiRequest(command, opt, out).then(() => {
+        return this.request(auth, command, opt, out).then(() => {
           return out;
         });
       } else {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
It is not possible to load the Digital Ocean Node Template form if any of the Digital Ocean API requests return more than a single page. This PR fixes this issue.

Types of changes
======
What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)

Linked Issues
======
Closes SURE-6021


