### PR TITLE
AKS MaxSurge fixes

### DIFF
--- a/lib/shared/addon/components/aks-node-pool-row/component.js
+++ b/lib/shared/addon/components/aks-node-pool-row/component.js
@@ -59,6 +59,13 @@ export default Component.extend({
     const labels = get(this, 'nodePool.nodeLabels');
 
     set(this, 'hasLabels', Object.keys(labels || {}).length > 0);
+
+    // Ensure maxSurge is set - it may not be for an existing cluster created before the UI was updated to support maxSurge
+    const maxSurge = get(this, 'nodePool.maxSurge');
+    
+    if (!maxSurge) {
+      set(this, 'nodePool.maxSurge', 1);
+    }
   },
 
   actions: {

--- a/lib/shared/addon/components/aks-node-pool-row/component.js
+++ b/lib/shared/addon/components/aks-node-pool-row/component.js
@@ -62,7 +62,7 @@ export default Component.extend({
 
     // Ensure maxSurge is set - it may not be for an existing cluster created before the UI was updated to support maxSurge
     const maxSurge = get(this, 'nodePool.maxSurge');
-    
+
     if (!maxSurge) {
       set(this, 'nodePool.maxSurge', 1);
     }

--- a/lib/shared/addon/components/cluster-driver/driver-aks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-aks/component.js
@@ -668,12 +668,12 @@ export default Component.extend(ClusterDriver, {
             const intValue = parseInt(value, 10);
 
             if (!isNaN(intValue)) {
-              valid = intValue > 1 && intValue < 100;
+              valid = intValue >= 1 && intValue <= 100;
             }
           } else {
             const intValue = parseInt(maxSurge, 10);
 
-            valid = !isNaN(intValue) && intValue > 1;
+            valid = !isNaN(intValue) && intValue >= 1;
           }
 
           if (!valid) {


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/8073

- Fixes maxSurge can not be 1 or 1%
- Ensures maxSurge is set to 1 when editing a cluster provisioned prior to these AKS UI changes 
