### PR TITLE
AKS MaxSurge: Address QA feedback

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -183,7 +183,7 @@ export const DEFAULT_AKS_NODE_POOL_CONFIG = {
   count:               1,
   enableAutoScaling:   false,
   maxPods:             110,
-  maxSurge:            '',
+  maxSurge:            '1',
   mode:                'System',
   name:                '',
   nodeLabels:          {},

--- a/lib/shared/addon/components/aks-node-pool-row/template.hbs
+++ b/lib/shared/addon/components/aks-node-pool-row/template.hbs
@@ -292,7 +292,6 @@
         {{t "clusterNew.azureaks.maxSurge.label"}}
       </label>
       <InputOrDisplay
-        @editable={{isNewNodePool}}
         @value={{nodePool.maxSurge}}
         @classesForDisplay="form-control-static"
       >

--- a/lib/shared/addon/components/cluster-driver/driver-aks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-aks/component.js
@@ -657,6 +657,30 @@ export default Component.extend(ClusterDriver, {
           errors.push(this.intl.t('clusterNew.azureaks.nodePools.errors.nameFormat'));
         }
 
+        // Validate maxSurge - must be percentage 1-100 or integer > 1
+        const maxSurge = np?.maxSurge;
+
+        if (maxSurge) {
+          let valid = false;
+
+          if (maxSurge.endsWith('%')) {
+            const value = maxSurge.substr(0, maxSurge.length - 1);
+            const intValue = parseInt(value, 10);
+
+            if (!isNaN(intValue)) {
+              valid = intValue > 1 && intValue < 100;
+            }
+          } else {
+            const intValue = parseInt(maxSurge, 10);
+
+            valid = !isNaN(intValue) && intValue > 1;
+          }
+
+          if (!valid) {
+            errors.push(this.intl.t('clusterNew.azureaks.nodePools.errors.maxSurge'));
+          }
+        }
+
         nodePoolErrors.push(npErr)
       });
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3726,6 +3726,7 @@ clusterNew:
         linuxName: Linux node pool names must be 1-11 characters.
         nameFormat: Node pool names must be all lower case, start with a letter and may only contain letters and numbers.
         windowsName: Windows node pool names must be 1-6 characters.
+        maxSurge: Max Surge must be either a percentage (1-100) or an integer greater than 1.
       name:
         label: Name
       nodeType:


### PR DESCRIPTION
This PR addresses feedback for https://github.com/rancher/dashboard/issues/8073.

It:

- Allows maxSurge to be editable after cluster creation
- Sets defaulr for maxSurge to 1
- Adds validation for maxSurge so it is either a percentage (1-100) or an integer greater than 1