### PR TITLE
[2.7.2] fix upgrade warning modal check for clusters that can't be upgraded

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-import/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-import/component.js
@@ -139,8 +139,9 @@ export default Component.extend(ClusterDriver, {
     const originalCluster = get(this, 'model.originalCluster')
     const originalVersion = coerceVersion(originalCluster[configField]?.kubernetesVersion);
     const currentVersion = coerceVersion(get(this, 'config.kubernetesVersion'))
+    const canUpgrade = originalVersion && currentVersion && (isK3sCluster || isRke2Cluster)
 
-    return satisfies(currentVersion, '>=1.25.0') && satisfies(originalVersion, '<1.25.0') && (isK3sCluster || isRke2Cluster)
+    return canUpgrade && satisfies(currentVersion, '>=1.25.0') && satisfies(originalVersion, '<1.25.0')
   }),
 
   confirmUpgrade(cbToCloseModal, canceled = false, btnCB){


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/8477
backport of https://github.com/rancher/ui/pull/4996