### PR TITLE
update k3s hardened cluster doc link

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -7928,7 +7928,7 @@ managedImportClusterInfo:
     int: Concurrency values must be integer values
   pspUpgradeWarning:
     modalTitle: 'Are you sure?'
-    k3sWarning: 'Kubernetes has removed support for Pod Security Policies (PSPs) starting with version 1.25. If you proceed with the upgrade, any PSPs that may be present in the cluster will no longer be available/enforced. If this is a hardened k3s cluster (or PodSecurityPolicy admission controller is enabled), please follow the instructions <a aria-label="documentation for hardened k3s cluster upgrades" href="https://docs.k3s.io/known-issues" target="_blank" rel="nofollow noreferrer noopener">here</a> before you proceed with saving the changes to the cluster.'
+    k3sWarning: 'Kubernetes has removed support for Pod Security Policies (PSPs) starting with version 1.25. If you proceed with the upgrade, any PSPs that may be present in the cluster will no longer be available/enforced. If this is a hardened k3s cluster (or PodSecurityPolicy admission controller is enabled), please follow the instructions <a aria-label="documentation for hardened k3s cluster upgrades" href="https://docs.k3s.io/known-issues#hardened-125" target="_blank" rel="nofollow noreferrer noopener">here</a> before you proceed with saving the changes to the cluster.'
     rke2Warning: 'Kubernetes has removed support for Pod Security Policies (PSPs) starting with version 1.25. Please follow the instructions <a aria-label="documentation for hardened rke2 cluster upgrades" href="https://docs.rke2.io/known_issues#hardened-125" target="_blank" rel="nofollow noreferrer noopener">here</a> to manually prepare the cluster for the upgrade before you proceed with saving the changes to the cluster.'
     proceed: Proceed
 


### PR DESCRIPTION
This PR updates a k3s doc link to point directly to the relevant section, same vein as https://github.com/rancher/ui/pull/4993