### PR TITLE
RKE1 Agent configuration

### DIFF
--- a/app/styles/_rancher.scss
+++ b/app/styles/_rancher.scss
@@ -66,6 +66,8 @@
 @import "app/styles/components/istio-graph";
 @import "app/styles/components/cluster-template-revision-upgrade-notification";
 @import "app/styles/components/node-group-row";
+@import "app/styles/components/agent-config";
+
 
 // Vendor
 // Pretty much what it says. Vendor specific changes/overrides or includes.

--- a/app/styles/components/_agent-config.scss
+++ b/app/styles/components/_agent-config.scss
@@ -1,0 +1,19 @@
+.agent-config {
+  .affinity-remove {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    
+    BUTTON{
+      color: $primary;
+      background: none;
+    }
+
+  }
+  
+  .affinity-term {
+    position: relative;
+  }
+}
+
+

--- a/app/styles/components/_pod-affinity-term-k8s.scss
+++ b/app/styles/components/_pod-affinity-term-k8s.scss
@@ -1,3 +1,0 @@
-.affinity-remove {
-  float: right;
-}

--- a/app/styles/components/_pod-affinity-term-k8s.scss
+++ b/app/styles/components/_pod-affinity-term-k8s.scss
@@ -1,0 +1,3 @@
+.affinity-remove {
+  float: right;
+}

--- a/lib/shared/addon/components/cluster-driver/driver-eks/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-eks/template.hbs
@@ -241,6 +241,32 @@
           </div>
         </div>
       </AccordionListItem>
+      <AccordionListItem
+          @title={{t "clusterNew.agentConfig.title.cluster"}}
+          @detail={{t "clusterNew.agentConfig.accordionDetail.cluster"}}
+          @expandOnInit={{false}}
+          @expandAll={{expandAll}}
+          @expand={{action expandFn}}
+        >
+        <FormAgentConfig
+          @mode={{mode}}
+          @cluster={{cluster}}
+          @type="cluster"
+        />
+      </AccordionListItem>
+      <AccordionListItem
+          @title={{t "clusterNew.agentConfig.title.fleet"}}
+          @detail={{t "clusterNew.agentConfig.accordionDetail.fleet"}}
+          @expandOnInit={{false}}
+          @expandAll={{expandAll}}
+          @expand={{action expandFn}}
+      >
+        <FormAgentConfig
+          @mode={{mode}}
+          @cluster={{cluster}}
+          @type="fleet"
+        />
+      </AccordionListItem>
       {{#if (eq step 2)}}
         <SaveCancel
           @editing={{eq mode "edit"}}

--- a/lib/shared/addon/components/cluster-driver/driver-import-eks/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-import-eks/template.hbs
@@ -116,6 +116,32 @@
           </div>
         </div>
       </AccordionListItem>
+      <AccordionListItem
+          @title={{t "clusterNew.agentConfig.title.cluster"}}
+          @detail={{t "clusterNew.agentConfig.accordionDetail.cluster"}}
+          @expandOnInit={{false}}
+          @expandAll={{expandAll}}
+          @expand={{action expandFn}}
+        >
+        <FormAgentConfig
+          @mode={{mode}}
+          @cluster={{cluster}}
+          @type="cluster"
+        />
+      </AccordionListItem>
+      <AccordionListItem
+          @title={{t "clusterNew.agentConfig.title.fleet"}}
+          @detail={{t "clusterNew.agentConfig.accordionDetail.fleet"}}
+          @expandOnInit={{false}}
+          @expandAll={{expandAll}}
+          @expand={{action expandFn}}
+      >
+        <FormAgentConfig
+          @mode={{mode}}
+          @cluster={{cluster}}
+          @type="fleet"
+        />
+      </AccordionListItem>
     {{/if}}
   </AccordionList>
   <TopErrors @errors={{mut allErrors}} />

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -1349,9 +1349,25 @@
            expandAll=al.expandAll
            expand=(action expandFn)
         }}
-        {{!-- //TODO nb pass in agentconfig --}}
+        {{!-- //TODO nb should agent configs be in <v3 cluster>.rancherKubernetesEngineConfig.lusterAgentDeploymentCustomization or <v3 cluster>.clusterAgentDeploymentCustomization --}}
           <FormAgentConfig
             @mode={{mode}}
+            @cluster={{cluster}}
+            @agentKey="clusterAgentDeploymentCustomization"
+          />
+        {{/accordion-list-item}}
+        {{!-- TODO nb localize --}}
+        {{#accordion-list-item
+           title='Fleet Agent Config'
+           expandOnInit=false
+           expandAll=al.expandAll
+           expand=(action expandFn)
+        }}
+        {{!-- //TODO nb should agent configs be in <v3 cluster>.rancherKubernetesEngineConfig.fleetAgentDeploymentCustomization or <v3 cluster>.fleetAgentDeploymentCustomization --}}
+          <FormAgentConfig
+            @mode={{mode}}
+            @cluster={{cluster}}
+            @agentKey="fleetAgentDeploymentCustomization"
           />
         {{/accordion-list-item}}
 

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -1342,6 +1342,18 @@
             @applyClusterTemplate={{applyClusterTemplate}}
           />
         {{/accordion-list-item}}
+        {{!-- TODO nb localize --}}
+        {{#accordion-list-item
+           title='Cluster Agent Config'
+           expandOnInit=false
+           expandAll=al.expandAll
+           expand=(action expandFn)
+        }}
+        {{!-- //TODO nb pass in agentconfig --}}
+          <FormAgentConfig
+            @mode={{mode}}
+          />
+        {{/accordion-list-item}}
 
       {{/if}}
     {{/accordion-list}}

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -1344,6 +1344,7 @@
         {{/accordion-list-item}}
         {{#accordion-list-item
            title=(t "clusterNew.agentConfig.title.cluster")
+           detail=(t "clusterNew.agentConfig.accordionDetail.cluster")
            expandOnInit=false
            expandAll=al.expandAll
            expand=(action expandFn)
@@ -1356,6 +1357,7 @@
         {{/accordion-list-item}}
         {{#accordion-list-item
            title=(t "clusterNew.agentConfig.title.fleet")
+           detail=(t "clusterNew.agentConfig.accordionDetail.fleet")
            expandOnInit=false
            expandAll=al.expandAll
            expand=(action expandFn)

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -1342,32 +1342,28 @@
             @applyClusterTemplate={{applyClusterTemplate}}
           />
         {{/accordion-list-item}}
-        {{!-- TODO nb localize --}}
         {{#accordion-list-item
-           title='Cluster Agent Config'
+           title=(t "clusterNew.agentConfig.title.cluster")
            expandOnInit=false
            expandAll=al.expandAll
            expand=(action expandFn)
         }}
-        {{!-- //TODO nb should agent configs be in <v3 cluster>.rancherKubernetesEngineConfig.lusterAgentDeploymentCustomization or <v3 cluster>.clusterAgentDeploymentCustomization --}}
           <FormAgentConfig
             @mode={{mode}}
             @cluster={{cluster}}
-            @agentKey="clusterAgentDeploymentCustomization"
+            @type="cluster"
           />
         {{/accordion-list-item}}
-        {{!-- TODO nb localize --}}
         {{#accordion-list-item
-           title='Fleet Agent Config'
+           title=(t "clusterNew.agentConfig.title.fleet")
            expandOnInit=false
            expandAll=al.expandAll
            expand=(action expandFn)
         }}
-        {{!-- //TODO nb should agent configs be in <v3 cluster>.rancherKubernetesEngineConfig.fleetAgentDeploymentCustomization or <v3 cluster>.fleetAgentDeploymentCustomization --}}
           <FormAgentConfig
             @mode={{mode}}
             @cluster={{cluster}}
-            @agentKey="fleetAgentDeploymentCustomization"
+            @type="fleet"
           />
         {{/accordion-list-item}}
 

--- a/lib/shared/addon/components/form-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-affinity-k8s/component.js
@@ -5,7 +5,6 @@ import {
   computed,
   get,
   set,
-  observer
 } from '@ember/object';
 
 /**
@@ -82,16 +81,16 @@ import {
 export default Component.extend({
   layout,
 
-  // affinity object
+  /**
+ * {
+ *  nodeAffinity
+ *  podAffinity
+ *  podAntiAffinity
+ * }
+ *
+ */
   value: null,
   mode:  'new',
-
-  actions: {
-    affinityChanged(key, val){
-      // TODO nb update affinity
-      console.log('affinity ', key, ' changed to: ', val)
-    }
-  },
 
   podAffinity: computed('value.podAffinity.{preferredDuringSchedulingIgnoredDuringExecution,requiredDuringSchedulingIgnoredDuringExecution}', {
     get(){

--- a/lib/shared/addon/components/form-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-affinity-k8s/component.js
@@ -86,15 +86,110 @@ export default Component.extend({
   value: null,
   mode:  'new',
 
-  podAffinity: computed('value.podAffinity', function(){
-    return get(this.value, 'podAffinity') || {}
+  actions: {
+    affinityChanged(key, val){
+      // TODO nb update affinity
+      console.log('affinity ', key, ' changed to: ', val)
+    }
+  },
+
+  podAffinity: computed('value.podAffinity.{preferredDuringSchedulingIgnoredDuringExecution,requiredDuringSchedulingIgnoredDuringExecution}', {
+    get(){
+      if (!this.value?.podAffinity){
+        set(this.value, 'podAffinity', {})
+      }
+      this.initPreferredRequired(this.value.podAffinity)
+
+      return get(this.value, 'podAffinity')
+    },
+    set(key, val){
+      // TODO nb move withoutId to own function
+      const withoutId = {
+        preferredDuringSchedulingIgnoredDuringExecution: (val.preferredDuringSchedulingIgnoredDuringExecution || []).map((term) => {
+          delete term._id;
+
+          return term
+        }),
+        requiredDuringSchedulingIgnoredDuringExecution: (val.requiredDuringSchedulingIgnoredDuringExecution || []).map((term) => {
+          delete term._id;
+
+          return term
+        })
+      }
+
+      set(this.value, 'podAffinity', withoutId)
+      this.notifyPropertyChange('value')
+
+      return val
+    }
   }),
 
-  podAntiAffinity: computed('value.podAntiAffinity', function(){
-    return get(this.value, 'podAntiAffinity') || {}
+  podAntiAffinity: computed('value.podAntiAffinity.{preferredDuringSchedulingIgnoredDuringExecution,requiredDuringSchedulingIgnoredDuringExecution}', {
+    get(){
+      if (!this.value?.podAntiAffinity){
+        set(this.value, 'podAntiAffinity', {})
+      }
+      this.initPreferredRequired(this.value.podAntiAffinity)
+
+      return get(this.value, 'podAntiAffinity')
+    },
+    set(key, val){
+      const withoutId = {
+        preferredDuringSchedulingIgnoredDuringExecution: (val.preferredDuringSchedulingIgnoredDuringExecution || []).map((term) => {
+          delete term._id;
+
+          return term
+        }),
+        requiredDuringSchedulingIgnoredDuringExecution: (val.requiredDuringSchedulingIgnoredDuringExecution || []).map((term) => {
+          delete term._id;
+
+          return term
+        })
+      }
+
+      set(this.value, 'podAntiAffinity', withoutId)
+      this.notifyPropertyChange('value')
+
+      return val
+    }
   }),
 
-  nodeAffinity: computed('value.nodeAffinity', function(){
-    return get(this.value, 'nodeAffinity') || {}
+  nodeAffinity: computed('value.nodeAffinity.{preferredDuringSchedulingIgnoredDuringExecution,requiredDuringSchedulingIgnoredDuringExecution}', {
+    get(){
+      if (!this.value?.nodeAffinity){
+        set(this.value, 'nodeAffinity', {})
+      }
+      this.initPreferredRequired(this.value.nodeAffinity)
+
+      return get(this.value, 'nodeAffinity')
+    },
+    set(key, val){
+      const withoutId = {
+        preferredDuringSchedulingIgnoredDuringExecution: (val.preferredDuringSchedulingIgnoredDuringExecution || []).map((term) => {
+          delete term._id;
+
+          return term
+        }),
+        requiredDuringSchedulingIgnoredDuringExecution: (val.requiredDuringSchedulingIgnoredDuringExecution || []).map((term) => {
+          delete term._id;
+
+          return term
+        })
+      }
+
+      set(this.value, 'nodeAffinity', withoutId)
+      this.notifyPropertyChange('value')
+
+      return val
+    }
   }),
+
+  initPreferredRequired: (val) => {
+    if (!val.preferredDuringSchedulingIgnoredDuringExecution){
+      set(val, 'preferredDuringSchedulingIgnoredDuringExecution', [])
+    }
+    if (!val.requiredDuringSchedulingIgnoredDuringExecution){
+      set(val, 'requiredDuringSchedulingIgnoredDuringExecution', [])
+    }
+  }
 })

--- a/lib/shared/addon/components/form-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-affinity-k8s/component.js
@@ -154,12 +154,15 @@ export default Component.extend({
     }
   }),
 
-  nodeAffinity: computed('value.nodeAffinity.{preferredDuringSchedulingIgnoredDuringExecution,requiredDuringSchedulingIgnoredDuringExecution}', {
+  nodeAffinity: computed('value.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution', 'value.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms', {
     get(){
       if (!this.value?.nodeAffinity){
         set(this.value, 'nodeAffinity', {})
       }
-      this.initPreferredRequired(this.value.nodeAffinity)
+      this.initPreferredRequired(this.value.nodeAffinity, true)
+      if (!this.value.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms){
+        set(this.value, 'nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms', [])
+      }
 
       return get(this.value, 'nodeAffinity')
     },
@@ -170,11 +173,13 @@ export default Component.extend({
 
           return term
         }),
-        requiredDuringSchedulingIgnoredDuringExecution: (val.requiredDuringSchedulingIgnoredDuringExecution || []).map((term) => {
-          delete term._id;
+        requiredDuringSchedulingIgnoredDuringExecution: {
+          nodeSelectorTerms: (val?.requiredDuringSchedulingIgnoredDuringExecution?.nodeSelectorTerms || []).map((term) => {
+            delete term._id;
 
-          return term
-        })
+            return term
+          })
+        }
       }
 
       set(this.value, 'nodeAffinity', withoutId)
@@ -184,11 +189,13 @@ export default Component.extend({
     }
   }),
 
-  initPreferredRequired: (val) => {
+  initPreferredRequired: (val, isNode) => {
     if (!val.preferredDuringSchedulingIgnoredDuringExecution){
       set(val, 'preferredDuringSchedulingIgnoredDuringExecution', [])
     }
-    if (!val.requiredDuringSchedulingIgnoredDuringExecution){
+    if (!val.requiredDuringSchedulingIgnoredDuringExecution && isNode){
+      set(val, 'requiredDuringSchedulingIgnoredDuringExecution', { nodeSelectorTerms: [] })
+    } else {
       set(val, 'requiredDuringSchedulingIgnoredDuringExecution', [])
     }
   }

--- a/lib/shared/addon/components/form-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-affinity-k8s/component.js
@@ -7,36 +7,6 @@ import {
   set,
 } from '@ember/object';
 
-/**
- * affinity: {
- *  nodeAffinity: {
- *    preferredDuringSchedulingIgnoredDuringExecution:
- *      - {
- *          preference: nodeselectorterm,
- *          weight: int
- *        }
- *    requiredDuringSchedulingIgnoredDuringExecution:
- *       nodeselectorterms:
- *          - nodeselectorterm
- *   }
- *
- *  podAffinity: {
- *    preferredDuringSchedulingIgnoredDuringExecution:
- *      - {
- *          weight: int,
- *          podaffinityterm: podaffinityterm
- *        }
- *    requiredDuringSchedulingIgnoredDuringExecution:
- *      - podaffinityterm
- *  }
- *
- *  podAntiAffinity: {
- *    same as podAffinity
- *  }
- * }
- */
-
-
 export default Component.extend({
   layout,
 

--- a/lib/shared/addon/components/form-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-affinity-k8s/component.js
@@ -193,10 +193,12 @@ export default Component.extend({
     if (!val.preferredDuringSchedulingIgnoredDuringExecution){
       set(val, 'preferredDuringSchedulingIgnoredDuringExecution', [])
     }
-    if (!val.requiredDuringSchedulingIgnoredDuringExecution && isNode){
-      set(val, 'requiredDuringSchedulingIgnoredDuringExecution', { nodeSelectorTerms: [] })
-    } else {
-      set(val, 'requiredDuringSchedulingIgnoredDuringExecution', [])
+    if (!val.requiredDuringSchedulingIgnoredDuringExecution){
+      if (isNode){
+        set(val, 'requiredDuringSchedulingIgnoredDuringExecution', { nodeSelectorTerms: [] })
+      } else {
+        set(val, 'requiredDuringSchedulingIgnoredDuringExecution', [])
+      }
     }
   }
 })

--- a/lib/shared/addon/components/form-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-affinity-k8s/component.js
@@ -34,63 +34,14 @@ import {
  *    same as podAffinity
  *  }
  * }
- *
- *
- * nodeselectorterm: {
- *    matchexpressions:
- *      - {
- *          key: string,
- *          operator: string, one of: [In, NotIn, Exists, DoesNotExist Gt, Lt]
- *          value: string array ... If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer.
- *      }
- *    matchfields: same as match expressions but matches fields instead of labels
- * }
- *
- *
- * podaffinityterm: {
- *   namespaceSelector: same as labelSelector OR if empty object, 'all namespaces'
- *   namespaces: string array of namespaces - if [] && namespaceSelector==null, 'use this pod's namespace'
- *   toplogyKey: string
- *   labelSelector: {
- *      matchExpressions:
- *        - {
- *            key: string,
- *            operator string one of: In, NotIn, Exists and DoesNotExist
- *            value: string array ... If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty.
- *          }
- *      matchLabels: {
- *            map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value".
- *            The requirements are ANDed.
- *        }
- *    }
-
- * }
- *
- * COMPONENTS NEEDED:
- * podaffinity - 2x podaffinitytermComponent arrays
- * nodeaffinity - 2x nodeselectortermComponent arrays
- * podaffinityterm - bool to switch between regular podaffinityterm and podaffinityterm + weight
- * nodeselectorterm- bool to switch between regular nodeselectorterm and nodeselectorterm + weight
- * matchexpressions - should have pod/node bool prop to work for both podaffinityterm.labelselector.matchexpressions and nodeselectorterm.matchexpressions/matchfields
- *
- *
- *
  */
 
 
 export default Component.extend({
   layout,
 
-  /**
- * {
- *  nodeAffinity
- *  podAffinity
- *  podAntiAffinity
- * }
- *
- */
-  value: null,
-  mode:  'new',
+  value:   null,
+  editing: false,
 
   podAffinity: computed('value.podAffinity.{preferredDuringSchedulingIgnoredDuringExecution,requiredDuringSchedulingIgnoredDuringExecution}', {
     get(){
@@ -102,18 +53,9 @@ export default Component.extend({
       return get(this.value, 'podAffinity')
     },
     set(key, val){
-      // TODO nb move withoutId to own function
       const withoutId = {
-        preferredDuringSchedulingIgnoredDuringExecution: (val.preferredDuringSchedulingIgnoredDuringExecution || []).map((term) => {
-          delete term._id;
-
-          return term
-        }),
-        requiredDuringSchedulingIgnoredDuringExecution: (val.requiredDuringSchedulingIgnoredDuringExecution || []).map((term) => {
-          delete term._id;
-
-          return term
-        })
+        preferredDuringSchedulingIgnoredDuringExecution: this.removeIds(val.preferredDuringSchedulingIgnoredDuringExecution),
+        requiredDuringSchedulingIgnoredDuringExecution:  this.removeIds(val.requiredDuringSchedulingIgnoredDuringExecution)
       }
 
       set(this.value, 'podAffinity', withoutId)
@@ -134,16 +76,8 @@ export default Component.extend({
     },
     set(key, val){
       const withoutId = {
-        preferredDuringSchedulingIgnoredDuringExecution: (val.preferredDuringSchedulingIgnoredDuringExecution || []).map((term) => {
-          delete term._id;
-
-          return term
-        }),
-        requiredDuringSchedulingIgnoredDuringExecution: (val.requiredDuringSchedulingIgnoredDuringExecution || []).map((term) => {
-          delete term._id;
-
-          return term
-        })
+        preferredDuringSchedulingIgnoredDuringExecution: this.removeIds(val.preferredDuringSchedulingIgnoredDuringExecution),
+        requiredDuringSchedulingIgnoredDuringExecution:  this.removeIds(val.requiredDuringSchedulingIgnoredDuringExecution )
       }
 
       set(this.value, 'podAntiAffinity', withoutId)
@@ -167,18 +101,8 @@ export default Component.extend({
     },
     set(key, val){
       const withoutId = {
-        preferredDuringSchedulingIgnoredDuringExecution: (val.preferredDuringSchedulingIgnoredDuringExecution || []).map((term) => {
-          delete term._id;
-
-          return term
-        }),
-        requiredDuringSchedulingIgnoredDuringExecution: {
-          nodeSelectorTerms: (val?.requiredDuringSchedulingIgnoredDuringExecution?.nodeSelectorTerms || []).map((term) => {
-            delete term._id;
-
-            return term
-          })
-        }
+        preferredDuringSchedulingIgnoredDuringExecution: this.removeIds(val.preferredDuringSchedulingIgnoredDuringExecution),
+        requiredDuringSchedulingIgnoredDuringExecution:  this.removeIds(val?.requiredDuringSchedulingIgnoredDuringExecution?.nodeSelectorTerms)
       }
 
       set(this.value, 'nodeAffinity', withoutId)
@@ -199,5 +123,13 @@ export default Component.extend({
         set(val, 'requiredDuringSchedulingIgnoredDuringExecution', [])
       }
     }
+  },
+
+  removeIds: (terms = []) => {
+    return terms.map((term) => {
+      delete term._id
+
+      return term
+    })
   }
 })

--- a/lib/shared/addon/components/form-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-affinity-k8s/component.js
@@ -22,6 +22,7 @@ export default Component.extend({
 
       return get(this.value, 'podAffinity')
     },
+
     set(key, val){
       const withoutId = {
         preferredDuringSchedulingIgnoredDuringExecution: this.removeIds(val.preferredDuringSchedulingIgnoredDuringExecution),
@@ -44,6 +45,8 @@ export default Component.extend({
 
       return get(this.value, 'podAntiAffinity')
     },
+
+
     set(key, val){
       const withoutId = {
         preferredDuringSchedulingIgnoredDuringExecution: this.removeIds(val.preferredDuringSchedulingIgnoredDuringExecution),
@@ -62,17 +65,19 @@ export default Component.extend({
       if (!this.value?.nodeAffinity){
         set(this.value, 'nodeAffinity', {})
       }
-      this.initPreferredRequired(this.value.nodeAffinity, true)
+
+      this.initPreferredRequired(get(this.value, 'nodeAffinity'), true)
       if (!this.value.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms){
         set(this.value, 'nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms', [])
       }
 
       return get(this.value, 'nodeAffinity')
     },
+
     set(key, val){
       const withoutId = {
         preferredDuringSchedulingIgnoredDuringExecution: this.removeIds(val.preferredDuringSchedulingIgnoredDuringExecution),
-        requiredDuringSchedulingIgnoredDuringExecution:  this.removeIds(val?.requiredDuringSchedulingIgnoredDuringExecution?.nodeSelectorTerms)
+        requiredDuringSchedulingIgnoredDuringExecution:  { nodeSelectorTerms: this.removeIds(val.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms ) }
       }
 
       set(this.value, 'nodeAffinity', withoutId)
@@ -101,5 +106,6 @@ export default Component.extend({
 
       return term
     })
-  }
+  },
+
 })

--- a/lib/shared/addon/components/form-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-affinity-k8s/component.js
@@ -1,0 +1,100 @@
+// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#affinity-v1-core
+import Component from '@ember/component';
+import layout from './template';
+import {
+  computed,
+  get,
+  set,
+  observer
+} from '@ember/object';
+
+/**
+ * affinity: {
+ *  nodeAffinity: {
+ *    preferredDuringSchedulingIgnoredDuringExecution:
+ *      - {
+ *          preference: nodeselectorterm,
+ *          weight: int
+ *        }
+ *    requiredDuringSchedulingIgnoredDuringExecution:
+ *       nodeselectorterms:
+ *          - nodeselectorterm
+ *   }
+ *
+ *  podAffinity: {
+ *    preferredDuringSchedulingIgnoredDuringExecution:
+ *      - {
+ *          weight: int,
+ *          podaffinityterm: podaffinityterm
+ *        }
+ *    requiredDuringSchedulingIgnoredDuringExecution:
+ *      - podaffinityterm
+ *  }
+ *
+ *  podAntiAffinity: {
+ *    same as podAffinity
+ *  }
+ * }
+ *
+ *
+ * nodeselectorterm: {
+ *    matchexpressions:
+ *      - {
+ *          key: string,
+ *          operator: string, one of: [In, NotIn, Exists, DoesNotExist Gt, Lt]
+ *          value: string array ... If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer.
+ *      }
+ *    matchfields: same as match expressions but matches fields instead of labels
+ * }
+ *
+ *
+ * podaffinityterm: {
+ *   namespaceSelector: same as labelSelector OR if empty object, 'all namespaces'
+ *   namespaces: string array of namespaces - if [] && namespaceSelector==null, 'use this pod's namespace'
+ *   toplogyKey: string
+ *   labelSelector: {
+ *      matchExpressions:
+ *        - {
+ *            key: string,
+ *            operator string one of: In, NotIn, Exists and DoesNotExist
+ *            value: string array ... If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty.
+ *          }
+ *      matchLabels: {
+ *            map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value".
+ *            The requirements are ANDed.
+ *        }
+ *    }
+
+ * }
+ *
+ * COMPONENTS NEEDED:
+ * podaffinity - 2x podaffinitytermComponent arrays
+ * nodeaffinity - 2x nodeselectortermComponent arrays
+ * podaffinityterm - bool to switch between regular podaffinityterm and podaffinityterm + weight
+ * nodeselectorterm- bool to switch between regular nodeselectorterm and nodeselectorterm + weight
+ * matchexpressions - should have pod/node bool prop to work for both podaffinityterm.labelselector.matchexpressions and nodeselectorterm.matchexpressions/matchfields
+ *
+ *
+ *
+ */
+
+
+export default Component.extend({
+  layout,
+
+  // affinity object
+  value: null,
+  mode:  'new',
+
+  podAffinity: computed('value.podAffinity', function(){
+    return get(this.value, 'podAffinity') || {}
+  }),
+
+  podAntiAffinity: computed('value.podAntiAffinity', function(){
+    return get(this.value, 'podAntiAffinity') || {}
+  }),
+
+  nodeAffinity: computed('value.nodeAffinity', function(){
+    return get(this.value, 'nodeAffinity') || {}
+  }),
+})

--- a/lib/shared/addon/components/form-affinity-k8s/template.hbs
+++ b/lib/shared/addon/components/form-affinity-k8s/template.hbs
@@ -1,0 +1,21 @@
+<div>
+  <div class="row">
+    <FormNodeAffinityK8s
+      @mode={{mode}}
+      @value={{nodeAffinity}}
+    />
+  </div>
+  <div class="row">
+    <FormPodAffinityK8s
+      @mode={{mode}}
+      @value={{podAffinity}}
+    />
+  </div>
+  <div class="row">
+    <FormPodAffinityK8s
+      @anti={{true}}
+      @mode={{mode}}
+      @value={{podAntiAffinity}}
+    />
+  </div>
+</div>

--- a/lib/shared/addon/components/form-affinity-k8s/template.hbs
+++ b/lib/shared/addon/components/form-affinity-k8s/template.hbs
@@ -2,7 +2,7 @@
   <div class="row">
     <FormNodeAffinityK8s
       @mode={{mode}}
-      @value={{nodeAffinity}}
+      @nodeAffinity={{nodeAffinity}}
     />
   </div>
   <div class="row">
@@ -11,6 +11,7 @@
       @value={{podAffinity}}
       @podAffinity={{podAffinity}}
       @podAntiAffinity={{podAntiAffinity}}
+      {{!-- //TODO nb used? --}}
       @update={{action "affinityChanged"}}
     />
   </div>

--- a/lib/shared/addon/components/form-affinity-k8s/template.hbs
+++ b/lib/shared/addon/components/form-affinity-k8s/template.hbs
@@ -9,13 +9,9 @@
     <FormPodAffinityK8s
       @mode={{mode}}
       @value={{podAffinity}}
-    />
-  </div>
-  <div class="row">
-    <FormPodAffinityK8s
-      @anti={{true}}
-      @mode={{mode}}
-      @value={{podAntiAffinity}}
+      @podAffinity={{podAffinity}}
+      @podAntiAffinity={{podAntiAffinity}}
+      @update={{action "affinityChanged"}}
     />
   </div>
 </div>

--- a/lib/shared/addon/components/form-affinity-k8s/template.hbs
+++ b/lib/shared/addon/components/form-affinity-k8s/template.hbs
@@ -1,13 +1,13 @@
 <div>
   <div class="row mb-10">
     <FormNodeAffinityK8s
-      @mode={{mode}}
+      @editing={{editing}}
       @nodeAffinity={{nodeAffinity}}
     />
   </div>
   <div class="row">
     <FormPodAffinityK8s
-      @mode={{mode}}
+      @editing={{editing}}
       @podAffinity={{podAffinity}}
       @podAntiAffinity={{podAntiAffinity}}
     />

--- a/lib/shared/addon/components/form-affinity-k8s/template.hbs
+++ b/lib/shared/addon/components/form-affinity-k8s/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <div class="row">
+  <div class="row mb-10">
     <FormNodeAffinityK8s
       @mode={{mode}}
       @nodeAffinity={{nodeAffinity}}
@@ -8,11 +8,8 @@
   <div class="row">
     <FormPodAffinityK8s
       @mode={{mode}}
-      @value={{podAffinity}}
       @podAffinity={{podAffinity}}
       @podAntiAffinity={{podAntiAffinity}}
-      {{!-- //TODO nb used? --}}
-      @update={{action "affinityChanged"}}
     />
   </div>
 </div>

--- a/lib/shared/addon/components/form-agent-config/component.js
+++ b/lib/shared/addon/components/form-agent-config/component.js
@@ -1,0 +1,70 @@
+import Component from '@ember/component';
+import layout from './template';
+import {
+  computed,
+  get,
+  set,
+} from '@ember/object';
+
+export default Component.extend({
+  layout,
+
+  mode:   'new',
+  // TODO nb pass in fleet/cluster agent config
+  config: {},
+
+  actions: {
+    updateLimits(val){
+      if (!val.cpu && !val.memory){
+        this.updateResourceRequirement('limits', null)
+      } else {
+        this.updateResourceRequirement('limits', val)
+      }
+    },
+    updateRequests(val){
+      if (!val.cpu && !val.memory){
+        this.updateResourceRequirement('requests', null)
+      } else {
+        this.updateResourceRequirement('requests', val)
+      }
+    }
+  },
+
+  overrideResourceRequirements: computed('config.overrideResourceRequirements.{requests,limits}', {
+    get(){
+      return get(this, 'config.overrideResourceRequirements') || {}
+    },
+    set(key, val){
+      if ((!val?.limits && !val?.requests) && get(this.config, 'overrideResourceRequirements')){
+        delete this.config.overrideResourceRequirements
+      } else {
+        set(this, 'config.overrideResourceRequirements', val)
+      }
+
+      return val
+    }
+  }),
+
+  limits: computed('overrideResourceRequirements.limits', function() {
+    return get(this, 'overrideResourceRequirements.limits') || {}
+  }),
+
+  requests: computed('overrideResourceRequirements.requests', function() {
+    return get(this, 'overrideResourceRequirements.requests') || {}
+  }),
+
+
+
+  updateResourceRequirement(type, val){
+    const neu = { ...this.overrideResourceRequirements }
+
+    if (val){
+      neu[type] = val
+    } else if (neu[type]){
+      delete neu[type]
+    }
+
+    this.set('overrideResourceRequirements', neu)
+  },
+
+})

--- a/lib/shared/addon/components/form-agent-config/component.js
+++ b/lib/shared/addon/components/form-agent-config/component.js
@@ -1,5 +1,7 @@
 import Component from '@ember/component';
 import layout from './template';
+import { inject as service } from '@ember/service';
+
 import {
   computed,
   get,
@@ -7,15 +9,27 @@ import {
   observer
 } from '@ember/object';
 
-import { once } from '@ember/runloop';
+
+import { isEqual } from '@ember/utils';
+
 
 export default Component.extend({
+  globalStore: service(),
+
   layout,
 
-  mode:     'new',
-  // TODO nb pass in fleet/cluster spec
-  cluster:   {},
-  agentKey: '',
+  mode:               'new',
+  cluster:            {},
+  // cluster or fleet agent deployment
+  type:               'cluster',
+  useDefaultAffinity: true,
+
+  init(){
+    this._super(...arguments);
+    if ( this.overrideAffinity && !isEqual(this.defaultAffinity, this.overrideAffinity)){
+      this.useDefaultAffinity = false
+    }
+  },
 
   actions: {
     updateLimits(val){
@@ -32,17 +46,10 @@ export default Component.extend({
       } else {
         this.updateResourceRequirement('requests', val)
       }
-    },
-
-    updateAffinity(val){
-      // TODO nb do
-
-      console.log('agentConfig updating affinity to: ', val)
     }
 
   },
 
-  // TODO nb add affinity
   agentObserver: observer('agentConfig.overrideResourceRequirements', 'agentConfig.appendTolerations', 'agentConfig.overrideAffinity', function() {
     const agentConfig = get(this, 'agentConfig') || {}
     const agentKey = get(this, 'agentKey')
@@ -53,6 +60,49 @@ export default Component.extend({
       delete this.cluster[agentKey]
     }
   }),
+
+  useDefaultAffinityObserver: observer('useDefaultAffinity', function(){
+    if (!this.useDefaultAffinity){
+      this.set('overrideAffinity', this.defaultAffinity)
+    } else {
+      // default rules will be applied by BE if this field is empty
+      this.set('overrideAffinity', null)
+    }
+  }),
+
+  agentKey: computed('type', function(){
+    return `${ this.type }AgentDeploymentConfiguration`
+  }),
+
+  defaultSettingId: computed('type', function(){
+    return `${ this.type }-agent-default-affinity`
+  }),
+
+  editing:   computed('mode', function() {
+    const mode = get(this, 'mode')
+
+    return mode === 'new' || mode === 'edit'
+  }),
+
+  defaultAffinity: computed('defaultSettingId', function(){
+    if (!this.defaultSettingId){
+      return null
+    }
+    const setting =  this.globalStore.getById('setting', this.defaultSettingId)
+
+    if (setting){
+      try {
+        const parsed = JSON.parse(setting.value)
+
+        return parsed
+      } catch (e){
+        console.error('error parsing affinity default value: ', e)
+      }
+    }
+
+    return null
+  }),
+
 
   agentConfig: computed('cluster', 'agentKey', function() {
     const agentKey = get(this, 'agentKey')
@@ -103,10 +153,15 @@ export default Component.extend({
 
   overrideAffinity: computed('agentConfig.overrideAffinity', {
     get(){
-      return get(this, 'agentConfig.overrideAffinity') || {}
+      return get(this, 'agentConfig.overrideAffinity')
     },
     set(key, val){
-      set(this.agentConfig, 'overrideAffinity', val)
+      if (val){
+        set(this.agentConfig, 'overrideAffinity', val)
+      } else if (this.agentConfig?.overrideAffinity){
+        delete this.agentConfig.overrideAffinity
+        this.notifyPropertyChange('agentConfig')
+      }
 
       return val
     }

--- a/lib/shared/addon/components/form-agent-config/component.js
+++ b/lib/shared/addon/components/form-agent-config/component.js
@@ -74,7 +74,7 @@ export default Component.extend({
   }),
 
   agentKey: computed('type', function(){
-    return `${ this.type }AgentDeploymentConfiguration`
+    return `${ this.type }AgentDeploymentCustomization`
   }),
 
   defaultSettingId: computed('type', function(){

--- a/lib/shared/addon/components/form-agent-config/component.js
+++ b/lib/shared/addon/components/form-agent-config/component.js
@@ -25,16 +25,25 @@ export default Component.extend({
         this.updateResourceRequirement('limits', val)
       }
     },
+
     updateRequests(val){
       if (!val.cpu && !val.memory){
         this.updateResourceRequirement('requests', null)
       } else {
         this.updateResourceRequirement('requests', val)
       }
+    },
+
+    updateAffinity(val){
+      // TODO nb do
+
+      console.log('agentConfig updating affinity to: ', val)
     }
+
   },
+
   // TODO nb add affinity
-  agentObserver: observer('agentConfig.overrideResourceRequirements', 'agentConfig.appendTolerations', function() {
+  agentObserver: observer('agentConfig.overrideResourceRequirements', 'agentConfig.appendTolerations', 'agentConfig.overrideAffinity', function() {
     const agentConfig = get(this, 'agentConfig') || {}
     const agentKey = get(this, 'agentKey')
 
@@ -90,6 +99,16 @@ export default Component.extend({
 
       return val
     },
+  }),
+
+  overrideAffinity: computed('agentConfig.overrideAffinity', {
+    get(){
+      return get(this, 'agentConfig.overrideAffinity') || {}
+    },
+    set(key, val){
+      // TODO nb update agentConfig
+      return val
+    }
   }),
 
   updateResourceRequirement(type, val){

--- a/lib/shared/addon/components/form-agent-config/component.js
+++ b/lib/shared/addon/components/form-agent-config/component.js
@@ -4,14 +4,18 @@ import {
   computed,
   get,
   set,
+  observer
 } from '@ember/object';
+
+import { once } from '@ember/runloop';
 
 export default Component.extend({
   layout,
 
-  mode:   'new',
-  // TODO nb pass in fleet/cluster agent config
-  config: {},
+  mode:     'new',
+  // TODO nb pass in fleet/cluster spec
+  cluster:   {},
+  agentKey: '',
 
   actions: {
     updateLimits(val){
@@ -29,17 +33,36 @@ export default Component.extend({
       }
     }
   },
+  // TODO nb add affinity
+  agentObserver: observer('agentConfig.overrideResourceRequirements', 'agentConfig.appendTolerations', function() {
+    const agentConfig = get(this, 'agentConfig') || {}
+    const agentKey = get(this, 'agentKey')
 
-  overrideResourceRequirements: computed('config.overrideResourceRequirements.{requests,limits}', {
+    if (Object.keys(agentConfig).length){
+      set(this.cluster, agentKey, agentConfig)
+    } else if (this.cluster[agentKey]){
+      delete this.cluster[agentKey]
+    }
+  }),
+
+  agentConfig: computed('cluster', 'agentKey', function() {
+    const agentKey = get(this, 'agentKey')
+
+    return get(this.cluster, agentKey) || {}
+  }),
+
+  overrideResourceRequirements: computed('agentConfig.overrideResourceRequirements.{requests,limits}', {
     get(){
-      return get(this, 'config.overrideResourceRequirements') || {}
+      return get(this, 'agentConfig.overrideResourceRequirements') || {}
     },
-    set(key, val){
-      if ((!val?.limits && !val?.requests) && get(this.config, 'overrideResourceRequirements')){
-        delete this.config.overrideResourceRequirements
-      } else {
-        set(this, 'config.overrideResourceRequirements', val)
+    set(key, val = {}){
+      if (val.limits || val.requests){
+        set(this, 'agentConfig.overrideResourceRequirements', val)
+      } else if (this.agentConfig.overrideResourceRequirements){
+        delete this.agentConfig.overrideResourceRequirements
+        this.notifyPropertyChange('agentConfig')
       }
+
 
       return val
     }
@@ -53,7 +76,21 @@ export default Component.extend({
     return get(this, 'overrideResourceRequirements.requests') || {}
   }),
 
+  appendTolerations: computed('agentConfig.appendTolerations', {
+    get(){
+      return get(this, 'agentConfig.appendTolerations') || []
+    },
+    set(key, val = []){
+      if (val.length){
+        set(this, 'agentConfig.appendTolerations', val)
+      } else if (this.agentConfig.appendTolerations){
+        delete this.agentConfig.appendTolerations
+        this.notifyPropertyChange('agentConfig')
+      }
 
+      return val
+    },
+  }),
 
   updateResourceRequirement(type, val){
     const neu = { ...this.overrideResourceRequirements }

--- a/lib/shared/addon/components/form-agent-config/component.js
+++ b/lib/shared/addon/components/form-agent-config/component.js
@@ -93,9 +93,7 @@ export default Component.extend({
 
     if (setting){
       try {
-        const parsed = JSON.parse(setting.value)
-
-        return parsed
+        return JSON.parse(setting.value)
       } catch (e){
         console.error('error parsing affinity default value: ', e)
       }

--- a/lib/shared/addon/components/form-agent-config/component.js
+++ b/lib/shared/addon/components/form-agent-config/component.js
@@ -24,9 +24,6 @@ export default Component.extend({
   type:               'cluster',
   useDefaultAffinity: true,
 
-  editing: computed.equal('mode', 'new'),
-
-
   init(){
     this._super(...arguments);
     if ( this.overrideAffinity && !isEqual(this.defaultAffinity, this.overrideAffinity)){
@@ -72,6 +69,13 @@ export default Component.extend({
       this.set('overrideAffinity', null)
     }
   }),
+
+  editing: computed('mode', function(){
+    const { mode } = this;
+
+    return mode === 'new' || mode === 'edit'
+  }),
+
 
   agentKey: computed('type', function(){
     return `${ this.type }AgentDeploymentCustomization`

--- a/lib/shared/addon/components/form-agent-config/component.js
+++ b/lib/shared/addon/components/form-agent-config/component.js
@@ -106,7 +106,8 @@ export default Component.extend({
       return get(this, 'agentConfig.overrideAffinity') || {}
     },
     set(key, val){
-      // TODO nb update agentConfig
+      set(this.agentConfig, 'overrideAffinity', val)
+
       return val
     }
   }),

--- a/lib/shared/addon/components/form-agent-config/component.js
+++ b/lib/shared/addon/components/form-agent-config/component.js
@@ -24,6 +24,9 @@ export default Component.extend({
   type:               'cluster',
   useDefaultAffinity: true,
 
+  editing: computed.equal('mode', 'new'),
+
+
   init(){
     this._super(...arguments);
     if ( this.overrideAffinity && !isEqual(this.defaultAffinity, this.overrideAffinity)){
@@ -76,12 +79,6 @@ export default Component.extend({
 
   defaultSettingId: computed('type', function(){
     return `${ this.type }-agent-default-affinity`
-  }),
-
-  editing:   computed('mode', function() {
-    const mode = get(this, 'mode')
-
-    return mode === 'new' || mode === 'edit'
   }),
 
   defaultAffinity: computed('defaultSettingId', function(){

--- a/lib/shared/addon/components/form-agent-config/template.hbs
+++ b/lib/shared/addon/components/form-agent-config/template.hbs
@@ -1,9 +1,14 @@
 <div class="agent-config">
-  {{!-- <BannerMessage
+  <BannerMessage
     @color="bg-warning mb-10"
-    @message="This is advanced blah blah"
-  /> --}}
+    @message={{t "clusterNew.agentConfig.banners.advanced" type=type}}
+    @icon="icon icon-alert"
+  />
   <div class ="mb-10 box">
+    <BannerMessage
+      @color="bg-info mb-10"
+      @message={{t "clusterNew.agentConfig.banners.resourceRequests"}}
+    />
     <div class="row">
       <ResourceList
         @mode={{mode}}
@@ -25,13 +30,40 @@
   <div class="mb-10">
     <div class="row">
       <div class="col span-12 box">
+        <BannerMessage
+          @color="bg-info mb-10"
+          @message={{t "clusterNew.agentConfig.banners.tolerations"}}
+        />
         {{scheduling-toleration editing=(or (eq mode "edit") (eq mode "new")) tolerate=appendTolerations}}
       </div>
     </div>
   </div>
-  <FormAffinityK8s
+  {{#if editing}}
+    <div class="row">
+      <div class="col span-12 mb-0">
+        <div class="radio">
+          <label>
+            {{radio-button
+              selection=useDefaultAffinity
+              value=true
+            }} {{t "clusterNew.agentConfig.overrideAffinity.useDefault"}}
+          </label>
+        </div> 
+        <div class="radio">
+          <label>
+            {{radio-button
+              selection=useDefaultAffinity
+              value=false
+            }} {{t "clusterNew.agentConfig.overrideAffinity.customize"}}
+          </label>
+        </div>
+      </div>
+    </div>
+  {{/if}}
+  {{#if (and (or (not useDefaultAffinity) (not editing) ) overrideAffinity) }}
+    <FormAffinityK8s
     @mode={{mode}}
     @value={{overrideAffinity}}
-    @update={{action "updateAffinity"}}
   />
+  {{/if}}
 </div>

--- a/lib/shared/addon/components/form-agent-config/template.hbs
+++ b/lib/shared/addon/components/form-agent-config/template.hbs
@@ -1,16 +1,30 @@
 <div>
-  <div class="row">
-    <ResourceList
-      @type={{t "clusterNew.agentConfig.resourceRequirements.requests"}}
-      @value={{requests}}
-      @update={{action "updateRequests" }}
-    />
-  </div>
+  {{!-- TODO nb localize --}}
+  <BannerMessage
+    @color="bg-warning mb-10"
+    @message="This is advanced blah blah"
+  />
+  <div class ="mb-10 box">
     <div class="row">
-    <ResourceList
-      @type={{t "clusterNew.agentConfig.resourceRequirements.limits"}}
-      @value={{limits}}
-      @update={{action "updateLimits"}}
-    />
+      <ResourceList
+        @type={{t "clusterNew.agentConfig.resourceRequirements.requests"}}
+        @value={{requests}}
+        @update={{action "updateRequests" }}
+      />
+    </div>
+      <div class="row">
+      <ResourceList
+        @type={{t "clusterNew.agentConfig.resourceRequirements.limits"}}
+        @value={{limits}}
+        @update={{action "updateLimits"}}
+      />
+    </div>
+  </div>
+  <div class="mb-10">
+    <div class="row">
+      <div class="col span-12 box">
+        {{scheduling-toleration editing=(or (eq mode "edit") (eq mode "new")) tolerate=appendTolerations}}
+      </div>
+    </div>
   </div>
 </div>

--- a/lib/shared/addon/components/form-agent-config/template.hbs
+++ b/lib/shared/addon/components/form-agent-config/template.hbs
@@ -1,0 +1,16 @@
+<div>
+  <div class="row">
+    <ResourceList
+      @type={{t "clusterNew.agentConfig.resourceRequirements.requests"}}
+      @value={{requests}}
+      @update={{action "updateRequests" }}
+    />
+  </div>
+    <div class="row">
+    <ResourceList
+      @type={{t "clusterNew.agentConfig.resourceRequirements.limits"}}
+      @value={{limits}}
+      @update={{action "updateLimits"}}
+    />
+  </div>
+</div>

--- a/lib/shared/addon/components/form-agent-config/template.hbs
+++ b/lib/shared/addon/components/form-agent-config/template.hbs
@@ -11,16 +11,15 @@
     />
     <div class="row">
       <ResourceList
-        @mode={{mode}}
+        @editing={{editing}}
         @type={{t "clusterNew.agentConfig.resourceRequirements.requests"}}
         @value={{requests}}
         @update={{action "updateRequests" }}
       />
     </div>
       <div class="row">
-        {{!-- TODO nb display/edit mode --}}
       <ResourceList
-        @mode={{mode}}
+        @editing={{editing}}
         @type={{t "clusterNew.agentConfig.resourceRequirements.limits"}}
         @value={{limits}}
         @update={{action "updateLimits"}}
@@ -34,11 +33,10 @@
           @color="bg-info mb-10"
           @message={{t "clusterNew.agentConfig.banners.tolerations"}}
         />
-        {{scheduling-toleration editing=(or (eq mode "edit") (eq mode "new")) tolerate=appendTolerations}}
+        {{scheduling-toleration editing=editing tolerate=appendTolerations}}
       </div>
     </div>
   </div>
-  {{#if editing}}
     <div class="row">
       <div class="col span-12 mb-0">
         <div class="radio">
@@ -46,6 +44,7 @@
             {{radio-button
               selection=useDefaultAffinity
               value=true
+              disabled=(not editing)
             }} {{t "clusterNew.agentConfig.overrideAffinity.useDefault"}}
           </label>
         </div> 
@@ -54,15 +53,15 @@
             {{radio-button
               selection=useDefaultAffinity
               value=false
+              disabled=(not editing)
             }} {{t "clusterNew.agentConfig.overrideAffinity.customize"}}
           </label>
         </div>
       </div>
     </div>
-  {{/if}}
   {{#if (and (or (not useDefaultAffinity) (not editing) ) overrideAffinity) }}
     <FormAffinityK8s
-    @mode={{mode}}
+    @editing={{editing}}
     @value={{overrideAffinity}}
   />
   {{/if}}

--- a/lib/shared/addon/components/form-agent-config/template.hbs
+++ b/lib/shared/addon/components/form-agent-config/template.hbs
@@ -1,19 +1,21 @@
-<div>
-  {{!-- TODO nb localize --}}
-  <BannerMessage
+<div class="agent-config">
+  {{!-- <BannerMessage
     @color="bg-warning mb-10"
     @message="This is advanced blah blah"
-  />
+  /> --}}
   <div class ="mb-10 box">
     <div class="row">
       <ResourceList
+        @mode={{mode}}
         @type={{t "clusterNew.agentConfig.resourceRequirements.requests"}}
         @value={{requests}}
         @update={{action "updateRequests" }}
       />
     </div>
       <div class="row">
+        {{!-- TODO nb display/edit mode --}}
       <ResourceList
+        @mode={{mode}}
         @type={{t "clusterNew.agentConfig.resourceRequirements.limits"}}
         @value={{limits}}
         @update={{action "updateLimits"}}
@@ -27,4 +29,9 @@
       </div>
     </div>
   </div>
+  <FormAffinityK8s
+    @mode={{mode}}
+    @value={{overrideAffinity}}
+    @update={{action "updateAffinity"}}
+  />
 </div>

--- a/lib/shared/addon/components/form-match-expressions-k8s/component.js
+++ b/lib/shared/addon/components/form-match-expressions-k8s/component.js
@@ -1,5 +1,207 @@
 // matchexpressions that matches k8s spec rather than norman spec
 import Component from '@ember/component';
 import layout from './template';
+import {
+  computed,
+  get,
+  set,
+  observer
+} from '@ember/object';
+import { randomStr } from '../../utils/util';
+/**
+ * FOR NODE:
+ * nodeSelectorTerm: {
+ *    matchexpressions:
+ *      - {
+ *          key: string,
+ *          operator: string, one of: [In, NotIn, Exists, DoesNotExist Gt, Lt]
+ *          value: string array ... If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer.
+ *      }
+ *   matchFields: same as matchExpressions
+ * }
 
-export default Component.extend({ layout })
+* FOR POD:
+labelSelector: {
+*      matchExpressions:
+*        - {
+*            key: string,
+*            operator string one of: In, NotIn, Exists and DoesNotExist
+*            value: string array ... If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty.
+*          }
+}
+
+ */
+
+const MATCH_TYPES = {
+  MATCH_EXPRESSIONS: 'matchExpressions',
+  MATCH_FIELDS:      'matchFields',
+  LABEL_SELECTOR:    'labelSelector'
+}
+
+export default Component.extend({
+  layout,
+  mode:             'new',
+  // TODO nb have parent component delete keys if empty
+  // TODO nb strip ID from match in parent component
+  nodeSelectorTerm: null,
+  labelSelector:    null,
+  allMatches:       [],
+  MATCH_TYPES,
+
+  typeOpts: [
+    {
+      value:    MATCH_TYPES.MATCH_EXPRESSIONS,
+      label: 'clusterNew.agentConfig.overrideAffinity.nodeAffinity.nodeSelectorTerm.typeOptions.matchExpression'
+    },
+    {
+      value:    MATCH_TYPES.MATCH_FIELDS,
+      label: 'clusterNew.agentConfig.overrideAffinity.nodeAffinity.nodeSelectorTerm.typeOptions.matchField'
+    }
+  ],
+
+  // nodeSelectorTerms contain matchExpressions and matchFields, which will be shown as one list
+  // each item has a dropdown to change from expression to field - we want to preserve the order of the list shown to the user when this is changed
+  init(){
+    this._super(...arguments);
+    if (this.nodeSelectorTerm){
+      const allMatches = []
+      const addMatches = function(matches = [], type){
+        matches.forEach((match) => {
+          allMatches.push({
+            type,
+            match: {
+              _id: randomStr(),
+              ...match
+            }
+          })
+        })
+      }
+
+      addMatches(this.nodeSelectorTerm?.matchExpressions, MATCH_TYPES.MATCH_EXPRESSIONS)
+      addMatches(this.nodeSelectorTerm?.matchFields, MATCH_TYPES.MATCH_FIELDS)
+      set(this, 'allMatches', allMatches)
+    } else {
+      const allMatches = (this.labelSelector?.matchExpressions || []).map((match) => {
+        return {
+          type:  MATCH_TYPES.LABEL_SELECTOR,
+          match: {
+            _id: randomStr(),
+            ...match
+          }
+        }
+      })
+
+      set(this, 'allMatches', allMatches)
+    }
+  },
+
+  actions: {
+    addMatch(){
+      const toAdd = {
+        type:  this.nodeSelectorTerm ? MATCH_TYPES.MATCH_EXPRESSIONS : MATCH_TYPES.LABEL_SELECTOR,
+        match: {
+          _id:      randomStr(),
+          operator: this.operatorOpts[0].value
+        },
+      }
+
+      get(this, 'allMatches').addObject(toAdd)
+      if (this.nodeSelectorTerm){
+        if (!this.nodeSelectorTerm.matchExpressions){
+          set(this.nodeSelectorTerm, 'matchExpressions', [])
+        }
+        this.nodeSelectorTerm.matchExpressions.push(toAdd.match)
+        this.notifyPropertyChange('nodeSelectorTerm')
+      } else {
+        this.labelSelector.push(toAdd)
+        this.notifyPropertyChange('labelSelector')
+      }
+    },
+
+    removeMatchAction(match){
+      set(this, 'allMatches', this.allMatches.filter((m) => m.match._id !== match.match._id))
+      switch (match.type){
+      case MATCH_TYPES.MATCH_EXPRESSIONS:
+        this.removeMatch('nodeSelectorTermmatchExpressions', match.match)
+        this.notifyPropertyChange('nodeSelectorTerm')
+        break;
+      case MATCH_TYPES.MATCH_FIELDS:
+        this.removeMatch('nodeSelectorTerm.matchFields', match.match)
+        this.notifyPropertyChange('nodeSelectorTerm')
+        break;
+      case MATCH_TYPES.LABEL_SELECTOR:
+        this.removeMatch('labelSelector', match.match)
+        this.notifyPropertyChange('labelSelector')
+        break;
+      default:
+        break;
+      }
+    },
+
+    typeChanged(match){
+      if (match.type === MATCH_TYPES.MATCH_EXPRESSIONS){
+        this.removeMatch('nodeSelectorTerm.matchExpressions', match.match)
+        if (!this.nodeSelectorTerm.matchFields){
+          set(this.nodeSelectorTerm, 'matchFields', [])
+        }
+        this.nodeSelectorTerm.matchFields.push(match.match)
+      } else {
+        this.removeMatch('nodeSelectorTerm.matchFields', match.match)
+        if (!this.nodeSelectorTerm.matchExpressions){
+          set(this.nodeSelectorTerm, 'matchExpressions', [])
+        }
+        this.nodeSelectorTerm.matchExpressions.push(match.match)
+      }
+      debugger
+      this.notifyPropertyChange('nodeSelectorTerm')
+    },
+  },
+
+  editing:   computed('mode', function() {
+    const mode = get(this, 'mode')
+
+    return mode === 'new' || mode === 'edit'
+  }),
+
+  operatorOpts: computed('nodeSelectorTerm', function(){
+    const either = [
+      {
+        value:    'In',
+        label: 'clusterNew.agentConfig.overrideAffinity.podAffinity.matchExpressions.operatorOptions.in'
+      },
+      {
+        value:    'NotIn',
+        label: 'clusterNew.agentConfig.overrideAffinity.podAffinity.matchExpressions.operatorOptions.notIn'
+      },
+      {
+        value:    'Exists',
+        label: 'clusterNew.agentConfig.overrideAffinity.podAffinity.matchExpressions.operatorOptions.exists'
+      },
+      {
+        value:    'DoesNotExist',
+        label: 'clusterNew.agentConfig.overrideAffinity.podAffinity.matchExpressions.operatorOptions.doesNotExist'
+      }
+    ];
+    const nodeOnly = [
+      {
+        value:    'Gt',
+        label: 'clusterNew.agentConfig.overrideAffinity.podAffinity.matchExpressions.operatorOptions.gt'
+      },
+      {
+        value:    'Lt',
+        label: 'clusterNew.agentConfig.overrideAffinity.podAffinity.matchExpressions.operatorOptions.lt'
+      }
+    ]
+
+    return get(this, 'nodeSelectorTerm') ? [...either, ...nodeOnly] : either
+  }),
+
+
+  removeMatch(path, match){
+    const target = get(this, path) || []
+    const neu = target.filter((m) => m._id !== match._id);
+
+    set(this, path, neu)
+  },
+
+})

--- a/lib/shared/addon/components/form-match-expressions-k8s/component.js
+++ b/lib/shared/addon/components/form-match-expressions-k8s/component.js
@@ -1,35 +1,10 @@
-// matchexpressions that matches k8s spec rather than norman spec
 import Component from '@ember/component';
 import layout from './template';
 import {
   computed,
   get,
   set,
-  observer
 } from '@ember/object';
-/**
- * FOR NODE:
- * nodeSelectorTerm: {
- *    matchexpressions:
- *      - {
- *          key: string,
- *          operator: string, one of: [In, NotIn, Exists, DoesNotExist Gt, Lt]
- *          value: string array ... If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer.
- *      }
- *   matchFields: same as matchExpressions
- * }
-
-* FOR POD:
-labelSelector: {
-*      matchExpressions:
-*        - {
-*            key: string,
-*            operator string one of: In, NotIn, Exists and DoesNotExist
-*            value: string array ... If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty.
-*          }
-}
-
- */
 
 const MATCH_TYPES = {
   MATCH_EXPRESSIONS: 'matchExpressions',

--- a/lib/shared/addon/components/form-match-expressions-k8s/component.js
+++ b/lib/shared/addon/components/form-match-expressions-k8s/component.js
@@ -1,0 +1,5 @@
+// matchexpressions that matches k8s spec rather than norman spec
+import Component from '@ember/component';
+import layout from './template';
+
+export default Component.extend({ layout })

--- a/lib/shared/addon/components/form-match-expressions-k8s/component.js
+++ b/lib/shared/addon/components/form-match-expressions-k8s/component.js
@@ -7,7 +7,6 @@ import {
   set,
   observer
 } from '@ember/object';
-import { randomStr } from '../../utils/util';
 /**
  * FOR NODE:
  * nodeSelectorTerm: {
@@ -43,7 +42,8 @@ export default Component.extend({
   mode:             'new',
   // TODO nb have parent component delete keys if empty
   // TODO nb strip ID from match in parent component
-  nodeSelectorTerm: null,
+  matchExpressions: null,
+  matchFields:      null,
   labelSelector:    null,
   allMatches:       [],
   MATCH_TYPES,
@@ -63,34 +63,28 @@ export default Component.extend({
   // each item has a dropdown to change from expression to field - we want to preserve the order of the list shown to the user when this is changed
   init(){
     this._super(...arguments);
-    if (this.nodeSelectorTerm){
+    if (this.labelSelector) {
+      const allMatches = (this.labelSelector?.matchExpressions || []).map((match) => {
+        return {
+          type: MATCH_TYPES.LABEL_SELECTOR,
+          match
+        }
+      })
+
+      set(this, 'allMatches', allMatches)
+    } else {
       const allMatches = []
       const addMatches = function(matches = [], type){
         matches.forEach((match) => {
           allMatches.push({
             type,
-            match: {
-              _id: randomStr(),
-              ...match
-            }
+            match
           })
         })
       }
 
-      addMatches(this.nodeSelectorTerm?.matchExpressions, MATCH_TYPES.MATCH_EXPRESSIONS)
-      addMatches(this.nodeSelectorTerm?.matchFields, MATCH_TYPES.MATCH_FIELDS)
-      set(this, 'allMatches', allMatches)
-    } else {
-      const allMatches = (this.labelSelector?.matchExpressions || []).map((match) => {
-        return {
-          type:  MATCH_TYPES.LABEL_SELECTOR,
-          match: {
-            _id: randomStr(),
-            ...match
-          }
-        }
-      })
-
+      addMatches(this.matchExpressions, MATCH_TYPES.MATCH_EXPRESSIONS)
+      addMatches(this.matchFields, MATCH_TYPES.MATCH_FIELDS)
       set(this, 'allMatches', allMatches)
     }
   },
@@ -98,40 +92,33 @@ export default Component.extend({
   actions: {
     addMatch(){
       const toAdd = {
-        type:  this.nodeSelectorTerm ? MATCH_TYPES.MATCH_EXPRESSIONS : MATCH_TYPES.LABEL_SELECTOR,
-        match: {
-          _id:      randomStr(),
-          operator: this.operatorOpts[0].value
-        },
+        type:  this.labelSelector ?  MATCH_TYPES.LABEL_SELECTOR : MATCH_TYPES.MATCH_EXPRESSIONS,
+        match: { operator: this.operatorOpts[0].value },
       }
 
       get(this, 'allMatches').addObject(toAdd)
-      if (this.nodeSelectorTerm){
-        if (!this.nodeSelectorTerm.matchExpressions){
-          set(this.nodeSelectorTerm, 'matchExpressions', [])
-        }
-        this.nodeSelectorTerm.matchExpressions.push(toAdd.match)
-        this.notifyPropertyChange('nodeSelectorTerm')
-      } else {
+      if (this.labelSelector) {
         this.labelSelector.push(toAdd)
         this.notifyPropertyChange('labelSelector')
+      } else {
+        this.matchExpressions.push(toAdd.match)
+        this.notifyPropertyChange('matchExpressions')
       }
     },
 
     removeMatchAction(match){
-      set(this, 'allMatches', this.allMatches.filter((m) => m.match._id !== match.match._id))
+      set(this, 'allMatches', this.allMatches.filter((m) => m !== match))
       switch (match.type){
       case MATCH_TYPES.MATCH_EXPRESSIONS:
-        this.removeMatch('nodeSelectorTermmatchExpressions', match.match)
-        this.notifyPropertyChange('nodeSelectorTerm')
+        this.removeMatch('matchExpressions', match.match)
+
         break;
       case MATCH_TYPES.MATCH_FIELDS:
-        this.removeMatch('nodeSelectorTerm.matchFields', match.match)
-        this.notifyPropertyChange('nodeSelectorTerm')
+        this.removeMatch('matchFields', match.match)
+
         break;
       case MATCH_TYPES.LABEL_SELECTOR:
         this.removeMatch('labelSelector', match.match)
-        this.notifyPropertyChange('labelSelector')
         break;
       default:
         break;
@@ -140,21 +127,23 @@ export default Component.extend({
 
     typeChanged(match){
       if (match.type === MATCH_TYPES.MATCH_EXPRESSIONS){
-        this.removeMatch('nodeSelectorTerm.matchExpressions', match.match)
-        if (!this.nodeSelectorTerm.matchFields){
-          set(this.nodeSelectorTerm, 'matchFields', [])
-        }
-        this.nodeSelectorTerm.matchFields.push(match.match)
+        this.removeMatch('matchExpressions', match.match)
+
+        this.matchFields.push(match.match)
+        this.notifyPropertyChange('matchFields')
       } else {
-        this.removeMatch('nodeSelectorTerm.matchFields', match.match)
-        if (!this.nodeSelectorTerm.matchExpressions){
-          set(this.nodeSelectorTerm, 'matchExpressions', [])
-        }
-        this.nodeSelectorTerm.matchExpressions.push(match.match)
+        this.removeMatch('matchFields', match.match)
+
+        this.matchExpressions.push(match.match)
+        this.notifyPropertyChange('matchExpressions')
       }
-      debugger
-      this.notifyPropertyChange('nodeSelectorTerm')
     },
+
+    operatorChanged(match, selected){
+      if (selected.value === 'Exists' || selected.value === 'DoesNotExist'){
+        match.match.value = []
+      }
+    }
   },
 
   editing:   computed('mode', function() {
@@ -163,7 +152,7 @@ export default Component.extend({
     return mode === 'new' || mode === 'edit'
   }),
 
-  operatorOpts: computed('nodeSelectorTerm', function(){
+  operatorOpts: computed('labelSelector', function(){
     const either = [
       {
         value:    'In',
@@ -193,13 +182,14 @@ export default Component.extend({
       }
     ]
 
-    return get(this, 'nodeSelectorTerm') ? [...either, ...nodeOnly] : either
+    return get(this, 'labelSelector') ?  either : [...either, ...nodeOnly]
   }),
 
 
   removeMatch(path, match){
     const target = get(this, path) || []
-    const neu = target.filter((m) => m._id !== match._id);
+
+    const neu = target.filter((m) => m !== match)
 
     set(this, path, neu)
   },

--- a/lib/shared/addon/components/form-match-expressions-k8s/component.js
+++ b/lib/shared/addon/components/form-match-expressions-k8s/component.js
@@ -39,7 +39,7 @@ const MATCH_TYPES = {
 
 export default Component.extend({
   layout,
-  mode:             'new',
+  editing:          false,
   matchExpressions: null,
   matchFields:      null,
 
@@ -145,12 +145,6 @@ export default Component.extend({
       }
     }
   },
-
-  editing:   computed('mode', function() {
-    const mode = get(this, 'mode')
-
-    return mode === 'new' || mode === 'edit'
-  }),
 
   operatorOpts: computed('labelSelector', function(){
     const either = [

--- a/lib/shared/addon/components/form-match-expressions-k8s/component.js
+++ b/lib/shared/addon/components/form-match-expressions-k8s/component.js
@@ -40,10 +40,10 @@ const MATCH_TYPES = {
 export default Component.extend({
   layout,
   mode:             'new',
-  // TODO nb have parent component delete keys if empty
-  // TODO nb strip ID from match in parent component
   matchExpressions: null,
   matchFields:      null,
+
+  // labelSelector.matchExpressions
   labelSelector:    null,
   allMatches:       [],
   MATCH_TYPES,
@@ -98,7 +98,7 @@ export default Component.extend({
 
       get(this, 'allMatches').addObject(toAdd)
       if (this.labelSelector) {
-        this.labelSelector.push(toAdd)
+        this.labelSelector.push(toAdd.match)
         this.notifyPropertyChange('labelSelector')
       } else {
         this.matchExpressions.push(toAdd.match)

--- a/lib/shared/addon/components/form-match-expressions-k8s/template.hbs
+++ b/lib/shared/addon/components/form-match-expressions-k8s/template.hbs
@@ -91,9 +91,9 @@
               inputClass='form-control input-sm'
             }}
             {{else if (or (eq match.match.operator "Gt") (eq match.match.operator "Lt"))}}
-              {{input
+              {{input-array-as-string
                 type="number"
-                class="form-control input-sm"
+                inputClass="form-control input-sm"
                 value=match.match.value
               }}
             {{else}}

--- a/lib/shared/addon/components/form-match-expressions-k8s/template.hbs
+++ b/lib/shared/addon/components/form-match-expressions-k8s/template.hbs
@@ -39,6 +39,7 @@
               @optionLabelPath="label"
               @localizedLabel={{true}}
               @action={{action "typeChanged" match}}
+              @disabled={{not editing}}
           />
           {{/input-or-display}}
           </td>

--- a/lib/shared/addon/components/form-match-expressions-k8s/template.hbs
+++ b/lib/shared/addon/components/form-match-expressions-k8s/template.hbs
@@ -1,0 +1,125 @@
+<table class="table fixed no-lines mb-20">
+  <thead>
+    <tr>
+      {{#if nodeSelectorTerm}}
+        <th class="acc-label">
+          {{t "clusterNew.agentConfig.overrideAffinity.nodeAffinity.nodeSelectorTerm.type"}}
+        </th>
+        <th width="40"></th>
+      {{/if}}
+      <th class="acc-label">
+        {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.matchExpressions.key"}}
+      </th>
+      <th width="40"></th>
+      <th class="acc-label">
+        {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.matchExpressions.operator"}}
+      </th>
+      <th width="40"></th>
+      <th class="acc-label">
+        {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.matchExpressions.value"}}
+      </th>
+      <th width="10">&nbsp;</th>
+      <th width="40"></th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each allMatches as |match|}}
+      <tr>
+        {{#if nodeSelectorTerm}}
+          <td>
+          {{#input-or-display
+              editable=editing
+              value=match.type
+          }}
+          <NewSelect
+              class="form-control input-sm"
+              @value={{match.type}}
+              @content={{typeOpts}}
+              @optionValuePath="value"
+              @optionLabelPath="label"
+              @localizedLabel={{true}}
+              @action={{action 'typeChanged' match}}
+          />
+          {{/input-or-display}}
+          </td>
+          <td>
+            &nbsp;
+          </td>
+        {{/if}}
+        <td>
+          {{#input-or-display
+              editable=editing
+              value=match.match.key
+          }}
+            {{input
+              type="text"
+              class="form-control input-sm"
+              value=match.match.key
+            }}
+          {{/input-or-display}}
+        </td>
+        <td>
+          &nbsp;
+        </td>
+        <td>
+          {{#input-or-display
+            editable=editing
+            value=match.match.operator
+          }}
+            {{new-select
+              class="form-control input-sm"
+              value=match.match.operator
+              content=operatorOpts
+              optionValuePath='value'
+              optionLabelPath='label'
+              localizedLabel=true
+            }}
+          {{/input-or-display}}
+        </td>
+        <td>
+          &nbsp;
+        </td>
+        <td>
+          {{#input-or-display
+              editable=editing
+              value=match.match.value
+          }}
+          {{#if (or (eq match.match.operator "In") (eq match.match.operator "NotIn"))}}
+            {{input
+              type="text"
+              class="form-control input-sm"
+              value=match.match.value
+            }}
+            {{else if (or (eq match.match.operator "Gt") (eq match.match.operator "Lt"))}}
+              {{input
+                type="number"
+                class="form-control input-sm"
+                value=match.match.value
+              }}
+            {{else}}
+            {{t "generic.na"}}
+            {{/if}}
+          {{/input-or-display}}
+        </td>
+        <td>
+          &nbsp;
+        </td>
+        {{#if editing}}
+          <div class="input-group-btn">
+            <button class="btn bg-primary btn-sm" type="button" {{action "removeMatchAction" match}}>
+              <i class="icon icon-minus"/>
+            </button>
+          </div>
+        {{/if }}
+      </tr>
+    {{/each}}
+  </tbody>
+</table>
+{{#if editing}}
+  <button class="btn bg-link icon-btn" type="button" {{action "addMatch"}}>
+    <i class="icon icon-plus text-small"/>
+    <span>
+      {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.matchExpressions.add"}}
+    </span>
+  </button>
+{{/if}}

--- a/lib/shared/addon/components/form-match-expressions-k8s/template.hbs
+++ b/lib/shared/addon/components/form-match-expressions-k8s/template.hbs
@@ -1,7 +1,7 @@
 <table class="table fixed no-lines mb-20">
   <thead>
     <tr>
-      {{#if nodeSelectorTerm}}
+      {{#if (not labelSelector)}}
         <th class="acc-label">
           {{t "clusterNew.agentConfig.overrideAffinity.nodeAffinity.nodeSelectorTerm.type"}}
         </th>
@@ -25,7 +25,7 @@
   <tbody>
     {{#each allMatches as |match|}}
       <tr>
-        {{#if nodeSelectorTerm}}
+        {{#if (not labelSelector)}}
           <td>
           {{#input-or-display
               editable=editing
@@ -38,7 +38,7 @@
               @optionValuePath="value"
               @optionLabelPath="label"
               @localizedLabel={{true}}
-              @action={{action 'typeChanged' match}}
+              @action={{action "typeChanged" match}}
           />
           {{/input-or-display}}
           </td>
@@ -66,14 +66,15 @@
             editable=editing
             value=match.match.operator
           }}
-            {{new-select
+            <NewSelect
               class="form-control input-sm"
-              value=match.match.operator
-              content=operatorOpts
-              optionValuePath='value'
-              optionLabelPath='label'
-              localizedLabel=true
-            }}
+              @value={{match.match.operator}}
+              @content={{operatorOpts}}
+              optionValuePath="value"
+              optionLabelPath="label"
+              @localizedLabel={{true}}
+              @action={{action "operatorChanged" match}}
+            />
           {{/input-or-display}}
         </td>
         <td>
@@ -85,10 +86,9 @@
               value=match.match.value
           }}
           {{#if (or (eq match.match.operator "In") (eq match.match.operator "NotIn"))}}
-            {{input
-              type="text"
-              class="form-control input-sm"
+            {{input-array-as-string
               value=match.match.value
+              inputClass='form-control input-sm'
             }}
             {{else if (or (eq match.match.operator "Gt") (eq match.match.operator "Lt"))}}
               {{input

--- a/lib/shared/addon/components/form-node-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-node-affinity-k8s/component.js
@@ -55,7 +55,6 @@ export default Component.extend({
  *
  */
   init(){
-    // TODO nb why is required... an array navigating back from view as yaml?
     this._super(...arguments);
     const allTerms = []
     const addTerms = function(terms = [], priority){
@@ -103,20 +102,22 @@ export default Component.extend({
 
 
     typeChanged(term, old){
-      // TODO nb add weight
       if (old === TERM_PRIORITY.REQUIRED){
         const removeFrom = get(this.nodeAffinity, 'requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms')
         const addTo = get(this.nodeAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
 
         set(this.nodeAffinity, 'requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms', this.removeFromSpec(term.term, removeFrom))
+        set(term, 'term', this.addWeight(term.term))
 
         addTo.pushObject(term.term)
       } else {
-        // TODO nb remove weight
         const removeFrom = get(this.nodeAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
         const addTo = get(this.nodeAffinity, 'requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms')
 
         set(this.nodeAffinity, 'preferredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
+        set(term, 'term', this.removeWeight(term.term))
+
+
         addTo.pushObject(term.term)
       }
       this.notifyPropertyChange('nodeAffinity')
@@ -133,5 +134,25 @@ export default Component.extend({
   removeFromSpec: (term, array) => {
     return array.filter((each) => each._id !== term._id)
   },
+
+  addWeight: (term) => {
+    const out = {
+      preference: term,
+      _id:             term._id
+    }
+
+    delete out.preference._id
+
+    return out
+  },
+
+  removeWeight: (term) => {
+    const out = {
+      _id: term._id,
+      ...term.preference
+    }
+
+    return out
+  }
 
 })

--- a/lib/shared/addon/components/form-node-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-node-affinity-k8s/component.js
@@ -38,8 +38,8 @@ export default Component.extend({
 
   TERM_PRIORITY,
   nodeAffinity:     null,
-  mode:            'new',
-  allTerms:        [],
+  editing:          false,
+  allTerms:         [],
 
   /**
  * this component renders one list for required & preferred arrays of node selector terms
@@ -85,7 +85,6 @@ export default Component.extend({
     },
 
     removeTerm(term){
-      // TODO nb does removeObject work here? Will it work in typeChanged?
       get(this, 'allTerms').removeObject(term)
 
       if (term.priority === TERM_PRIORITY.REQUIRED){
@@ -124,12 +123,6 @@ export default Component.extend({
     },
 
   },
-
-  editing: computed('mode', function() {
-    const mode = get(this, 'mode')
-
-    return mode === 'new' || mode === 'edit'
-  }),
 
   removeFromSpec: (term, array) => {
     return array.filter((each) => each._id !== term._id)

--- a/lib/shared/addon/components/form-node-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-node-affinity-k8s/component.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+import layout from './template';
+
+export default Component.extend({ layout })

--- a/lib/shared/addon/components/form-node-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-node-affinity-k8s/component.js
@@ -17,7 +17,7 @@ export default Component.extend({
 
   /**
  * this component renders one list for required & preferred arrays of node selector terms
- * each nodeaffinitytermk8s component can change between required and perferred
+ * each nodeaffinitytermk8s component can change between required and preferred
  * the overall list shouldn't re-order when a term is moved to a different underlying array so rather than computing this off the arrays in spec
  * this list will track which array a term should belong to and the arrays in spec will be computed off this
  *
@@ -114,12 +114,10 @@ export default Component.extend({
   },
 
   removeWeight: (term) => {
-    const out = {
+    return {
       _id: term._id,
       ...term.preference
     }
-
-    return out
   }
 
 })

--- a/lib/shared/addon/components/form-node-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-node-affinity-k8s/component.js
@@ -1,4 +1,137 @@
 import Component from '@ember/component';
 import layout from './template';
+import {
+  computed,
+  get,
+  set,
+  observer
+} from '@ember/object';
+import { randomStr } from '../../utils/util';
+import { TERM_PRIORITY } from '../form-pod-affinity-k8s/component';
+/**
+ *  nodeAffinity: {
+ *    preferredDuringSchedulingIgnoredDuringExecution:
+ *      - {
+ *          preference: nodeselectorterm,
+ *          weight: int
+ *        }
+ *    requiredDuringSchedulingIgnoredDuringExecution:
+ *       nodeSelectorTerms:
+ *          - nodeselectorterm
+ *   }
+ *
+ *
+ *   nodeselectorterm: {
+ *    matchexpressions:
+ *      - {
+ *          key: string,
+ *          operator: string, one of: [In, NotIn, Exists, DoesNotExist Gt, Lt]
+ *          value: string array ... If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer.
+ *      }
+ *    matchfields: same as match expressions but matches fields instead of labels
+ * }
+ */
 
-export default Component.extend({ layout })
+
+export default Component.extend({
+  layout,
+
+  TERM_PRIORITY,
+  nodeAffinity:     null,
+  mode:            'new',
+  allTerms:        [],
+
+  /**
+ * this component renders one list for required & preferred arrays of node selector terms
+ * each nodeaffinitytermk8s component can change between required and perferred
+ * the overall list shouldn't re-order when a term is moved to a different underlying array so rather than computing this off the arrays in spec
+ * this list will track which array a term should belong to and the arrays in spec will be computed off this
+ *
+ * list of all terms:
+ * - {
+ *    priority: preferred/required
+ *    term:preferred or required term
+ *   }
+ *
+ */
+  init(){
+    // TODO nb why is required... an array navigating back from view as yaml?
+    this._super(...arguments);
+    const allTerms = []
+    const addTerms = function(terms = [], priority){
+      terms.forEach((term) => {
+        allTerms.push({
+          priority,
+          term
+        })
+      })
+    }
+
+    addTerms(this.nodeAffinity?.preferredDuringSchedulingIgnoredDuringExecution, TERM_PRIORITY.PREFERRED)
+    addTerms(this.nodeAffinity?.requiredDuringSchedulingIgnoredDuringExecution?.nodeSelectorTerms, TERM_PRIORITY.REQUIRED)
+    set(this, 'allTerms', allTerms)
+  },
+
+  actions: {
+    addTerm(){
+      const neu = {
+        priority: TERM_PRIORITY.REQUIRED,
+        term:     { _id: randomStr() }
+      }
+
+      this.allTerms.push(neu)
+      get(this.nodeAffinity, 'requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms').addObject(neu.term)
+      this.notifyPropertyChange('allTerms')
+      this.notifyPropertyChange('nodeAffinity')
+    },
+
+    removeTerm(term){
+      // TODO nb does removeObject work here? Will it work in typeChanged?
+      get(this, 'allTerms').removeObject(term)
+
+      if (term.priority === TERM_PRIORITY.REQUIRED){
+        const removeFrom = get(this.nodeAffinity, 'requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms')
+
+        removeFrom.removeObject(term.term)
+      } else {
+        const removeFrom = get(this.nodeAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
+
+        removeFrom.removeObject(term.term)
+      }
+      this.notifyPropertyChange('nodeAffinity')
+    },
+
+
+    typeChanged(term, old){
+      // TODO nb add weight
+      if (old === TERM_PRIORITY.REQUIRED){
+        const removeFrom = get(this.nodeAffinity, 'requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms')
+        const addTo = get(this.nodeAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
+
+        set(this.nodeAffinity, 'requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms', this.removeFromSpec(term.term, removeFrom))
+
+        addTo.pushObject(term.term)
+      } else {
+        // TODO nb remove weight
+        const removeFrom = get(this.nodeAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
+        const addTo = get(this.nodeAffinity, 'requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms')
+
+        set(this.nodeAffinity, 'preferredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
+        addTo.pushObject(term.term)
+      }
+      this.notifyPropertyChange('nodeAffinity')
+    },
+
+  },
+
+  editing: computed('mode', function() {
+    const mode = get(this, 'mode')
+
+    return mode === 'new' || mode === 'edit'
+  }),
+
+  removeFromSpec: (term, array) => {
+    return array.filter((each) => each._id !== term._id)
+  },
+
+})

--- a/lib/shared/addon/components/form-node-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-node-affinity-k8s/component.js
@@ -1,37 +1,11 @@
 import Component from '@ember/component';
 import layout from './template';
 import {
-  computed,
   get,
   set,
-  observer
 } from '@ember/object';
 import { randomStr } from '../../utils/util';
 import { TERM_PRIORITY } from '../form-pod-affinity-k8s/component';
-/**
- *  nodeAffinity: {
- *    preferredDuringSchedulingIgnoredDuringExecution:
- *      - {
- *          preference: nodeselectorterm,
- *          weight: int
- *        }
- *    requiredDuringSchedulingIgnoredDuringExecution:
- *       nodeSelectorTerms:
- *          - nodeselectorterm
- *   }
- *
- *
- *   nodeselectorterm: {
- *    matchexpressions:
- *      - {
- *          key: string,
- *          operator: string, one of: [In, NotIn, Exists, DoesNotExist Gt, Lt]
- *          value: string array ... If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer.
- *      }
- *    matchfields: same as match expressions but matches fields instead of labels
- * }
- */
-
 
 export default Component.extend({
   layout,

--- a/lib/shared/addon/components/form-node-affinity-k8s/template.hbs
+++ b/lib/shared/addon/components/form-node-affinity-k8s/template.hbs
@@ -1,3 +1,29 @@
-<div>
-  node affinity component
+<div class="box">
+  <div>
+    <label class="acc-label">
+        {{t "clusterNew.agentConfig.overrideAffinity.nodeAffinity.title"}}
+    </label>
+  </div>
+  <div class="row">
+    <div class="col span-12">
+      <div>
+        {{#each allTerms as |term|}}
+          <FormNodeSelectorTermK8s
+            @value={{term}}
+            @mode={{mode}}
+            @remove={{action "removeTerm" term}}
+            @typeChanged={{action "typeChanged" term}}
+          />
+        {{/each}}
+      </div>
+      {{#if editing}}
+        <button class="btn bg-link icon-btn" type="button" {{action "addTerm"}}>
+          <i class="icon icon-plus text-small"/>
+          <span>
+            {{t "clusterNew.agentConfig.overrideAffinity.nodeAffinity.addTerm"}}
+          </span>
+        </button>
+      {{/if}}
+    </div>
+  </div>
 </div>

--- a/lib/shared/addon/components/form-node-affinity-k8s/template.hbs
+++ b/lib/shared/addon/components/form-node-affinity-k8s/template.hbs
@@ -10,7 +10,7 @@
         {{#each allTerms as |term|}}
           <FormNodeSelectorTermK8s
             @value={{term}}
-            @mode={{mode}}
+            @editing={{editing}}
             @remove={{action "removeTerm" term}}
             @typeChanged={{action "typeChanged" term}}
           />

--- a/lib/shared/addon/components/form-node-affinity-k8s/template.hbs
+++ b/lib/shared/addon/components/form-node-affinity-k8s/template.hbs
@@ -1,0 +1,3 @@
+<div>
+  node affinity component
+</div>

--- a/lib/shared/addon/components/form-node-selector-term-k8s/component.js
+++ b/lib/shared/addon/components/form-node-selector-term-k8s/component.js
@@ -5,7 +5,6 @@ import {
   computed,
   get,
   set,
-  observer
 } from '@ember/object';
 import { TERM_PRIORITY } from '../form-pod-affinity-k8s/component';
 
@@ -25,8 +24,8 @@ import { TERM_PRIORITY } from '../form-pod-affinity-k8s/component';
 export default Component.extend({
   layout,
 
-  value: null,
-  mode:  'new',
+  value:   null,
+  editing: false,
 
   priorityOptions,
   TERM_PRIORITY,
@@ -40,11 +39,6 @@ export default Component.extend({
     }
   },
 
-  editing:   computed('mode', function() {
-    const mode = get(this, 'mode')
-
-    return mode === 'new' || mode === 'edit'
-  }),
 
   weight: computed('value.term', 'value.priority', {
     get(){
@@ -57,7 +51,6 @@ export default Component.extend({
 
           set(this.value.term, 'weight', toInt)
         } catch (e){
-          // TODO nb handle bad weight value better
           console.error(e)
         }
       } else if (this.value?.term?.weight){

--- a/lib/shared/addon/components/form-node-selector-term-k8s/component.js
+++ b/lib/shared/addon/components/form-node-selector-term-k8s/component.js
@@ -8,19 +8,6 @@ import {
 } from '@ember/object';
 import { TERM_PRIORITY } from '../form-pod-affinity-k8s/component';
 
-/**   nodeselectorterm: {
-  *    matchexpressions:
-  *      - {
-  *          key: string,
-  *          operator: string, one of: [In, NotIn, Exists, DoesNotExist Gt, Lt]
-  *          value: string array ... If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer.
-  *      }
-  *    matchfields: same as match expressions but matches fields instead of labels
-  * }
-  *
-  */
-
-
 export default Component.extend({
   layout,
 

--- a/lib/shared/addon/components/form-node-selector-term-k8s/component.js
+++ b/lib/shared/addon/components/form-node-selector-term-k8s/component.js
@@ -1,6 +1,26 @@
 import Component from '@ember/component';
 import layout from './template';
 import { priorityOptions } from '../form-pod-affinity-term-k8s/component';
+import {
+  computed,
+  get,
+  set,
+  observer
+} from '@ember/object';
+import { TERM_PRIORITY } from '../form-pod-affinity-k8s/component';
+
+/**   nodeselectorterm: {
+  *    matchexpressions:
+  *      - {
+  *          key: string,
+  *          operator: string, one of: [In, NotIn, Exists, DoesNotExist Gt, Lt]
+  *          value: string array ... If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer.
+  *      }
+  *    matchfields: same as match expressions but matches fields instead of labels
+  * }
+  *
+  */
+
 
 export default Component.extend({
   layout,
@@ -9,6 +29,7 @@ export default Component.extend({
   mode:  'new',
 
   priorityOptions,
+  TERM_PRIORITY,
 
   actions:   {
     removeTerm(){
@@ -18,4 +39,107 @@ export default Component.extend({
     }
   },
 
+  editing:   computed('mode', function() {
+    const mode = get(this, 'mode')
+
+    return mode === 'new' || mode === 'edit'
+  }),
+
+  weight: computed('value.term', 'value.priority', {
+    get(){
+      return get(this.value, 'term.weight')
+    },
+    set(key, val){
+      if (val || val === '0') {
+        try {
+          const toInt = parseInt(val, 10)
+
+          set(this.value.term, 'weight', toInt)
+        } catch (e){
+          // TODO nb handle bad weight value better
+          console.error(e)
+        }
+      } else if (this.value?.term?.weight){
+        delete this.value.term.weight
+        this.notifyPropertyChange('value')
+      }
+
+      return val
+    }
+  }),
+
+
+  priority: computed('priorityOptions', 'value.priority', {
+    get(){
+      return get(this.value, 'priority')
+    },
+    set(key, val){
+      const old = get(this.value, 'priority')
+
+      set(this.value, 'priority', val)
+      this.typeChanged(old)
+
+      return val
+    },
+  }),
+
+  nodeSelectorTerm: computed('value.priority', 'value.term.preference', {
+    get(){
+      if (this.value.priority === TERM_PRIORITY.PREFERRED){
+        return this.value?.term?.preference
+      }
+
+      return this.value.term
+    },
+    set(key, val){
+      // neu will be data actually populated in cluster spec
+      // only include matchExpressions and matchFields keys if they contain data
+      // strip _id field (added and used exclusively by UI)
+      const neu = {}
+
+      if (val.matchExpressions && val.matchExpressions.length){
+        neu.matchExpressions = val.matchExpressions.map((match) => {
+          const out = { ...match };
+
+          delete out._id
+
+          return out
+        })
+      }
+      if (val.matchFields && val.matchFields.length){
+        neu.matchFields = val.matchFields.map((match) => {
+          const out = { ...match };
+
+          delete out._id
+
+          return out
+        })
+      }
+
+      // the parent component is tracking 'value' in a combined array of affinity.preferred.. antiAffinity.preferred... affinity.required... etc
+      // need to alter the existing object because creating a new one wouldn't affect the term that is actually stored in agentConfig.overrideAffinity
+      let target;
+
+      debugger
+      if (this.value.priority === TERM_PRIORITY.PREFERRED){
+        target = this.value?.term?.preference || {}
+      } else {
+        target = this.value?.term || {}
+      }
+      if (!neu.matchExpressions && target.matchExpressions){
+        delete target.matchExpressions
+      } else {
+        set(target, 'matchExpressions', neu.matchExpressions)
+      }
+      if (!neu.matchFields && target.matchFields){
+        delete target.matchFields
+      } else {
+        set(target, 'matchFields', neu.matchFields)
+      }
+      this.notifyPropertyChange('value')
+
+      return val
+    }
+
+  })
 })

--- a/lib/shared/addon/components/form-node-selector-term-k8s/component.js
+++ b/lib/shared/addon/components/form-node-selector-term-k8s/component.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+import layout from './template';
+
+export default Component.extend({ layout })

--- a/lib/shared/addon/components/form-node-selector-term-k8s/component.js
+++ b/lib/shared/addon/components/form-node-selector-term-k8s/component.js
@@ -1,4 +1,21 @@
 import Component from '@ember/component';
 import layout from './template';
+import { priorityOptions } from '../form-pod-affinity-term-k8s/component';
 
-export default Component.extend({ layout })
+export default Component.extend({
+  layout,
+
+  value: null,
+  mode:  'new',
+
+  priorityOptions,
+
+  actions:   {
+    removeTerm(){
+      if (this.remove){
+        this.remove()
+      }
+    }
+  },
+
+})

--- a/lib/shared/addon/components/form-node-selector-term-k8s/component.js
+++ b/lib/shared/addon/components/form-node-selector-term-k8s/component.js
@@ -31,6 +31,7 @@ export default Component.extend({
   priorityOptions,
   TERM_PRIORITY,
 
+
   actions:   {
     removeTerm(){
       if (this.remove){
@@ -83,63 +84,46 @@ export default Component.extend({
     },
   }),
 
-  nodeSelectorTerm: computed('value.priority', 'value.term.preference', {
-    get(){
-      if (this.value.priority === TERM_PRIORITY.PREFERRED){
-        return this.value?.term?.preference
-      }
+  nodeSelectorTerm: computed('value.priority', 'value.term.preference', function() {
+    if (this.value.priority === TERM_PRIORITY.PREFERRED){
+      return this.value?.term?.preference
+    }
 
-      return this.value.term
+    return this.value.term
+  }),
+
+  matchExpressions: computed('nodeSelectorTerm.matchExpressions', {
+    get(){
+      return get(this, 'nodeSelectorTerm.matchExpressions') || []
     },
     set(key, val){
-      // neu will be data actually populated in cluster spec
-      // only include matchExpressions and matchFields keys if they contain data
-      // strip _id field (added and used exclusively by UI)
-      const neu = {}
+      if ((!val || !val.length) && this.nodeSelectorTerm.matchExpressions){
+        delete get(this, 'nodeSelectorTerm').matchExpressions
 
-      if (val.matchExpressions && val.matchExpressions.length){
-        neu.matchExpressions = val.matchExpressions.map((match) => {
-          const out = { ...match };
-
-          delete out._id
-
-          return out
-        })
+        this.notifyPropertyChange('nodeSelectorTerm')
+      } else if (val && val.length){
+        set(this.nodeSelectorTerm, 'matchExpressions', val)
       }
-      if (val.matchFields && val.matchFields.length){
-        neu.matchFields = val.matchFields.map((match) => {
-          const out = { ...match };
-
-          delete out._id
-
-          return out
-        })
-      }
-
-      // the parent component is tracking 'value' in a combined array of affinity.preferred.. antiAffinity.preferred... affinity.required... etc
-      // need to alter the existing object because creating a new one wouldn't affect the term that is actually stored in agentConfig.overrideAffinity
-      let target;
-
-      debugger
-      if (this.value.priority === TERM_PRIORITY.PREFERRED){
-        target = this.value?.term?.preference || {}
-      } else {
-        target = this.value?.term || {}
-      }
-      if (!neu.matchExpressions && target.matchExpressions){
-        delete target.matchExpressions
-      } else {
-        set(target, 'matchExpressions', neu.matchExpressions)
-      }
-      if (!neu.matchFields && target.matchFields){
-        delete target.matchFields
-      } else {
-        set(target, 'matchFields', neu.matchFields)
-      }
-      this.notifyPropertyChange('value')
 
       return val
     }
+  }),
 
-  })
+  matchFields: computed('nodeSelectorTerm.matchFields', {
+    get(){
+      return get(this, 'nodeSelectorTerm.matchFields') || []
+    },
+    set(key, val){
+      if ((!val || !val.length) && this.nodeSelectorTerm.matchFields){
+        delete get(this, 'nodeSelectorTerm').matchFields
+
+        this.notifyPropertyChange('nodeSelectorTerm')
+      } else if (val && val.length) {
+        set(this.nodeSelectorTerm, 'matchFields', val)
+      }
+
+      return val
+    }
+  }),
+
 })

--- a/lib/shared/addon/components/form-node-selector-term-k8s/template.hbs
+++ b/lib/shared/addon/components/form-node-selector-term-k8s/template.hbs
@@ -8,25 +8,27 @@
   {{/if }}
   <div class="row mt-10">
     <div class="col span-6">
-      {{!-- <label class="acc-label">
-        {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.priority"}}
-      </label> --}}
-      <NewSelect 
-        @class="form-control"
-        @value={{priority}}
-        @optionLabelPath="label"
-        @optionValuePath="value"
-        @localizedLabel={{true}}
-        @content={{priorityOptions}}
-      />
+      {{#input-or-display
+        editable=editing
+        value=priority
+      }}
+        <NewSelect 
+          @class="form-control"
+          @value={{priority}}
+          @optionLabelPath="label"
+          @optionValuePath="value"
+          @localizedLabel={{true}}
+          @content={{priorityOptions}}
+          @disabled={{not editing}}
+        />
+      {{/input-or-display}}
     </div>
   </div>
   <div class="row">
     <FormMatchExpressionsK8s
-      {{!-- @nodeSelectorTerm={{nodeSelectorTerm}} --}}
       @matchExpressions={{matchExpressions}}
       @matchFields={{matchFields}}
-      @mode={{mode}}
+      @editing={{editing}}
     />
   </div>
   <div class="row">

--- a/lib/shared/addon/components/form-node-selector-term-k8s/template.hbs
+++ b/lib/shared/addon/components/form-node-selector-term-k8s/template.hbs
@@ -23,7 +23,9 @@
   </div>
   <div class="row">
     <FormMatchExpressionsK8s
-      @nodeSelectorTerm={{nodeSelectorTerm}}
+      {{!-- @nodeSelectorTerm={{nodeSelectorTerm}} --}}
+      @matchExpressions={{matchExpressions}}
+      @matchFields={{matchFields}}
       @mode={{mode}}
     />
   </div>

--- a/lib/shared/addon/components/form-node-selector-term-k8s/template.hbs
+++ b/lib/shared/addon/components/form-node-selector-term-k8s/template.hbs
@@ -22,12 +22,18 @@
     </div>
   </div>
   <div class="row">
+    <FormMatchExpressionsK8s
+      @nodeSelectorTerm={{nodeSelectorTerm}}
+      @mode={{mode}}
+    />
+  </div>
+  <div class="row">
     {{#if (eq value.priority TERM_PRIORITY.PREFERRED)}}
       <div class="col span-6">
         <label class="acc-label">{{t "clusterNew.agentConfig.overrideAffinity.podAffinity.weight.label"}}</label>
         {{#input-or-display
           editable=editing
-          value=toplogyKey
+          value=weight
         }}
         {{input
           type="text"

--- a/lib/shared/addon/components/form-node-selector-term-k8s/template.hbs
+++ b/lib/shared/addon/components/form-node-selector-term-k8s/template.hbs
@@ -1,0 +1,42 @@
+<div class="box mb-10 affinity-term">
+  {{#if editing}}
+    <div class="affinity-remove">
+      <button class="btn btn-sm " type="button" {{action "removeTerm"}}>
+          <i class="icon icon-x"/>
+      </button>
+    </div>
+  {{/if }}
+  <div class="row mt-10">
+    <div class="col span-6">
+      {{!-- <label class="acc-label">
+        {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.priority"}}
+      </label> --}}
+      <NewSelect 
+        @class="form-control"
+        @value={{priority}}
+        @optionLabelPath="label"
+        @optionValuePath="value"
+        @localizedLabel={{true}}
+        @content={{priorityOptions}}
+      />
+    </div>
+  </div>
+  <div class="row">
+    {{#if (eq value.priority TERM_PRIORITY.PREFERRED)}}
+      <div class="col span-6">
+        <label class="acc-label">{{t "clusterNew.agentConfig.overrideAffinity.podAffinity.weight.label"}}</label>
+        {{#input-or-display
+          editable=editing
+          value=toplogyKey
+        }}
+        {{input
+          type="text"
+          class="form-control input-sm"
+          value=weight
+          placeholder=(t "clusterNew.agentConfig.overrideAffinity.podAffinity.weight.placeholder")
+        }}
+        {{/input-or-display}}
+      </div>
+    {{/if}}
+  </div>
+</div>

--- a/lib/shared/addon/components/form-pod-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-k8s/component.js
@@ -6,6 +6,7 @@ import {
   set,
   observer
 } from '@ember/object';
+import { randomStr } from '../../utils/util';
 
 /**  podAffinity: {
   *    preferredDuringSchedulingIgnoredDuringExecution:
@@ -16,13 +17,57 @@ import {
   *    requiredDuringSchedulingIgnoredDuringExecution:
   *      - podaffinityterm
   *  }
+  * podAntiAffinity: same shape
   */
+
+export const TERM_PRIORITY = {
+  PREFERRED: 'preferred',
+  REQUIRED:  'required'
+}
+
 export default Component.extend({
   layout,
 
-  value: null,
-  mode:  'new',
-  anti:  false,
+  TERM_PRIORITY,
+  podAffinity:     null,
+  podAntiAffinity: null,
+  value:           null,
+  mode:            'new',
+  anti:            false,
+  allTerms:        [],
+  /**
+ * this component renders one list for required & preferred arrays of terms in affinity & antiAffinity
+ * each podaffinitytermk8s component can change between affinity and antiaffinity and between required and perferred
+ * the overall list shouldn't re-order when a term is moved to a different underlying array so rather than computing this off the arrays in spec
+ * this list will track which array a term should belong to and the arrays in spec will be computed off this
+ * list of all terms
+ * - {
+ *    priority: preferred/required
+ *    anti: bool
+ *    term:preferred or required term
+ *   }
+ *
+ */
+  init(){
+    this._super(...arguments);
+    const allTerms = []
+    const addTerms = function(terms = [], priority, isAnti){
+      terms.forEach((term) => {
+        allTerms.push({
+          priority,
+          anti: isAnti,
+          term
+        })
+      })
+    }
+
+    addTerms(this.podAffinity?.preferredDuringSchedulingIgnoredDuringExecution, TERM_PRIORITY.PREFERRED, false)
+    addTerms(this.podAffinity?.requiredDuringSchedulingIgnoredDuringExecution, TERM_PRIORITY.REQUIRED, false)
+    addTerms(this.podAntiAffinity?.preferredDuringSchedulingIgnoredDuringExecution, TERM_PRIORITY.PREFERRED, true)
+    addTerms(this.podAntiAffinity?.requiredDuringSchedulingIgnoredDuringExecution, TERM_PRIORITY.REQUIRED, true)
+
+    set(this, 'allTerms', allTerms)
+  },
 
   actions: {
     addRequired(){
@@ -32,8 +77,137 @@ export default Component.extend({
       this.preferredDuringSchedulingIgnoredDuringExecution.pushObject({})
     },
 
-    removeTerm(term, key){
-      get(this, key).removeObject(term)
+    addTerm(){
+      const neu = {
+        priority: TERM_PRIORITY.REQUIRED,
+        anti:     false,
+        term:     { _id: randomStr() }
+      }
+
+      this.allTerms.push(neu)
+      get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution').addObject(neu.term)
+      this.notifyPropertyChange('allTerms')
+      this.notifyPropertyChange('podAffinity')
+
+      // TODO nb update relevent spec array
+    },
+
+    removeTerm(term){
+      // TODO nb update relevent spec array
+      get(this, 'allTerms').removeObject(term)
+      if (term.anti){
+        if (term.priority === TERM_PRIORITY.REQUIRED){
+          const removeFrom = get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
+
+          removeFrom.removeObject(term.term)
+        } else {
+          const removeFrom = get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
+
+          removeFrom.removeObject(term.term)
+        }
+        this.notifyPropertyChange('podAntiAffinity')
+      } else {
+        if (term.priority === TERM_PRIORITY.REQUIRED){
+          const removeFrom = get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
+
+          removeFrom.removeObject(term.term)
+        } else {
+          const removeFrom = get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
+
+          removeFrom.removeObject(term.term)
+        }
+        this.notifyPropertyChange('podAffinity')
+      }
+    },
+
+    affinityChanged(){
+      // TODO nb this.update()
+      // needed?
+    },
+
+
+
+    typeChanged(term, old, neu){
+      if (term.anti){
+        if (old === TERM_PRIORITY.REQUIRED){
+          const removeFrom = get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
+          const addTo = get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
+
+          // removeFrom.removeObject(term.term)
+          set(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
+
+          addTo.pushObject(term.term)
+        } else {
+          const removeFrom = get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
+          const addTo = get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
+
+          // removeFrom.removeObject(term.term)
+          set(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
+
+          addTo.pushObject(term.term)
+        }
+        this.notifyPropertyChange('podAntiAffinity')
+      } else {
+        if (old === TERM_PRIORITY.REQUIRED){
+          const removeFrom = get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
+          const addTo = get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
+
+          // removeFrom.removeObject(term.term)
+          set(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
+
+          addTo.pushObject(term.term)
+        } else {
+          const removeFrom = get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
+          const addTo = get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
+
+          // removeFrom.removeObject(term.term)
+          set(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
+          addTo.pushObject(term.term)
+        }
+        this.notifyPropertyChange('podAffinity')
+      }
+    },
+
+    antiChanged(term, old, neu){
+      if (old){
+        if (term.priority === TERM_PRIORITY.REQUIRED){
+          const removeFrom = get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
+          const addTo = get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
+
+          // removeFrom.removeObject(term.term)
+          set(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
+
+          addTo.pushObject(term.term)
+        } else {
+          const removeFrom = get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
+          const addTo = get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
+
+          // removeFrom.removeObject(term.term)
+          set(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
+
+          addTo.pushObject(term.term)
+        }
+      } else {
+        if (term.priority === TERM_PRIORITY.REQUIRED){
+          const removeFrom = get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
+          const addTo = get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
+
+          // removeFrom.removeObject(term.term)
+          set(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
+
+          addTo.pushObject(term.term)
+        } else {
+          const removeFrom = get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
+          const addTo = get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
+
+          // removeFrom.removeObject(term.term)
+          set(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
+
+          addTo.pushObject(term.term)
+        }
+      }
+      this.notifyPropertyChange('podAffinity')
+      this.notifyPropertyChange('podAntiAffinity')
     }
   },
 
@@ -43,14 +217,38 @@ export default Component.extend({
     return mode === 'new' || mode === 'edit'
   }),
 
-  requiredDuringSchedulingIgnoredDuringExecution: computed('value.requiredDuringSchedulingIgnoredDuringExecution', function(){
-    return get(this.value, 'requiredDuringSchedulingIgnoredDuringExecution') || []
-  }),
+  removeFromSpec: (term, array) => {
+    return array.filter((each) => each._id !== term._id)
+  },
 
-  preferredDuringSchedulingIgnoredDuringExecution: computed('value.preferredDuringSchedulingIngnoredDuringExecution', function(){
-    return get(this.value, 'preferredDuringSchedulingIgnoredDuringExecution') || []
-  }),
+  // affinityRequiredDuringSchedulingIgnoredDuringExecution: computed('podAffinity.requiredDuringSchedulingIgnoredDuringExecution', {
+  //   get(){
+  //     return get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution') || []
+  //   },
+  //   set(key, val){
+  //     debugger
+  //     if (get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')){
+  //       get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution').addObject(val)
+  //     } else {
+  //       set(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution', [val])
+  //     }
+  //     this.notifyPropertyChange('podAffinity')
 
+  //     return val
+  //   }
+  // }),
+
+  // affinityPreferredDuringSchedulingIgnoredDuringExecution: computed('podAffinity.preferredDuringSchedulingIngnoredDuringExecution', function(){
+  //   return get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution') || []
+  // }),
+
+  // antiAffinityRequiredDuringSchedulingIgnoredDuringExecution: computed('podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution', function(){
+  //   return get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution') || []
+  // }),
+
+  // antiAffinityPreferredDuringSchedulingIgnoredDuringExecution: computed('podAntiAffinity.preferredDuringSchedulingIngnoredDuringExecution', function(){
+  //   return get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution') || []
+  // }),
 
 
 })

--- a/lib/shared/addon/components/form-pod-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-k8s/component.js
@@ -1,0 +1,56 @@
+import Component from '@ember/component';
+import layout from './template';
+import {
+  computed,
+  get,
+  set,
+  observer
+} from '@ember/object';
+
+/**  podAffinity: {
+  *    preferredDuringSchedulingIgnoredDuringExecution:
+  *      - {
+  *          weight: int,
+  *          podaffinityterm: podaffinityterm
+  *        }
+  *    requiredDuringSchedulingIgnoredDuringExecution:
+  *      - podaffinityterm
+  *  }
+  */
+export default Component.extend({
+  layout,
+
+  value: null,
+  mode:  'new',
+  anti:  false,
+
+  actions: {
+    addRequired(){
+      this.requiredDuringSchedulingIgnoredDuringExecution.pushObject({})
+    },
+    addPreferred(){
+      this.preferredDuringSchedulingIgnoredDuringExecution.pushObject({})
+    },
+
+    removeTerm(term, key){
+      get(this, key).removeObject(term)
+    }
+  },
+
+  editing: computed('mode', function() {
+    const mode = get(this, 'mode')
+
+    return mode === 'new' || mode === 'edit'
+  }),
+
+  requiredDuringSchedulingIgnoredDuringExecution: computed('value.requiredDuringSchedulingIgnoredDuringExecution', function(){
+    return get(this.value, 'requiredDuringSchedulingIgnoredDuringExecution') || []
+  }),
+
+  preferredDuringSchedulingIgnoredDuringExecution: computed('value.preferredDuringSchedulingIngnoredDuringExecution', function(){
+    return get(this.value, 'preferredDuringSchedulingIgnoredDuringExecution') || []
+  }),
+
+
+
+})

--- a/lib/shared/addon/components/form-pod-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-k8s/component.js
@@ -1,24 +1,10 @@
 import Component from '@ember/component';
 import layout from './template';
 import {
-  computed,
   get,
   set,
-  observer
 } from '@ember/object';
 import { randomStr } from '../../utils/util';
-
-/**  podAffinity: {
-  *    preferredDuringSchedulingIgnoredDuringExecution:
-  *      - {
-  *          weight: int,
-  *          podaffinityterm: podaffinityterm
-  *        }
-  *    requiredDuringSchedulingIgnoredDuringExecution:
-  *      - podaffinityterm
-  *  }
-  * podAntiAffinity: same shape
-  */
 
 export const TERM_PRIORITY = {
   PREFERRED: 'preferred',

--- a/lib/shared/addon/components/form-pod-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-k8s/component.js
@@ -33,7 +33,6 @@ export default Component.extend({
   podAntiAffinity: null,
   value:           null,
   mode:            'new',
-  anti:            false,
   allTerms:        [],
   /**
  * this component renders one list for required & preferred arrays of terms in affinity & antiAffinity
@@ -70,13 +69,6 @@ export default Component.extend({
   },
 
   actions: {
-    addRequired(){
-      this.requiredDuringSchedulingIgnoredDuringExecution.pushObject({})
-    },
-    addPreferred(){
-      this.preferredDuringSchedulingIgnoredDuringExecution.pushObject({})
-    },
-
     addTerm(){
       const neu = {
         priority: TERM_PRIORITY.REQUIRED,
@@ -92,6 +84,7 @@ export default Component.extend({
 
     removeTerm(term){
       // TODO nb update relevent spec array
+      // TODO nb does removeObject work here? Will it work in typeChanged and antiChanged?
       get(this, 'allTerms').removeObject(term)
       if (term.anti){
         if (term.priority === TERM_PRIORITY.REQUIRED){
@@ -118,44 +111,48 @@ export default Component.extend({
       }
     },
 
-    affinityChanged(){
-      // TODO nb this.update()
-      // needed?
-    },
-
-
-
     typeChanged(term, old){
       if (term.anti){
+        // TODO nb add 'weight'
         if (old === TERM_PRIORITY.REQUIRED){
           const removeFrom = get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
 
           set(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
+          // preferred terms are an object with weight and podAffinityTerm fields; required terms are just the contents of podAffinityTerm
+          set(term, 'term', this.addWeight(term.term))
 
           addTo.pushObject(term.term)
         } else {
+          // TODO nb remove weight
           const removeFrom = get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
 
           set(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
+          set(term, 'term', this.removeWeight(term))
+
 
           addTo.pushObject(term.term)
         }
         this.notifyPropertyChange('podAntiAffinity')
       } else {
+        // TODO nb add 'weight'
         if (old === TERM_PRIORITY.REQUIRED){
           const removeFrom = get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
 
           set(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
+          set(term, 'term', this.addWeight(term.term))
 
           addTo.pushObject(term.term)
         } else {
+          // TODO nb remove weight
           const removeFrom = get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
 
           set(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
+          set(term, 'term', this.removeWeight(term))
+
           addTo.pushObject(term.term)
         }
         this.notifyPropertyChange('podAffinity')
@@ -210,5 +207,26 @@ export default Component.extend({
   removeFromSpec: (term, array) => {
     return array.filter((each) => each._id !== term._id)
   },
+
+  addWeight: (term) => {
+    const out = {
+      // weight:          null,
+      podAffinityTerm: term,
+      _id:             term._id
+    }
+
+    delete out.podAffinityTerm._id
+
+    return out
+  },
+
+  removeWeight: (term) => {
+    const out = {
+      _id: term._id,
+      ...term.podAffinityTerm
+    }
+
+    return out
+  }
 
 })

--- a/lib/shared/addon/components/form-pod-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-k8s/component.js
@@ -21,7 +21,7 @@ export default Component.extend({
   allTerms:        [],
   /**
  * this component renders one list for required & preferred arrays of terms in affinity & antiAffinity
- * each podaffinitytermk8s component can change between affinity and antiaffinity and between required and perferred
+ * each podaffinitytermk8s component can change between affinity and antiaffinity and between required and preferred
  * the overall list shouldn't re-order when a term is moved to a different underlying array so rather than computing this off the arrays in spec
  * this list will track which array a term should belong to and the arrays in spec will be computed off this
  * list of all terms
@@ -194,12 +194,10 @@ export default Component.extend({
   },
 
   removeWeight: (term) => {
-    const out = {
+    return {
       _id: term._id,
       ...term.podAffinityTerm
     }
-
-    return out
   }
 
 })

--- a/lib/shared/addon/components/form-pod-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-k8s/component.js
@@ -31,7 +31,6 @@ export default Component.extend({
   TERM_PRIORITY,
   podAffinity:     null,
   podAntiAffinity: null,
-  value:           null,
   mode:            'new',
   allTerms:        [],
   /**

--- a/lib/shared/addon/components/form-pod-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-k8s/component.js
@@ -88,8 +88,6 @@ export default Component.extend({
       get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution').addObject(neu.term)
       this.notifyPropertyChange('allTerms')
       this.notifyPropertyChange('podAffinity')
-
-      // TODO nb update relevent spec array
     },
 
     removeTerm(term){
@@ -127,13 +125,12 @@ export default Component.extend({
 
 
 
-    typeChanged(term, old, neu){
+    typeChanged(term, old){
       if (term.anti){
         if (old === TERM_PRIORITY.REQUIRED){
           const removeFrom = get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
 
-          // removeFrom.removeObject(term.term)
           set(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
 
           addTo.pushObject(term.term)
@@ -141,7 +138,6 @@ export default Component.extend({
           const removeFrom = get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
 
-          // removeFrom.removeObject(term.term)
           set(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
 
           addTo.pushObject(term.term)
@@ -152,7 +148,6 @@ export default Component.extend({
           const removeFrom = get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
 
-          // removeFrom.removeObject(term.term)
           set(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
 
           addTo.pushObject(term.term)
@@ -160,7 +155,6 @@ export default Component.extend({
           const removeFrom = get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
 
-          // removeFrom.removeObject(term.term)
           set(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
           addTo.pushObject(term.term)
         }
@@ -168,13 +162,12 @@ export default Component.extend({
       }
     },
 
-    antiChanged(term, old, neu){
+    antiChanged(term, old){
       if (old){
         if (term.priority === TERM_PRIORITY.REQUIRED){
           const removeFrom = get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
 
-          // removeFrom.removeObject(term.term)
           set(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
 
           addTo.pushObject(term.term)
@@ -182,7 +175,6 @@ export default Component.extend({
           const removeFrom = get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
 
-          // removeFrom.removeObject(term.term)
           set(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
 
           addTo.pushObject(term.term)
@@ -192,7 +184,6 @@ export default Component.extend({
           const removeFrom = get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
 
-          // removeFrom.removeObject(term.term)
           set(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
 
           addTo.pushObject(term.term)
@@ -200,7 +191,6 @@ export default Component.extend({
           const removeFrom = get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
 
-          // removeFrom.removeObject(term.term)
           set(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution', this.removeFromSpec(term.term, removeFrom))
 
           addTo.pushObject(term.term)
@@ -220,35 +210,5 @@ export default Component.extend({
   removeFromSpec: (term, array) => {
     return array.filter((each) => each._id !== term._id)
   },
-
-  // affinityRequiredDuringSchedulingIgnoredDuringExecution: computed('podAffinity.requiredDuringSchedulingIgnoredDuringExecution', {
-  //   get(){
-  //     return get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution') || []
-  //   },
-  //   set(key, val){
-  //     debugger
-  //     if (get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')){
-  //       get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution').addObject(val)
-  //     } else {
-  //       set(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution', [val])
-  //     }
-  //     this.notifyPropertyChange('podAffinity')
-
-  //     return val
-  //   }
-  // }),
-
-  // affinityPreferredDuringSchedulingIgnoredDuringExecution: computed('podAffinity.preferredDuringSchedulingIngnoredDuringExecution', function(){
-  //   return get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution') || []
-  // }),
-
-  // antiAffinityRequiredDuringSchedulingIgnoredDuringExecution: computed('podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution', function(){
-  //   return get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution') || []
-  // }),
-
-  // antiAffinityPreferredDuringSchedulingIgnoredDuringExecution: computed('podAntiAffinity.preferredDuringSchedulingIngnoredDuringExecution', function(){
-  //   return get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution') || []
-  // }),
-
 
 })

--- a/lib/shared/addon/components/form-pod-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-k8s/component.js
@@ -124,7 +124,6 @@ export default Component.extend({
 
           addTo.pushObject(term.term)
         } else {
-          // TODO nb remove weight
           const removeFrom = get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
 
@@ -136,7 +135,6 @@ export default Component.extend({
         }
         this.notifyPropertyChange('podAntiAffinity')
       } else {
-        // TODO nb add 'weight'
         if (old === TERM_PRIORITY.REQUIRED){
           const removeFrom = get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
@@ -146,7 +144,6 @@ export default Component.extend({
 
           addTo.pushObject(term.term)
         } else {
-          // TODO nb remove weight
           const removeFrom = get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
 

--- a/lib/shared/addon/components/form-pod-affinity-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-k8s/component.js
@@ -31,7 +31,7 @@ export default Component.extend({
   TERM_PRIORITY,
   podAffinity:     null,
   podAntiAffinity: null,
-  mode:            'new',
+  editing:         false,
   allTerms:        [],
   /**
  * this component renders one list for required & preferred arrays of terms in affinity & antiAffinity
@@ -82,8 +82,6 @@ export default Component.extend({
     },
 
     removeTerm(term){
-      // TODO nb update relevent spec array
-      // TODO nb does removeObject work here? Will it work in typeChanged and antiChanged?
       get(this, 'allTerms').removeObject(term)
       if (term.anti){
         if (term.priority === TERM_PRIORITY.REQUIRED){
@@ -112,7 +110,6 @@ export default Component.extend({
 
     typeChanged(term, old){
       if (term.anti){
-        // TODO nb add 'weight'
         if (old === TERM_PRIORITY.REQUIRED){
           const removeFrom = get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution')
           const addTo = get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution')
@@ -193,12 +190,6 @@ export default Component.extend({
       this.notifyPropertyChange('podAntiAffinity')
     }
   },
-
-  editing: computed('mode', function() {
-    const mode = get(this, 'mode')
-
-    return mode === 'new' || mode === 'edit'
-  }),
 
   removeFromSpec: (term, array) => {
     return array.filter((each) => each._id !== term._id)

--- a/lib/shared/addon/components/form-pod-affinity-k8s/template.hbs
+++ b/lib/shared/addon/components/form-pod-affinity-k8s/template.hbs
@@ -1,11 +1,7 @@
 <div class="box">
   <div>
     <label class="acc-label">
-      {{#if anti}}
-        {{t "clusterNew.agentConfig.overrideAffinity.podAntiAffinity.title"}}
-      {{else}}
-        {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.title"}}
-      {{/if}}
+      {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.title"}}
     </label>
   </div>
   <div class="row">

--- a/lib/shared/addon/components/form-pod-affinity-k8s/template.hbs
+++ b/lib/shared/addon/components/form-pod-affinity-k8s/template.hbs
@@ -9,41 +9,23 @@
     </label>
   </div>
   <div class="row">
-    <div class="col span-6">
+    <div class="col span-12">
       <div>
-        {{#each requiredDuringSchedulingIgnoredDuringExecution as |requiredTerm|}}
+        {{#each allTerms as |term|}}
           <FormPodAffinityTermK8s
-            @value={{requiredTerm}}
+            @value={{term}}
             @mode={{mode}}
-            @remove={{action "removeTerm" requiredTerm "requiredDuringSchedulingIgnoredDuringExecution"}}
+            @remove={{action "removeTerm" term}}
+            @typeChanged={{action "typeChanged" term}}
+            @antiChanged={{action "antiChanged" term}}
           />
         {{/each}}
       </div>
       {{#if editing}}
-        <button class="btn bg-link icon-btn" type="button" {{action "addRequired"}}>
+        <button class="btn bg-link icon-btn" type="button" {{action "addTerm"}}>
           <i class="icon icon-plus text-small"/>
           <span>
-            {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.addRequired"}}
-          </span>
-        </button>
-      {{/if}}
-    </div>
-    <div class="col span-6">
-      <div>
-        {{#each preferredDuringSchedulingIgnoredDuringExecution as |preferredTerm|}}
-          <FormPodAffinityTermK8s
-            @value={{preferredTerm}}
-            @mode={{mode}}
-            @preferred={{true}}
-            @remove={{action "removeTerm" prefferedTerm "preferredDuringSchedulingIgnoredDuringExecution"}}
-          />
-        {{/each}}
-      </div>
-      {{#if editing}}
-        <button class="btn bg-link icon-btn" type="button" {{action "addPreferred"}}>
-          <i class="icon icon-plus text-small"/>
-          <span>
-            {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.addPreferred"}}
+            {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.addTerm"}}
           </span>
         </button>
       {{/if}}

--- a/lib/shared/addon/components/form-pod-affinity-k8s/template.hbs
+++ b/lib/shared/addon/components/form-pod-affinity-k8s/template.hbs
@@ -10,7 +10,7 @@
         {{#each allTerms as |term|}}
           <FormPodAffinityTermK8s
             @value={{term}}
-            @mode={{mode}}
+            @editing={{editing}}
             @remove={{action "removeTerm" term}}
             @typeChanged={{action "typeChanged" term}}
             @antiChanged={{action "antiChanged" term}}

--- a/lib/shared/addon/components/form-pod-affinity-k8s/template.hbs
+++ b/lib/shared/addon/components/form-pod-affinity-k8s/template.hbs
@@ -1,0 +1,52 @@
+<div class="box">
+  <div>
+    <label class="acc-label">
+      {{#if anti}}
+        {{t "clusterNew.agentConfig.overrideAffinity.podAntiAffinity.title"}}
+      {{else}}
+        {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.title"}}
+      {{/if}}
+    </label>
+  </div>
+  <div class="row">
+    <div class="col span-6">
+      <div>
+        {{#each requiredDuringSchedulingIgnoredDuringExecution as |requiredTerm|}}
+          <FormPodAffinityTermK8s
+            @value={{requiredTerm}}
+            @mode={{mode}}
+            @remove={{action "removeTerm" requiredTerm "requiredDuringSchedulingIgnoredDuringExecution"}}
+          />
+        {{/each}}
+      </div>
+      {{#if editing}}
+        <button class="btn bg-link icon-btn" type="button" {{action "addRequired"}}>
+          <i class="icon icon-plus text-small"/>
+          <span>
+            {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.addRequired"}}
+          </span>
+        </button>
+      {{/if}}
+    </div>
+    <div class="col span-6">
+      <div>
+        {{#each preferredDuringSchedulingIgnoredDuringExecution as |preferredTerm|}}
+          <FormPodAffinityTermK8s
+            @value={{preferredTerm}}
+            @mode={{mode}}
+            @preferred={{true}}
+            @remove={{action "removeTerm" prefferedTerm "preferredDuringSchedulingIgnoredDuringExecution"}}
+          />
+        {{/each}}
+      </div>
+      {{#if editing}}
+        <button class="btn bg-link icon-btn" type="button" {{action "addPreferred"}}>
+          <i class="icon icon-plus text-small"/>
+          <span>
+            {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.addPreferred"}}
+          </span>
+        </button>
+      {{/if}}
+    </div>
+  </div>
+</div>

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
@@ -131,11 +131,12 @@ export default Component.extend({
       return namespaces.join(', ')
     },
     set(key, val){
-      if (val || val === ''){
-      // a,b,c or a, b, c
-        const parsed = val.split(/,\s*/g).map((ns) => ns.trim()).filter((ns) => !!ns)
+      if (val && val.length){
+      // // a,b,c or a, b, c
+      //   const parsed = val.split(/,\s*/g).map((ns) => ns.trim()).filter((ns) => !!ns)
 
-        set(this.podAffintyTerm, 'namespaces', parsed)
+        // set(this.podAffintyTerm, 'namespaces', parsed)
+        set(this.podAffintyTerm, 'namespaces', val)
       } else if (this.podAffintyTerm.namespaces){
         delete this.podAffintyTerm.namespaces
         this.notifyPropertyChange('value')

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
@@ -132,10 +132,6 @@ export default Component.extend({
     },
     set(key, val){
       if (val && val.length){
-      // // a,b,c or a, b, c
-      //   const parsed = val.split(/,\s*/g).map((ns) => ns.trim()).filter((ns) => !!ns)
-
-        // set(this.podAffintyTerm, 'namespaces', parsed)
         set(this.podAffintyTerm, 'namespaces', val)
       } else if (this.podAffintyTerm.namespaces){
         delete this.podAffintyTerm.namespaces
@@ -155,6 +151,25 @@ export default Component.extend({
         set(this.podAffintyTerm, 'namespaceSelector', val)
       } else if (this.podAffintyTerm.namespaceSelector){
         delete this.podAffintyTerm.namespaceSelector
+        this.notifyPropertyChange('value')
+      }
+
+      return val
+    }
+  }),
+
+  labelSelector: computed('podAffintyTerm.labelSelector.matchExpressions', {
+    get(){
+      return this.podAffintyTerm?.labelSelector?.matchExpressions || []
+    },
+    set(key, val){
+      if (val && val.length){
+        if (!this.podAffintyTerm.labelSelector){
+          set(this.podAffintyTerm, 'labelSelector', {})
+        }
+        set(this.podAffintyTerm.labelSelector, 'matchExpressions', val)
+      } else if (this.podAffintyTerm?.labelSelector?.matchExpressions){
+        delete this.podAffintyTerm.labelSelector.matchExpressions
         this.notifyPropertyChange('value')
       }
 

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
@@ -68,7 +68,7 @@ export default Component.extend({
    * }
    */
   value:         null,
-  mode:          'new',
+  editing:     false,
   remove:        null,
   typeChanged:   null,
   antiChanged:   null,
@@ -90,13 +90,6 @@ export default Component.extend({
     }
   },
 
-  editing:   computed('mode', function() {
-    const mode = get(this, 'mode')
-
-    return mode === 'new' || mode === 'edit'
-  }),
-
-
   podAffintyTerm: computed('value.term', 'value.priority', function() {
     return get(this.value, 'priority') === TERM_PRIORITY.REQUIRED ? get(this.value, 'term') : get(this.value, 'term.podAffinityTerm')
   }),
@@ -112,7 +105,6 @@ export default Component.extend({
 
           set(this.value.term, 'weight', toInt)
         } catch (e){
-          // TODO nb handle bad weight value better
           console.error(e)
         }
       } else if (this.value?.term?.weight){

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
@@ -1,0 +1,132 @@
+import Component from '@ember/component';
+import layout from './template';
+import {
+  computed,
+  get,
+  set,
+  observer
+} from '@ember/object';
+
+/** if preferred:
+ * - {
+  *   weight: int,
+  *   podaffinityterm: podaffinityterm
+  *  }
+  *  else:
+  *  - podAffinityTerm
+  *
+  * podaffinityterm: {
+  *   namespaceSelector: same as labelSelector OR if empty object, 'all namespaces'
+  *   namespaces: string array of namespaces - if [] && namespaceSelector==null, 'use this pod's namespace'
+  *   toplogyKey: string
+  *   labelSelector: {
+  *      matchExpressions:
+  *        - {
+  *            key: string,
+  *            operator string one of: In, NotIn, Exists and DoesNotExist
+  *            value: string array ... If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty.
+  *          }
+  *      matchLabels: {
+  *            map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value".
+  *            The requirements are ANDed.
+  *        }
+  *    }
+
+  * }
+  */
+
+const namespaceModes = {
+  ALL:      'all',
+  THIS_POD: 'thisPod',
+  IN_LIST:  'inList'
+}
+
+
+export default Component.extend({
+  layout,
+  namespaceModes,
+
+  value:         null,
+  mode:          'new',
+  perferred:     false,
+  remove:        null,
+
+  actions:   {
+    removeTerm(){
+      if (this.remove){
+        this.remove()
+      }
+    }
+  },
+
+  namespaceModeObserver: observer('namespaceMode', function() {
+    const namespaceMode = get(this, 'namespaceMode');
+
+    switch (namespaceMode){
+    case namespaceModes.ALL:
+      set(this, 'namespaceSelector', {})
+      set(this, 'namespaces', '')
+      break;
+
+    case namespaceModes.THIS_POD:
+      set(this, 'namespaceSelector', null);
+      set(this, 'namespaces', '');
+      break;
+
+    case namespaceModes.IN_LIST:
+      set(this, 'namespaceSelector', null)
+    }
+  }),
+
+  editing:   computed('mode', function() {
+    const mode = get(this, 'mode')
+
+    return mode === 'new' || mode === 'edit'
+  }),
+
+  topologyKey: computed('value.topologyKey', function(){
+    return get(this.value, 'topologyKey') || ''
+  }),
+
+  namespaces: computed('value.namespaces', 'namespaceMode', {
+    get(){
+      const namespaces = get(this.value, 'namespaces') || [];
+
+      return namespaces.join(', ')
+    },
+    set(key, val){
+      // TODO nb delete if not set
+      if (val || val === ''){
+      // a,b,c or a, b, c
+        const parsed = val.split(/,\s*/g).map((ns) => ns.trim()).filter((ns) => !!ns)
+
+        set(this.value, 'namespaces', parsed)
+      } else if (this.value.namespaces){
+        delete this.value.namespaces
+        this.notifyPropertyChange('value')
+      }
+
+      return val
+    }
+  }),
+
+  namespaceSelector: computed('value.namespaceSelector', 'namespaceMode', {
+    get(){
+      return this.value.namespaceSelector || {}
+    },
+    set(key, val){
+      if (val){
+        set(this.value, 'namespaceSelector', val)
+      } else if (this.value.namespaceSelector){
+        delete this.value.namespaceSelector
+        this.notifyPropertyChange('value')
+      }
+
+      return val
+    }
+  }),
+
+  namespaceMode: namespaceModes.ALL,
+
+
+})

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
@@ -4,37 +4,8 @@ import {
   computed,
   get,
   set,
-  observer
 } from '@ember/object';
 import { TERM_PRIORITY } from '../form-pod-affinity-k8s/component';
-
-/** if preferred:
- * - {
-  *   weight: int,
-  *   podaffinityterm: podaffinityterm
-  *  }
-  *  else:
-  *  - podAffinityTerm
-  *
-  * podaffinityterm: {
-  *   namespaceSelector: same as labelSelector OR if empty object, 'all namespaces'
-  *   namespaces: string array of namespaces - if [] && namespaceSelector==null, 'use this pod's namespace'
-  *   toplogyKey: string
-  *   labelSelector: {
-  *      matchExpressions:
-  *        - {
-  *            key: string,
-  *            operator string one of: In, NotIn, Exists and DoesNotExist
-  *            value: string array ... If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty.
-  *          }
-  *      matchLabels: {
-  *            map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value".
-  *            The requirements are ANDed.
-  *        }
-  *    }
-
-  * }
-  */
 
 const namespaceModes = {
   ALL:      'all',

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
@@ -6,6 +6,7 @@ import {
   set,
   observer
 } from '@ember/object';
+import { TERM_PRIORITY } from '../form-pod-affinity-k8s/component';
 
 /** if preferred:
  * - {
@@ -46,10 +47,38 @@ export default Component.extend({
   layout,
   namespaceModes,
 
+  /**
+   * {
+   *  priority: preferred or required
+   *  anti: bool - podAffinity or podAntiAffinity
+   *  term: podaffinityterm OR
+   *   {
+   *    weight,
+   *    podAffintyTerm
+   *   }
+   * }
+   */
   value:         null,
   mode:          'new',
-  perferred:     false,
   remove:        null,
+  typeChanged:   null,
+  antiChanged:   null,
+
+  priorityOptions: [{
+    value: TERM_PRIORITY.REQUIRED,
+    label: 'clusterNew.agentConfig.overrideAffinity.podAffinity.typeOptions.required'
+  }, {
+    value: TERM_PRIORITY.PREFERRED,
+    label: 'clusterNew.agentConfig.overrideAffinity.podAffinity.typeOptions.preferred'
+  }],
+
+  affinityOptions: [{
+    value: 'true',
+    label: 'clusterNew.agentConfig.overrideAffinity.podAffinity.typeOptions.antiAffinity'
+  }, {
+    value: 'false',
+    label: 'clusterNew.agentConfig.overrideAffinity.podAffinity.typeOptions.affinity'
+  }],
 
   actions:   {
     removeTerm(){
@@ -95,7 +124,6 @@ export default Component.extend({
       return namespaces.join(', ')
     },
     set(key, val){
-      // TODO nb delete if not set
       if (val || val === ''){
       // a,b,c or a, b, c
         const parsed = val.split(/,\s*/g).map((ns) => ns.trim()).filter((ns) => !!ns)
@@ -124,6 +152,39 @@ export default Component.extend({
 
       return val
     }
+  }),
+
+  priority: computed('priorityOptions', 'value.priority', {
+    get(){
+      return get(this.value, 'priority')
+    },
+    set(key, val){
+      const old = get(this.value, 'priority')
+
+      set(this.value, 'priority', val)
+      this.typeChanged(old, val)
+
+      return val
+    },
+  }),
+
+  anti: computed('affinityOptions', 'value.anti', {
+    get(){
+      const isAnti = get(this.value, 'anti')
+
+
+      return isAnti ? 'true' : 'false'
+    },
+    set(key, val){
+      const old = get(this, 'anti') === 'true'
+      const neu = val === 'true'
+
+      set(this.value, 'anti', neu)
+
+      this.antiChanged(old, neu)
+
+      return val
+    },
   }),
 
   namespaceMode: namespaceModes.ALL,

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
@@ -97,7 +97,6 @@ export default Component.extend({
   }),
 
 
-  // TODO nb acccount for weight if value.priority === 'preferred'
   podAffintyTerm: computed('value.term', 'value.priority', function() {
     return get(this.value, 'priority') === TERM_PRIORITY.REQUIRED ? get(this.value, 'term') : get(this.value, 'term.podAffinityTerm')
   }),
@@ -107,7 +106,7 @@ export default Component.extend({
       return get(this.value, 'priority') === TERM_PRIORITY.REQUIRED ? null : get(this.value, 'term.weight')
     },
     set(key, val){
-      if (val || val === 0) {
+      if (val || val === '0') {
         try {
           const toInt = parseInt(val, 10)
 

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
@@ -42,11 +42,20 @@ const namespaceModes = {
   IN_LIST:  'inList'
 }
 
+export const priorityOptions =  [{
+  value: TERM_PRIORITY.REQUIRED,
+  label: 'clusterNew.agentConfig.overrideAffinity.podAffinity.typeOptions.required'
+}, {
+  value: TERM_PRIORITY.PREFERRED,
+  label: 'clusterNew.agentConfig.overrideAffinity.podAffinity.typeOptions.preferred'
+}]
+
 
 export default Component.extend({
   layout,
   namespaceModes,
-
+  priorityOptions,
+  TERM_PRIORITY,
   /**
    * {
    *  priority: preferred or required
@@ -64,13 +73,6 @@ export default Component.extend({
   typeChanged:   null,
   antiChanged:   null,
 
-  priorityOptions: [{
-    value: TERM_PRIORITY.REQUIRED,
-    label: 'clusterNew.agentConfig.overrideAffinity.podAffinity.typeOptions.required'
-  }, {
-    value: TERM_PRIORITY.PREFERRED,
-    label: 'clusterNew.agentConfig.overrideAffinity.podAffinity.typeOptions.preferred'
-  }],
 
   affinityOptions: [{
     value: 'true',
@@ -88,27 +90,44 @@ export default Component.extend({
     }
   },
 
-  // namespaceModeObserver: observer('namespaceMode', () => {
-
-  // }),
-
   editing:   computed('mode', function() {
     const mode = get(this, 'mode')
 
     return mode === 'new' || mode === 'edit'
   }),
 
-  term: computed('value.term', function(){
-    return get(this.value, 'term') || {}
+
+  // TODO nb acccount for weight if value.priority === 'preferred'
+  podAffintyTerm: computed('value.term', 'value.priority', function() {
+    return get(this.value, 'priority') === TERM_PRIORITY.REQUIRED ? get(this.value, 'term') : get(this.value, 'term.podAffinityTerm')
   }),
 
-  topologyKey: computed('value.topologyKey', function(){
-    return get(this.value, 'topologyKey') || ''
-  }),
-
-  namespaces: computed('term.namespaces', 'namespaceMode', {
+  weight: computed('value.term', 'value.priority', {
     get(){
-      const namespaces = get(this.term, 'namespaces') || [];
+      return get(this.value, 'priority') === TERM_PRIORITY.REQUIRED ? null : get(this.value, 'term.weight')
+    },
+    set(key, val){
+      if (val || val === 0) {
+        try {
+          const toInt = parseInt(val, 10)
+
+          set(this.value.term, 'weight', toInt)
+        } catch (e){
+          // TODO nb handle bad weight value better
+          console.error(e)
+        }
+      } else if (this.value?.term?.weight){
+        delete this.value.term.weight
+        this.notifyPropertyChange('value')
+      }
+
+      return val
+    }
+  }),
+
+  namespaces: computed('podAffintyTerm.namespaces', 'namespaceMode', {
+    get(){
+      const namespaces = get(this.podAffintyTerm, 'namespaces') || [];
 
       return namespaces.join(', ')
     },
@@ -117,9 +136,9 @@ export default Component.extend({
       // a,b,c or a, b, c
         const parsed = val.split(/,\s*/g).map((ns) => ns.trim()).filter((ns) => !!ns)
 
-        set(this.term, 'namespaces', parsed)
-      } else if (this.term.namespaces){
-        delete this.term.namespaces
+        set(this.podAffintyTerm, 'namespaces', parsed)
+      } else if (this.podAffintyTerm.namespaces){
+        delete this.podAffintyTerm.namespaces
         this.notifyPropertyChange('value')
       }
 
@@ -127,15 +146,15 @@ export default Component.extend({
     }
   }),
 
-  namespaceSelector: computed('namespaceMode', 'term.namespaceSelector', {
+  namespaceSelector: computed('namespaceMode', 'podAffintyTerm.namespaceSelector', {
     get(){
-      return this.term.namespaceSelector || {}
+      return this.podAffintyTerm.namespaceSelector || {}
     },
     set(key, val){
       if (val){
-        set(this.term, 'namespaceSelector', val)
-      } else if (this.term.namespaceSelector){
-        delete this.term.namespaceSelector
+        set(this.podAffintyTerm, 'namespaceSelector', val)
+      } else if (this.podAffintyTerm.namespaceSelector){
+        delete this.podAffintyTerm.namespaceSelector
         this.notifyPropertyChange('value')
       }
 
@@ -178,19 +197,17 @@ export default Component.extend({
 
   // null or empty namespaces and null selector = 'this pod's namespace'
   // null or empty namespaces and empty object selector = 'all namespaces'
-  namespaceMode: computed('term.namespaceSelector',  'term.namespaces.length', {
+  namespaceMode: computed('podAffintyTerm.namespaceSelector', 'podAffintyTerm.namespaces.length', {
     get(){
-      if (this.term.namespaceSelector){
+      if (this.podAffintyTerm.namespaceSelector){
         return namespaceModes.ALL
-      } else if (this.term.namespaces){
+      } else if (this.podAffintyTerm.namespaces){
         return namespaceModes.IN_LIST
       }
 
       return namespaceModes.THIS_POD
     },
     set(key, val){
-      // const namespaceMode = get(this, 'namespaceMode');
-
       switch (val){
       case namespaceModes.ALL:
         set(this, 'namespaceSelector', {})
@@ -208,7 +225,6 @@ export default Component.extend({
 
       return val
     }
-  })
-
+  }),
 
 })

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/component.js
@@ -88,24 +88,9 @@ export default Component.extend({
     }
   },
 
-  namespaceModeObserver: observer('namespaceMode', function() {
-    const namespaceMode = get(this, 'namespaceMode');
+  // namespaceModeObserver: observer('namespaceMode', () => {
 
-    switch (namespaceMode){
-    case namespaceModes.ALL:
-      set(this, 'namespaceSelector', {})
-      set(this, 'namespaces', '')
-      break;
-
-    case namespaceModes.THIS_POD:
-      set(this, 'namespaceSelector', null);
-      set(this, 'namespaces', '');
-      break;
-
-    case namespaceModes.IN_LIST:
-      set(this, 'namespaceSelector', null)
-    }
-  }),
+  // }),
 
   editing:   computed('mode', function() {
     const mode = get(this, 'mode')
@@ -113,13 +98,17 @@ export default Component.extend({
     return mode === 'new' || mode === 'edit'
   }),
 
+  term: computed('value.term', function(){
+    return get(this.value, 'term') || {}
+  }),
+
   topologyKey: computed('value.topologyKey', function(){
     return get(this.value, 'topologyKey') || ''
   }),
 
-  namespaces: computed('value.namespaces', 'namespaceMode', {
+  namespaces: computed('term.namespaces', 'namespaceMode', {
     get(){
-      const namespaces = get(this.value, 'namespaces') || [];
+      const namespaces = get(this.term, 'namespaces') || [];
 
       return namespaces.join(', ')
     },
@@ -128,9 +117,9 @@ export default Component.extend({
       // a,b,c or a, b, c
         const parsed = val.split(/,\s*/g).map((ns) => ns.trim()).filter((ns) => !!ns)
 
-        set(this.value, 'namespaces', parsed)
-      } else if (this.value.namespaces){
-        delete this.value.namespaces
+        set(this.term, 'namespaces', parsed)
+      } else if (this.term.namespaces){
+        delete this.term.namespaces
         this.notifyPropertyChange('value')
       }
 
@@ -138,15 +127,15 @@ export default Component.extend({
     }
   }),
 
-  namespaceSelector: computed('value.namespaceSelector', 'namespaceMode', {
+  namespaceSelector: computed('namespaceMode', 'term.namespaceSelector', {
     get(){
-      return this.value.namespaceSelector || {}
+      return this.term.namespaceSelector || {}
     },
     set(key, val){
       if (val){
-        set(this.value, 'namespaceSelector', val)
-      } else if (this.value.namespaceSelector){
-        delete this.value.namespaceSelector
+        set(this.term, 'namespaceSelector', val)
+      } else if (this.term.namespaceSelector){
+        delete this.term.namespaceSelector
         this.notifyPropertyChange('value')
       }
 
@@ -162,7 +151,7 @@ export default Component.extend({
       const old = get(this.value, 'priority')
 
       set(this.value, 'priority', val)
-      this.typeChanged(old, val)
+      this.typeChanged(old)
 
       return val
     },
@@ -181,13 +170,45 @@ export default Component.extend({
 
       set(this.value, 'anti', neu)
 
-      this.antiChanged(old, neu)
+      this.antiChanged(old)
 
       return val
     },
   }),
 
-  namespaceMode: namespaceModes.ALL,
+  // null or empty namespaces and null selector = 'this pod's namespace'
+  // null or empty namespaces and empty object selector = 'all namespaces'
+  namespaceMode: computed('term.namespaceSelector',  'term.namespaces.length', {
+    get(){
+      if (this.term.namespaceSelector){
+        return namespaceModes.ALL
+      } else if (this.term.namespaces){
+        return namespaceModes.IN_LIST
+      }
+
+      return namespaceModes.THIS_POD
+    },
+    set(key, val){
+      // const namespaceMode = get(this, 'namespaceMode');
+
+      switch (val){
+      case namespaceModes.ALL:
+        set(this, 'namespaceSelector', {})
+        set(this, 'namespaces', null)
+        break;
+
+      case namespaceModes.THIS_POD:
+        set(this, 'namespaceSelector', null);
+        set(this, 'namespaces', null);
+        break;
+
+      case namespaceModes.IN_LIST:
+        set(this, 'namespaceSelector', null)
+      }
+
+      return val
+    }
+  })
 
 
 })

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/styles.scss
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/styles.scss
@@ -1,3 +1,0 @@
-.affinity-remove {
-  float: right !important;
-}

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/styles.scss
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/styles.scss
@@ -1,0 +1,3 @@
+.affinity-remove {
+  float: right !important;
+}

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
@@ -1,0 +1,63 @@
+<div class="box mb-10 affinity-term">
+  {{#if editing}}
+    <div class="affinity-remove">
+      <button class="btn btn-sm " type="button" {{action "removeTerm"}}>
+          <i class="icon icon-x"/>
+      </button>
+    </div>
+  {{/if }}
+  <div class="row">
+    <div class="col span-12">
+      <div class="radio">
+        <label>
+          {{radio-button
+            selection=namespaceMode
+            value=namespaceModes.ALL
+          }} {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.namespaces.radioOptions.all"}}
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          {{radio-button
+            selection=namespaceMode
+            value=namespaceModes.THIS_POD
+          }} {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.namespaces.radioOptions.thisPod"}}
+        </label>
+      </div> 
+      <div class="radio">
+        <label>
+          {{radio-button
+            selection=namespaceMode
+            value=namespaceModes.IN_LIST
+          }} {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.namespaces.radioOptions.inList"}}
+        </label>
+      </div>
+      {{#if (eq namespaceMode namespaceModes.IN_LIST) }}
+        {{#input-or-display
+          editable=editing
+          value=namespaces
+        }}
+        {{input
+          type="text"
+          class="form-control input-sm"
+          value=namespaces
+        }}
+        {{/input-or-display}}
+      {{/if}}
+    </div>
+    <div class="col span-12">
+      <label class="acc-label">{{t "clusterNew.agentConfig.overrideAffinity.podAffinity.topologyKey.label"}}</label>
+      {{#input-or-display
+        editable=editing
+        value=toplogyKey
+      }}
+      {{input
+        type="text"
+        class="form-control input-sm"
+        value=topologyKey
+        placeholder=(t "clusterNew.agentConfig.overrideAffinity.podAffinity.topologyKey.placeholder")
+      }}
+      {{/input-or-display}}
+    </div>
+  </div>
+</div>

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
@@ -36,7 +36,7 @@
   </div>
   <div class="row">
     <div class="col span-12">
-            <div class="radio">
+      <div class="radio">
         <label>
           {{radio-button
             selection=namespaceMode
@@ -73,19 +73,37 @@
         {{/input-or-display}}
       {{/if}}
     </div>
-    <div class="col span-12">
+  </div>
+  <div class="row">
+    <div class="col span-6">
       <label class="acc-label">{{t "clusterNew.agentConfig.overrideAffinity.podAffinity.topologyKey.label"}}</label>
       {{#input-or-display
         editable=editing
-        value=toplogyKey
+        value=podAffintyTerm.topologyKey
       }}
       {{input
         type="text"
         class="form-control input-sm"
-        value=topologyKey
+        value=podAffintyTerm.topologyKey
         placeholder=(t "clusterNew.agentConfig.overrideAffinity.podAffinity.topologyKey.placeholder")
       }}
       {{/input-or-display}}
     </div>
+    {{#if (eq value.priority TERM_PRIORITY.PREFERRED)}}
+      <div class="col span-6">
+        <label class="acc-label">{{t "clusterNew.agentConfig.overrideAffinity.podAffinity.weight.label"}}</label>
+        {{#input-or-display
+          editable=editing
+          value=weight
+        }}
+        {{input
+          type="number"
+          class="form-control input-sm"
+          value=weight
+          placeholder=(t "clusterNew.agentConfig.overrideAffinity.podAffinity.weight.placeholder")
+        }}
+        {{/input-or-display}}
+      </div>
+    {{/if}}
   </div>
 </div>

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
@@ -23,11 +23,8 @@
         />
       {{/input-or-display}}
     </div>
-    <div class="col span-6">
-      {{#input-or-display
-        editable=editing
-        value=anti
-      }}
+    <div class="col span-6"> 
+      {{#if editing}}
         <NewSelect 
           @class="form-control"
           @value={{anti}}
@@ -37,7 +34,11 @@
           @content={{affinityOptions}}
           @disabled={{not editing}}
         />
-      {{/input-or-display}}
+      {{else if anti}}
+        <span>{{ t "clusterNew.agentConfig.overrideAffinity.podAffinity.typeOptions.antiAffinity" }}</span>
+      {{else}}
+        <span>{{ t "clusterNew.agentConfig.overrideAffinity.podAffinity.typeOptions.affinity" }}</span>
+      {{/if}}
     </div>
   </div>
   <div class="row">

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
@@ -36,6 +36,14 @@
   </div>
   <div class="row">
     <div class="col span-12">
+            <div class="radio">
+        <label>
+          {{radio-button
+            selection=namespaceMode
+            value=namespaceModes.THIS_POD
+          }} {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.namespaces.radioOptions.thisPod"}}
+        </label>
+      </div> 
       <div class="radio">
         <label>
           {{radio-button
@@ -44,14 +52,6 @@
           }} {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.namespaces.radioOptions.all"}}
         </label>
       </div>
-      <div class="radio">
-        <label>
-          {{radio-button
-            selection=namespaceMode
-            value=namespaceModes.THIS_POD
-          }} {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.namespaces.radioOptions.thisPod"}}
-        </label>
-      </div> 
       <div class="radio">
         <label>
           {{radio-button

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
@@ -35,7 +35,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="col span-12">
+    <div class="col span-12 mb-0">
       <div class="radio">
         <label>
           {{radio-button
@@ -60,19 +60,21 @@
           }} {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.namespaces.radioOptions.inList"}}
         </label>
       </div>
-      {{#if (eq namespaceMode namespaceModes.IN_LIST) }}
-        {{#input-or-display
-          editable=editing
-          value=namespaces
-        }}
-        {{input
-          type="text"
-          class="form-control input-sm"
-          value=namespaces
-        }}
-        {{/input-or-display}}
-      {{/if}}
     </div>
+    {{#if (eq namespaceMode namespaceModes.IN_LIST) }}
+    <div class="col span-6 mt-0">
+      {{#input-or-display
+        editable=editing
+        value=namespaces
+      }}
+      {{input-array-as-string
+        type="text"
+        inputClass="form-control input-sm"
+        value=namespaces
+      }}
+      {{/input-or-display}}
+    </div>
+    {{/if}}
   </div>
   <div class="row">
     <div class="col span-6">

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
@@ -6,6 +6,34 @@
       </button>
     </div>
   {{/if }}
+  <div class="row mt-10">
+    <div class="col span-6">
+      {{!-- <label class="acc-label">
+        {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.priority"}}
+      </label> --}}
+      <NewSelect 
+        @class="form-control"
+        @value={{priority}}
+        @optionLabelPath="label"
+        @optionValuePath="value"
+        @localizedLabel={{true}}
+        @content={{priorityOptions}}
+      />
+    </div>
+    <div class="col span-6">
+      {{!-- <label class="acc-label">
+        {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.priority"}}
+      </label> --}}
+      <NewSelect 
+        @class="form-control"
+        @value={{anti}}
+        @optionLabelPath="label"
+        @optionValuePath="value"
+        @localizedLabel={{true}}
+        @content={{affinityOptions}}
+      />
+    </div>
+  </div>
   <div class="row">
     <div class="col span-12">
       <div class="radio">

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
@@ -77,6 +77,12 @@
     {{/if}}
   </div>
   <div class="row">
+    <FormMatchExpressionsK8s
+      @mode={{mode}}
+      @labelSelector={{labelSelector}}
+    />
+  </div>
+  <div class="row">
     <div class="col span-6">
       <label class="acc-label">{{t "clusterNew.agentConfig.overrideAffinity.podAffinity.topologyKey.label"}}</label>
       {{#input-or-display

--- a/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
+++ b/lib/shared/addon/components/form-pod-affinity-term-k8s/template.hbs
@@ -8,30 +8,36 @@
   {{/if }}
   <div class="row mt-10">
     <div class="col span-6">
-      {{!-- <label class="acc-label">
-        {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.priority"}}
-      </label> --}}
-      <NewSelect 
-        @class="form-control"
-        @value={{priority}}
-        @optionLabelPath="label"
-        @optionValuePath="value"
-        @localizedLabel={{true}}
-        @content={{priorityOptions}}
-      />
+      {{#input-or-display
+        editable=editing
+        value=priority
+      }}
+        <NewSelect 
+          @class="form-control"
+          @value={{priority}}
+          @optionLabelPath="label"
+          @optionValuePath="value"
+          @localizedLabel={{true}}
+          @content={{priorityOptions}}
+          @disabled={{not editing}}
+        />
+      {{/input-or-display}}
     </div>
     <div class="col span-6">
-      {{!-- <label class="acc-label">
-        {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.priority"}}
-      </label> --}}
-      <NewSelect 
-        @class="form-control"
-        @value={{anti}}
-        @optionLabelPath="label"
-        @optionValuePath="value"
-        @localizedLabel={{true}}
-        @content={{affinityOptions}}
-      />
+      {{#input-or-display
+        editable=editing
+        value=anti
+      }}
+        <NewSelect 
+          @class="form-control"
+          @value={{anti}}
+          @optionLabelPath="label"
+          @optionValuePath="value"
+          @localizedLabel={{true}}
+          @content={{affinityOptions}}
+          @disabled={{not editing}}
+        />
+      {{/input-or-display}}
     </div>
   </div>
   <div class="row">
@@ -41,6 +47,7 @@
           {{radio-button
             selection=namespaceMode
             value=namespaceModes.THIS_POD
+            disabled=(not editing)
           }} {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.namespaces.radioOptions.thisPod"}}
         </label>
       </div> 
@@ -49,6 +56,7 @@
           {{radio-button
             selection=namespaceMode
             value=namespaceModes.ALL
+            disabled=(not editing)
           }} {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.namespaces.radioOptions.all"}}
         </label>
       </div>
@@ -57,6 +65,7 @@
           {{radio-button
             selection=namespaceMode
             value=namespaceModes.IN_LIST
+            disabled=(not editing)
           }} {{t "clusterNew.agentConfig.overrideAffinity.podAffinity.namespaces.radioOptions.inList"}}
         </label>
       </div>
@@ -78,7 +87,7 @@
   </div>
   <div class="row">
     <FormMatchExpressionsK8s
-      @mode={{mode}}
+      @editing={{editing}}
       @labelSelector={{labelSelector}}
     />
   </div>

--- a/lib/shared/addon/components/input-array-as-string/component.js
+++ b/lib/shared/addon/components/input-array-as-string/component.js
@@ -7,6 +7,7 @@ export default Component.extend({
   value:      null,
   // pass in a class to style the input component directly
   inputClass: '',
+  type:       'text',
 
   asString: computed('value', {
     get(){
@@ -19,7 +20,13 @@ export default Component.extend({
         const trimmed = s.trim()
 
         if (trimmed.length){
-          all.push(trimmed)
+          if (this.type === 'number'){
+            const asInt = parseInt(trimmed, 10)
+
+            all.push(asInt)
+          } else {
+            all.push(trimmed)
+          }
         }
 
         return all

--- a/lib/shared/addon/components/input-array-as-string/component.js
+++ b/lib/shared/addon/components/input-array-as-string/component.js
@@ -1,0 +1,34 @@
+import Component from '@ember/component';
+import layout from './template';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  layout,
+  value:      null,
+  // pass in a class to style the input component directly
+  inputClass: '',
+
+  asString: computed('value', {
+    get(){
+      const { value = '' } = this;
+
+      return typeof value === 'string' ? value : value.join(', ')
+    },
+    set(key, val = ''){
+      const out = val.split(/,|, /g).reduce((all, s) => {
+        const trimmed = s.trim()
+
+        if (trimmed.length){
+          all.push(trimmed)
+        }
+
+        return all
+      }, [])
+
+      this.set('value', out)
+
+      return val
+    }
+
+  })
+})

--- a/lib/shared/addon/components/input-array-as-string/template.hbs
+++ b/lib/shared/addon/components/input-array-as-string/template.hbs
@@ -1,0 +1,4 @@
+{{input
+  value=asString
+  class=inputClass
+}}

--- a/lib/shared/addon/components/input-array-as-string/template.hbs
+++ b/lib/shared/addon/components/input-array-as-string/template.hbs
@@ -1,4 +1,5 @@
 {{input
   value=asString
   class=inputClass
+  type=type
 }}

--- a/lib/shared/addon/components/resource-list/component.js
+++ b/lib/shared/addon/components/resource-list/component.js
@@ -4,9 +4,6 @@ import layout from './template';
 import {
   computed,
   get,
-  set,
-  setProperties,
-  observer
 } from '@ember/object';
 import { parseSi } from '../../utils/parse-unit';
 
@@ -26,6 +23,7 @@ export default Component.extend({
       let memory = get(this.value, 'memory')
 
       if (!!memory){
+        // parseSi returns memory in Bytes- multiply by number of Bytes in MiB
         memory = parseSi(memory, 1024) / 1048576
       }
 
@@ -39,7 +37,6 @@ export default Component.extend({
       } else if (out.memory){
         delete out.memory
       }
-
       this.update(out)
 
       return val
@@ -52,6 +49,7 @@ export default Component.extend({
       let cpu = get(this.value, 'cpu')
 
       if (!!cpu){
+        // parse si returns cpu in CPUs - multiply by 1000 to get mCPUs
         cpu = parseSi(cpu) * 1000
       }
 
@@ -60,10 +58,10 @@ export default Component.extend({
     set(key, val){
       const out = { ...this.value }
 
-      if (!val && out.cpu){
-        delete out.cpu
-      } else {
+      if (!!val){
         out.cpu = `${ val }m`
+      } else if (out.cpu){
+        delete out.cpu
       }
       this.update(out)
 

--- a/lib/shared/addon/components/resource-list/component.js
+++ b/lib/shared/addon/components/resource-list/component.js
@@ -16,7 +16,7 @@ export default Component.extend({
     this._super(...arguments);
   },
 
-  // The form displays a MiB suffix but if edited by yaml this value may have been set with other units, eg '1GiB' should be converted to 1024 (MiB)
+  // The form displays a MiB suffix but if edited by yaml this value may have been set with other units, eg '1Gi' should be converted to 1024 (MiB)
   // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
   memory: computed('value', {
     get(){
@@ -33,7 +33,7 @@ export default Component.extend({
       const out = { ...this.value }
 
       if (!!val){
-        out.memory = `${ val }MiB`
+        out.memory = `${ val }Mi`
       } else if (out.memory){
         delete out.memory
       }

--- a/lib/shared/addon/components/resource-list/component.js
+++ b/lib/shared/addon/components/resource-list/component.js
@@ -1,0 +1,75 @@
+// Used to define limits or requests https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core
+import Component from '@ember/component';
+import layout from './template';
+import {
+  computed,
+  get,
+  set,
+  setProperties,
+  observer
+} from '@ember/object';
+import { parseSi } from '../../utils/parse-unit';
+
+export default Component.extend({
+  layout,
+  value: null,
+  type:  '',
+
+  init() {
+    this._super(...arguments);
+  },
+
+  // The form displays a MiB suffix but if edited by yaml this value may have been set with other units, eg '1GiB' should be converted to 1024 (MiB)
+  // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
+  memory: computed('value', {
+    get(){
+      let memory = get(this.value, 'memory')
+
+      if (!!memory){
+        memory = parseSi(memory, 1024) / 1048576
+      }
+
+      return memory
+    },
+    set(key, val){
+      const out = { ...this.value }
+
+      if (!!val){
+        out.memory = `${ val }MiB`
+      } else if (out.memory){
+        delete out.memory
+      }
+
+      this.update(out)
+
+      return val
+    }
+  }),
+
+  // The form displays a mCPU suffix but if set in YAML this may be another unit, eg '1' (CPU) should be converted to 1000 (mCPU)
+  cpu: computed('value', {
+    get(){
+      let cpu = get(this.value, 'cpu')
+
+      if (!!cpu){
+        cpu = parseSi(cpu) * 1000
+      }
+
+      return cpu
+    },
+    set(key, val){
+      const out = { ...this.value }
+
+      if (!val && out.cpu){
+        delete out.cpu
+      } else {
+        out.cpu = `${ val }m`
+      }
+      this.update(out)
+
+      return val
+    }
+  }),
+
+
+})

--- a/lib/shared/addon/components/resource-list/component.js
+++ b/lib/shared/addon/components/resource-list/component.js
@@ -11,6 +11,9 @@ export default Component.extend({
   layout,
   value: null,
   type:  '',
+  mode:  'new',
+
+  editing: computed.equal('mode', 'new'),
 
   init() {
     this._super(...arguments);

--- a/lib/shared/addon/components/resource-list/template.hbs
+++ b/lib/shared/addon/components/resource-list/template.hbs
@@ -4,12 +4,17 @@
     {{t "clusterNew.agentConfig.resourceRequirements.cpu" type=type}}
   </label>
       <div class="input-group">
-      {{input-integer
-        step="100"
+      {{#input-or-display
+        editable=editing
         value=cpu
-        classNames="form-control"
-        placeholder=(t "formSecurity.milliCpuReservation.placeholder")
       }}
+        {{input-integer
+          step="100"
+          value=cpu
+          classNames="form-control"
+          placeholder=(t "formSecurity.milliCpuReservation.placeholder")
+        }}
+      {{/input-or-display}}
         <div class="input-group-addon bg-default">
           {{t "generic.mCPU"}}
         </div>
@@ -20,12 +25,17 @@
       {{t "clusterNew.agentConfig.resourceRequirements.memory" type=type}}
     </label>
     <div class="input-group">
-      {{input-integer
-        step="1"
+      {{#input-or-display
+        editable=editing
         value=memory
-        classNames="form-control"
-        placeholder=(t "formSecurity.memoryReservation.placeholder")
       }}
+        {{input-integer
+          step="1"
+          value=memory
+          classNames="form-control"
+          placeholder=(t "formSecurity.memoryReservation.placeholder")
+        }}
+      {{/input-or-display}}
       <div class="input-group-addon bg-default">
         {{t "generic.mibibyte"}}
       </div>

--- a/lib/shared/addon/components/resource-list/template.hbs
+++ b/lib/shared/addon/components/resource-list/template.hbs
@@ -11,7 +11,7 @@
         placeholder=(t "formSecurity.milliCpuReservation.placeholder")
       }}
         <div class="input-group-addon bg-default">
-          {{t "formSecurity.milliCpuReservation.unit"}}
+          {{t "generic.mCPU"}}
         </div>
       </div>
     </div>

--- a/lib/shared/addon/components/resource-list/template.hbs
+++ b/lib/shared/addon/components/resource-list/template.hbs
@@ -1,0 +1,34 @@
+<div class="row">
+ <div class="col span-6">
+  <label class="acc-label">
+    {{t "clusterNew.agentConfig.resourceRequirements.cpu" type=type}}
+  </label>
+      <div class="input-group">
+      {{input-integer
+        step="100"
+        value=cpu
+        classNames="form-control"
+        placeholder=(t "formSecurity.milliCpuReservation.placeholder")
+      }}
+        <div class="input-group-addon bg-default">
+          {{t "formSecurity.milliCpuReservation.unit"}}
+        </div>
+      </div>
+    </div>
+  <div class="col span-6">
+    <label class="acc-label" for="input-milli-limit-memory">
+      {{t "clusterNew.agentConfig.resourceRequirements.memory" type=type}}
+    </label>
+    <div class="input-group">
+      {{input-integer
+        step="1"
+        value=memory
+        classNames="form-control"
+        placeholder=(t "formSecurity.memoryReservation.placeholder")
+      }}
+      <div class="input-group-addon bg-default">
+        {{t "generic.mibibyte"}}
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/shared/addon/components/scheduling-toleration/template.hbs
+++ b/lib/shared/addon/components/scheduling-toleration/template.hbs
@@ -58,7 +58,7 @@
                value=(or toleration.operator "Equal")
             }}
               {{searchable-select
-                class="form-control input-sm pt-0"
+                class="form-control input-sm"
                 content=operatorChoices
                 value=toleration.operator
               }}
@@ -92,7 +92,7 @@
                value=(or toleration.effect "*")
             }}
               {{searchable-select
-                class="form-control input-sm pt-0"
+                class="form-control input-sm"
                 allowCustom=true
                 content=effectChoices
                 value=toleration.effect

--- a/lib/shared/app/components/form-affinity-k8s/component.js
+++ b/lib/shared/app/components/form-affinity-k8s/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/form-affinity-k8s/component';

--- a/lib/shared/app/components/form-agent-config/component.js
+++ b/lib/shared/app/components/form-agent-config/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/form-agent-config/component';

--- a/lib/shared/app/components/form-match-expressions-k8s/component.js
+++ b/lib/shared/app/components/form-match-expressions-k8s/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/form-match-expressions-k8s/component';

--- a/lib/shared/app/components/form-node-affinity-k8s/component.js
+++ b/lib/shared/app/components/form-node-affinity-k8s/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/form-node-affinity-k8s/component';

--- a/lib/shared/app/components/form-node-selector-term-k8s/component.js
+++ b/lib/shared/app/components/form-node-selector-term-k8s/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/form-node-selector-term-k8s/component';

--- a/lib/shared/app/components/form-pod-affinity-k8s/component.js
+++ b/lib/shared/app/components/form-pod-affinity-k8s/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/form-pod-affinity-k8s/component';

--- a/lib/shared/app/components/form-pod-affinity-term-k8s/component.js
+++ b/lib/shared/app/components/form-pod-affinity-term-k8s/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/form-pod-affinity-term-k8s/component';

--- a/lib/shared/app/components/input-array-as-string/component.js
+++ b/lib/shared/app/components/input-array-as-string/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/input-array-as-string/component';

--- a/lib/shared/app/components/resource-list/component.js
+++ b/lib/shared/app/components/resource-list/component.js
@@ -1,0 +1,1 @@
+export { default } from 'shared/components/resource-list/component';

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -86,6 +86,7 @@ generic:
   noRating: No Rating
   node: Node
   none: None
+  mCPU: mCPU
   completedOf: "{completed} of {total}"
   owner: Owner
   paste: Paste

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3349,6 +3349,13 @@ clusterNew:
     viewYaml: View as YAML
     yaml: Edit as YAML
   agentConfig:
+    title:
+      cluster: Cluster Agent Configuration
+      fleet: Fleet Agent Configuration
+    banners:
+      advanced: This is advanced configuration for the {type} agent deployment. You should generally leave this as is.
+      resourceRequests: Pod requests and limits do not make use of a default configuration.
+      tolerations: Tolerations added here will be appended to the default tolerations dynamically configured by Rancher.
     resourceRequirements:
       label: Resource Requirements
       cpu: CPU {type}
@@ -3356,6 +3363,8 @@ clusterNew:
       requests: Requests
       limits: Limits
     overrideAffinity:
+      customize: Customize affinity rules
+      useDefault: Use default affinity rules defined by Rancher
       podAntiAffinity:
         title: Pod AntiAffinity
       podAffinity:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3378,9 +3378,26 @@ clusterNew:
           placeholder: e.g. 1
           label: Weight
         priority: Priority
+        matchExpressions:
+          add: Add Match Expression
+          operator: Operator
+          value: Value
+          key: Key
+          operatorOptions:
+            in: In list
+            notIn: Not in list
+            exists: Exists
+            doesNotExist: Does not exist
+            lt: Less than
+            gt: Greater than
       nodeAffinity:
         title: Node Affinity
         addTerm: Add Node Selector
+        nodeSelectorTerm:
+          typeOptions:
+            matchExpression: Expression
+            matchField: Field
+          type: Match Type
   aliyunack:
     shortLabel: Alibaba ACK
   amazoneks:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3360,16 +3360,21 @@ clusterNew:
         title: Pod AntiAffinity
       podAffinity:
         title: Pod Affinity
-        addRequired: Add Required Pod Affinity Term
-        addPreferred: Add Preferred Pod Affinity Term
+        addTerm: Add Pod Affinity Term
         topologyKey:
           label: Topology Key
           placeholder: e.g. failure-domain.beta.kubernetes.io/zone
+        typeOptions:
+          affinity: Affinity
+          antiAffinity: AntiAffinity
+          preferred: Preferred
+          required: Required
         namespaces:
           radioOptions:
             all: All Namespaces
             thisPod: This pod's namespace
             inList: 'Namespaces in this list:'
+        priority: Priority
       nodeAffinity:
         title: Node Affinity
   aliyunack:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3352,6 +3352,9 @@ clusterNew:
     title:
       cluster: Cluster Agent Configuration
       fleet: Fleet Agent Configuration
+    accordionDetail:
+      cluster: Customize scheduling fields and resource limits for the Rancher cluster agent
+      fleet: Customize scheduling fields and resource limits for the Rancher fleet agent  
     banners:
       advanced: This is advanced configuration for the {type} agent deployment. You should generally leave this as is.
       resourceRequests: Pod requests and limits do not make use of a default configuration.

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3347,6 +3347,13 @@ clusterNew:
     viewCancel: View as a Form
     viewYaml: View as YAML
     yaml: Edit as YAML
+  agentConfig:
+    resourceRequirements:
+      label: Resource Requirements
+      cpu: CPU {type}
+      memory: Memory {type}
+      requests: Requests
+      limits: Limits
   aliyunack:
     shortLabel: Alibaba ACK
   amazoneks:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3374,9 +3374,13 @@ clusterNew:
             all: All Namespaces
             thisPod: This pod's namespace
             inList: 'Namespaces in this list:'
+        weight:
+          placeholder: e.g. 1
+          label: Weight
         priority: Priority
       nodeAffinity:
         title: Node Affinity
+        addTerm: Add Node Selector
   aliyunack:
     shortLabel: Alibaba ACK
   amazoneks:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3356,7 +3356,7 @@ clusterNew:
       cluster: Customize scheduling fields and resource limits for the Rancher cluster agent
       fleet: Customize scheduling fields and resource limits for the Rancher fleet agent  
     banners:
-      advanced: This is advanced configuration for the {type} agent deployment. You should generally leave this as is.
+      advanced: This is the advanced configuration for the {type} agent deployment. You should generally leave this as is.
       resourceRequests: Pod requests and limits do not make use of a default configuration.
       tolerations: Tolerations added here will be appended to the default tolerations dynamically configured by Rancher.
     resourceRequirements:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3355,6 +3355,23 @@ clusterNew:
       memory: Memory {type}
       requests: Requests
       limits: Limits
+    overrideAffinity:
+      podAntiAffinity:
+        title: Pod AntiAffinity
+      podAffinity:
+        title: Pod Affinity
+        addRequired: Add Required Pod Affinity Term
+        addPreferred: Add Preferred Pod Affinity Term
+        topologyKey:
+          label: Topology Key
+          placeholder: e.g. failure-domain.beta.kubernetes.io/zone
+        namespaces:
+          radioOptions:
+            all: All Namespaces
+            thisPod: This pod's namespace
+            inList: 'Namespaces in this list:'
+      nodeAffinity:
+        title: Node Affinity
   aliyunack:
     shortLabel: Alibaba ACK
   amazoneks:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3380,9 +3380,9 @@ clusterNew:
           required: Required
         namespaces:
           radioOptions:
-            all: All Namespaces
+            all: All namespaces
             thisPod: This pod's namespace
-            inList: 'Namespaces in this list:'
+            inList: Pods in specific namespaces
         weight:
           placeholder: e.g. 1
           label: Weight


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/8534

Updated to include https://github.com/rancher/dashboard/issues/8535 - agent configuration for EKS hosted and imported clusters. 

This should more or less line up with the RKE2 implementation https://github.com/rancher/dashboard/pull/8643

For more details on desired behavior check out [RFC](https://confluence.suse.com/pages/viewpage.action?pageId=1185186511) and [Designs](https://confluence.suse.com/pages/viewpage.action?spaceKey=CU&title=Ability+to+configure+agent+deployments+per+cluster)

![Screen Shot 2023-04-20 at 2 13 30 PM](https://user-images.githubusercontent.com/42977925/233489157-88015089-fd80-41fd-8538-e470e90082c2.png)
![Screen Shot 2023-04-20 at 2 13 58 PM](https://user-images.githubusercontent.com/42977925/233489167-637bc833-76fb-42c6-8cf3-b6068baf2a18.png)
![Screen Shot 2023-04-20 at 2 14 05 PM](https://user-images.githubusercontent.com/42977925/233489170-872088b5-0bec-4afa-a181-6172034bfb19.png)
![Screen Shot 2023-04-20 at 2 14 18 PM](https://user-images.githubusercontent.com/42977925/233489173-272b5c73-b9e6-427c-a355-a5084d6b8ea2.png)
![Screen Shot 2023-04-20 at 2 14 44 PM](https://user-images.githubusercontent.com/42977925/233489179-72160404-1529-4707-a5dc-2ae7d1ccd054.png)
![Screen Shot 2023-04-20 at 2 34 41 PM](https://user-images.githubusercontent.com/42977925/233492802-47cf2251-905b-485a-a844-7a48b77a2d4d.png)

