### PR TITLE
Add new available EKS k8s versions to hardcoded list

### DIFF
--- a/lib/shared/addon/utils/amazon.js
+++ b/lib/shared/addon/utils/amazon.js
@@ -683,7 +683,7 @@ export const EKS_REGIONS = [
 ];
 
 // from https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-export const EKS_VERSIONS = ['1.24', '1.23']; // sort newest->oldest so we dont have to run any logic to sort like other provider versions
+export const EKS_VERSIONS = ['1.26', '1.25', '1.24', '1.23']; // sort newest->oldest so we dont have to run any logic to sort like other provider versions
 
 export const nameFromResource = function(r, idField) {
   let id = r[idField];


### PR DESCRIPTION
Signed-off by: Furkat Gofurov (furkat.gofurov@suse.com)

Updates hardcoded EKS supported k8s versions list with newer versions based on https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html

Since tech debt https://github.com/rancher/dashboard/issues/7295 is still open, we need to manually update this. 

@mjura @pgonin 