### PR TITLE
Fix Azure node pool name length validation and error message

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-aks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-aks/component.js
@@ -644,7 +644,7 @@ export default Component.extend(ClusterDriver, {
 
         // aka.ms/aks-naming-rules
         if (npOs === 'Linux') {
-          if (!npName || npName.length > 11) {
+          if (!npName || npName.length > 12) {
             errors.push(this.intl.t('clusterNew.azureaks.nodePools.errors.linuxName'));
           }
         } else if (npOs === 'Windows') {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3724,7 +3724,7 @@ clusterNew:
       availablityZones:
         label: Node Availabilty Zones
       errors:
-        linuxName: Linux node pool names must be 1-11 characters.
+        linuxName: Linux node pool names must be 1-12 characters.
         nameFormat: Node pool names must be all lower case, start with a letter and may only contain letters and numbers.
         windowsName: Windows node pool names must be 1-6 characters.
         maxSurge: Max Surge must be either a percentage (1-100) or an integer greater than 1.


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======

Based on https://learn.microsoft.com/en-us/azure/aks/use-system-pools?tabs=azure-cli#limitations:

``The name of a node pool may only contain lowercase alphanumeric characters and must begin with a lowercase letter. For Linux node pools, the length must be between 1 and 12 characters. For Windows node pools, the length must be between one and six characters.``

![image](https://github.com/rancher/ui/assets/40443040/78016caf-74f2-472a-a886-4d5161b8dac1)

meaning there is a mismatch in nodepool name length validation between Rancher UI and AKS API. Since Azure documentation states that the length of nodepool name must be 12 or fewer characters, this PR changes Azure nodepool name length validation from 11 chars long to 12. 


Types of changes
======


What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======

https://github.com/rancher/aks-operator/issues/209

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
