### PR TITLE
Allow legacy login page to be used by Rancher CLI

### DIFF
--- a/lib/login/addon/login/controller.js
+++ b/lib/login/addon/login/controller.js
@@ -42,7 +42,7 @@ export default Controller.extend({
   init() {
     this._super(...arguments);
 
-    // The Rancher CLI still uses /login - so show the login page if a query string is present 
+    // The Rancher CLI still uses /login - so show the login page if a query string is present
     const isDevelopment = get(this, 'app.environment') === 'development';
     const showLogin = isDevelopment || !!window.location.search;
 

--- a/lib/login/addon/login/controller.js
+++ b/lib/login/addon/login/controller.js
@@ -42,9 +42,11 @@ export default Controller.extend({
   init() {
     this._super(...arguments);
 
+    // The Rancher CLI still uses /login - so show the login page if a query string is present 
     const isDevelopment = get(this, 'app.environment') === 'development';
+    const showLogin = isDevelopment || !!window.location.search;
 
-    this.set('showLogin', isDevelopment);
+    this.set('showLogin', showLogin);
   },
 
   actions: {

--- a/lib/login/addon/login/route.js
+++ b/lib/login/addon/login/route.js
@@ -86,7 +86,7 @@ export default Route.extend({
 
   activate() {
     // Redirect to /dashboard in a production build
-    // The Rancher CLI still uses /login - so don't redirect if a query string is present 
+    // The Rancher CLI still uses /login - so don't redirect if a query string is present
     const isDevelopment = get(this, 'app.environment') === 'development';
     const showLogin = isDevelopment || !!window.location.search;
 

--- a/lib/login/addon/login/route.js
+++ b/lib/login/addon/login/route.js
@@ -86,7 +86,11 @@ export default Route.extend({
 
   activate() {
     // Redirect to /dashboard in a production build
-    if (get(this, 'app.environment') !== 'development') {
+    // The Rancher CLI still uses /login - so don't redirect if a query string is present 
+    const isDevelopment = get(this, 'app.environment') === 'development';
+    const showLogin = isDevelopment || !!window.location.search;
+
+    if (!showLogin) {
       const url = `${ window.location.origin }/dashboard`;
 
       window.location.replace(url);


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/8964

Re-enabled the legacy login page if the URL contains a query string - this ensures it can be used by the Rancher CLI.