### PR TITLE
Fix editing agent config in imported EKS clusters

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -1121,6 +1121,18 @@ export default Resource.extend(Grafana, ResourceUsage, {
         if (this.compareStringArrays(originalModel.model.originalCluster.annotations, this.annotations)) {
           options.data.annotations = this.annotations;
         }
+
+        const { clusterAgentDeploymentCustomization = {}, fleetAgentDeploymentCustomization = {} } = originalModel.model.originalCluster
+
+        const { clusterAgentDeploymentCustomization:newClusterAgentDeploymentCustomization = {}, fleetAgentDeploymentCustomization: newFleetAgentDeploymentCustomization = {} } = this;
+
+        if (JSON.stringify(clusterAgentDeploymentCustomization) !== JSON.stringify(newClusterAgentDeploymentCustomization)){
+          options.data.clusterAgentDeploymentCustomization = newClusterAgentDeploymentCustomization
+        }
+
+        if (JSON.stringify(fleetAgentDeploymentCustomization) !== JSON.stringify(newFleetAgentDeploymentCustomization)){
+          options.data.fleetAgentDeploymentCustomization = newFleetAgentDeploymentCustomization
+        }
       }
 
       return this._super(options);


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/8887

When pre-existing imported EKS clusters are saved, the upstream `eksConfig` spec is grabbed and only the difference between that and the `eksConfig` the user is attempting to save is sent in the network request:
https://github.com/rancher/ui/blob/a471895e9b78c36bbdf4435d74364b40e4bcbfd8/app/models/cluster.js#L1244-L1290

 This PR updates the cluster `save` method to check if the cluster or fleet agent configs have been changed and include them in the save request if so. I opted to just compare the entire config object; it felt a little extra to check each field within it for changes and this solution seems to work just fine from my own testing. 

We hit a similar problem saving labels and annotations previously: https://github.com/rancher/ui/pull/4950/files


#### Testing
1. Import an existing EKS cluster
2. Edit the cluster and modify the cluster and fleet agent configs, save and verify that the save request's payload includes the `clusterAgentDeploymentCustomization` and `fleetAgentDeploymentCustomization` fields.
4. Edit the cluster again and modify some agent config values added in step 2, save and verify that the modified cluster/fleet agent config values are included in the save request