### PR TITLE
fix agent config cpu req unit formatting

### DIFF
--- a/lib/shared/addon/components/form-agent-config/template.hbs
+++ b/lib/shared/addon/components/form-agent-config/template.hbs
@@ -62,7 +62,7 @@
   {{#if (and (or (not useDefaultAffinity) (not editing) ) overrideAffinity) }}
     <BannerMessage
       @color="bg-warning mb-10"
-      @message={{t "clusterNew.agentConfig.banners.affinity"}}
+      @message={{t "clusterNew.agentConfig.banners.affinity" htmlSafe=true}}
     />
     <FormAffinityK8s
     @editing={{editing}}

--- a/lib/shared/addon/components/resource-list/component.js
+++ b/lib/shared/addon/components/resource-list/component.js
@@ -6,6 +6,7 @@ import {
   get,
 } from '@ember/object';
 import { parseSi } from '../../utils/parse-unit';
+import { convertToMillis } from '../../utils/util';
 
 export default Component.extend({
   layout,
@@ -51,12 +52,7 @@ export default Component.extend({
     get(){
       let cpu = get(this.value, 'cpu')
 
-      if (!!cpu){
-        // parse si returns cpu in CPUs - multiply by 1000 to get mCPUs
-        cpu = parseSi(cpu) * 1000
-      }
-
-      return cpu
+      return cpu ? convertToMillis(cpu.toString()) : null
     },
     set(key, val){
       const out = { ...this.value }


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/8871
https://github.com/rancher/dashboard/issues/8864

This PR updates the unit parsing/formatting for cpu requests to use the same utility function used for other mCPU inputs around the Ember UI. The previous solution implemented runs into problems w/ floating point arithmetic accuracy, eg when the value inputted is `1001m` this is parsed to `1.001` and `1.001*1000` returns `1000.99...`. 


![Screen Shot 2023-05-15 at 10 59 54 AM](https://github.com/rancher/ui/assets/42977925/64adc4c7-1797-4a5e-bf70-4447309c498a)
