### PR TITLE
set eks default kubernetes version to highest supported version

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-eks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-eks/component.js
@@ -80,7 +80,7 @@ export default Component.extend(ClusterDriver, {
     let config = get(this, 'cluster.eksConfig');
 
     if ( !config ) {
-      const kubernetesVersion = this.kubernetesVersionContent.firstObject;
+      const kubernetesVersion = this.versionChoices.firstObject.value
       const ngConfig = { ...DEFAULT_NODE_GROUP_CONFIG, };
 
       set(ngConfig, 'launchTemplate', this.globalStore.createRecord({
@@ -457,7 +457,7 @@ export default Component.extend(ClusterDriver, {
 
   versionChoices: computed('editing', 'kubernetesVersionContent', 'nodeGroupsVersionCollection.[]', function() {
     const {
-      config,
+      config = {},
       intl,
       kubernetesVersionContent,
       mode,


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/8721

Currently, the default kubernetes version set during eks provisioning is the highest version in the hardcoded list defined in `lib/shared/addon/utils/amazon.js`...we need to account for the possibility that the list includes versions outside the range defined in the `ui-k8s-default-version-range` setting. The dropdown shown in the EKS provisioning form properly filters versions using this setting, so I've updated the eks config initialization to reference this filtered list instead of the full hardcoded list. 

The current list of supported EKS versions doesn't include anything outside the default range in 2.7-head rancher instances. To test this PR:
* update the `ui-k8s-default-version-range` setting to `<=v1.23.x`
* print out `config.kubernetesVersion` in `lib/shared/addon/components/cluster-driver/driver-eks/template.hbs`
* go to create an EKS cluster and see that the print out is 1.24 whilst the component shows 1.23

This PR will unblock https://github.com/rancher/ui/pull/5009
