### PR TITLE
Fix for edit of imported AKS cluster

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-aks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-aks/component.js
@@ -658,7 +658,12 @@ export default Component.extend(ClusterDriver, {
         }
 
         // Validate maxSurge - must be percentage 1-100 or integer > 1
-        const maxSurge = np?.maxSurge;
+        // NOTE: it can be a number in the case of editing an imported cluster - convert to string if so
+        let maxSurge = np?.maxSurge;
+
+        if (maxSurge && typeof(maxSurge) === 'number') {
+          maxSurge = `${ maxSurge }`;
+        }
 
         if (maxSurge) {
           let valid = false;


### PR DESCRIPTION
Fixes bug where you can not edit an imported AKS cluster.

In this case, maxSurge is a number, not a string, so we need to convert it.