### PR TITLE
Enable editing of members in the edit k3s cluster page

### DIFF
--- a/lib/shared/addon/components/cru-cluster/template.hbs
+++ b/lib/shared/addon/components/cru-cluster/template.hbs
@@ -64,10 +64,9 @@
           @message={{t "clusterPage.removeMemberNote"}}
         />
       {{/if}}
-
       <FormMembers
         @creator={{model.me}}
-        @editing={{and (and notView (not isK3sCluster)) (not isEksClusterPending)}}
+        @editing={{and (and notView) (not isEksClusterPending)}}
         @expanded={{expanded}}
         @isNew={{newCluster}}
         @memberConfig={{memberConfig}}


### PR DESCRIPTION


<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
- Button was disbaled via 'editing' = false
- I've gone through the history trying to find out why editing members of a k3s cluster (and previously imported rke2) was disabled
  - There's no info in any of the PRs or issues
  - Going to take the plunge and say we're find doing this
  - K3S editing disabled via https://github.com/rancher/ui/pull/3766/files
  - RKE2 editing disabled via https://github.com/rancher/ui/pull/4074/files
  - RKE2 editing enabled via https://github.com/rancher/ui/pull/4866


Linked Issues
======
Fixes https://github.com/rancher/dashboard/issues/8940

### K3S (with this fix)
![image](https://github.com/rancher/ui/assets/18697775/d02c6deb-9118-4135-b209-8bb42e924918)

Note - Both RKE (handled by this UI) and RKE2 (handled by dashboard) both allowed the removal of cluster members in their respective edit pages

### RKE (no fix required)
![image](https://github.com/rancher/ui/assets/18697775/0a506169-5fec-4b1b-bd58-12d9063de69e)

### RKE2 (no fix required)
![image](https://github.com/rancher/ui/assets/18697775/d0ab9d58-6465-4c70-82c1-e8d4d8c4f383)




