### PR TITLE
Correct agent config matchExpressions values

### DIFF
--- a/lib/shared/addon/components/form-match-expressions-k8s/component.js
+++ b/lib/shared/addon/components/form-match-expressions-k8s/component.js
@@ -116,7 +116,7 @@ export default Component.extend({
 
     operatorChanged(match, selected){
       if (selected.value === 'Exists' || selected.value === 'DoesNotExist'){
-        match.match.value = []
+        match.match.values = []
       }
     }
   },

--- a/lib/shared/addon/components/form-match-expressions-k8s/template.hbs
+++ b/lib/shared/addon/components/form-match-expressions-k8s/template.hbs
@@ -84,18 +84,18 @@
         <td>
           {{#input-or-display
               editable=editing
-              value=match.match.value
+              value=match.match.values
           }}
           {{#if (or (eq match.match.operator "In") (eq match.match.operator "NotIn"))}}
             {{input-array-as-string
-              value=match.match.value
+              value=match.match.values
               inputClass='form-control input-sm'
             }}
             {{else if (or (eq match.match.operator "Gt") (eq match.match.operator "Lt"))}}
               {{input-array-as-string
                 type="number"
                 inputClass="form-control input-sm"
-                value=match.match.value
+                value=match.match.values
               }}
             {{else}}
             {{t "generic.na"}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3394,7 +3394,7 @@ clusterNew:
         matchExpressions:
           add: Add Match Expression
           operator: Operator
-          value: Value
+          value: Values
           key: Key
           operatorOptions:
             in: In list


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/8856

The `value` field wasn't populating with the default affinity values correctly because the key was wrong, should be `values` not `value`: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#nodeselectorrequirement-v1-core

I've also updated the label in the UI to more accurately reflect the spec: 
![Screen Shot 2023-05-11 at 3 35 45 PM](https://github.com/rancher/ui/assets/42977925/63d6b210-9454-416c-8441-5ae12edcf5e9)
