### PR TITLE
Add Docker Engine 20.10 support

### DIFF
--- a/lib/shared/addon/components/form-engine-opts/component.js
+++ b/lib/shared/addon/components/form-engine-opts/component.js
@@ -35,8 +35,11 @@ export default Component.extend({
       value: defaultEngine
     };
 
+    // Default Engine version - store, so we can check if the option is already in the list below
+    let defaultEngineVersion = '';
+
     try {
-      const defaultEngineVersion = defaultEngine.split('/').lastObject.replace('.sh', '');
+      defaultEngineVersion = defaultEngine.split('/').lastObject.replace('.sh', '');
 
       if (!isEmpty(defaultEngineVersion)) {
         defaultEngineVersionObj.label = get(this, 'intl').t('formEngineOpts.engineInstallUrl.recommended', { version: defaultEngineVersion });
@@ -44,7 +47,10 @@ export default Component.extend({
     } catch (_err) {}
 
     let out           = [
-      defaultEngineVersionObj,
+      {
+        label: 'v20.10.x',
+        value: 'https://releases.rancher.com/install-docker/20.10.sh'
+      },
       {
         label: 'v19.03.x',
         value: 'https://releases.rancher.com/install-docker/19.03.sh'
@@ -74,6 +80,15 @@ export default Component.extend({
         value: 'none'
       },
     ];
+
+    // Ensure the engine version is formatted in the same way as the label (currently 'v${VERSION}.x')
+    const defaultEngineVersionLabel = get(this, 'intl').t('formEngineOpts.engineInstallUrl.version', { version: defaultEngineVersion });
+
+    // Remove default engine version if it is already there (in case default is set to one of the options above)
+    out = out.filter(opt => opt.label !== defaultEngineVersionLabel);
+
+    // Add the default at the start of the list
+    out.unshift(defaultEngineVersionObj);
 
     return out;
   }),

--- a/lib/shared/addon/components/form-engine-opts/component.js
+++ b/lib/shared/addon/components/form-engine-opts/component.js
@@ -85,7 +85,7 @@ export default Component.extend({
     const defaultEngineVersionLabel = get(this, 'intl').t('formEngineOpts.engineInstallUrl.version', { version: defaultEngineVersion });
 
     // Remove default engine version if it is already there (in case default is set to one of the options above)
-    out = out.filter(opt => opt.label !== defaultEngineVersionLabel);
+    out = out.filter((opt) => opt.label !== defaultEngineVersionLabel);
 
     // Add the default at the start of the list
     out.unshift(defaultEngineVersionObj);

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -6630,6 +6630,7 @@ formEngineOpts:
     label: Docker Install URL
     placeholder: e.g. http://get.docker.com/
     recommended: "v{version}.x ( Recommended )"
+    version: "v{version}.x"
     recommendedNoVersion: Recommended
     latest: Latest
     none:


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/8682

Adds Docker Engine 20.10 to the docker engine option list.

Currently the default engine is 20.10, so this PR also ensures that versions are not repeated. This means as is, 20.10 only shows once. As and when the backend add 23.10, this will show up correctly.

As is:

![image](https://user-images.githubusercontent.com/1955897/233128103-40cfbc7b-2458-4d2b-a3a5-339874c60d75.png)

After setting the default engine setting to 23.10:

![image](https://user-images.githubusercontent.com/1955897/233129135-a9666817-ea18-43ce-8a92-25b564c528e2.png)
