### PR TITLE
Ensure embedded ember pages in dashboard work with cypress / e2e

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -2,6 +2,7 @@ import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
+import { isEmbedded, dashboardWindow } from 'shared/utils/util';
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;
@@ -11,9 +12,7 @@ export default class App extends Application {
   Resolver = Resolver;
 
   ready = function() {
-    const isEmbedded = window.top !== window;
-
-    if (isEmbedded) {
+    if (isEmbedded()) {
       // Add a class 'hide-when-embedded' which can be used to hide elements
       // that we don't want to show up when embedded
       const head = document.getElementsByTagName('head')[0];
@@ -29,7 +28,7 @@ export default class App extends Application {
       head.appendChild(styl);
 
       // Notify outer window that the app has loaded when we are embedded
-      window.top.postMessage({ action: 'ready' });
+      dashboardWindow().postMessage({ action: 'ready' });
     }
   };
 

--- a/app/application/controller.js
+++ b/app/application/controller.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import { run } from '@ember/runloop';
 import { observer, set } from '@ember/object';
+import { isEmbedded } from 'shared/utils/util';
 
 export default Controller.extend({
   settings: service(),
@@ -31,9 +32,7 @@ export default Controller.extend({
       run.backburner.DEBUG = true;
     }
 
-    const embedded = window.top !== window;
-
-    set(this, 'isEmbedded', embedded);
+    set(this, 'isEmbedded', isEmbedded());
   },
 
   // currentRouteName is set by Ember.Router

--- a/app/application/route.js
+++ b/app/application/route.js
@@ -3,6 +3,7 @@ import Route from '@ember/routing/route';
 import { cancel, next, schedule } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import C from 'ui/utils/constants';
+import { isEmbedded, dashboardWindow } from 'shared/utils/util';
 
 export default Route.extend({
   access:   service(),
@@ -144,10 +145,9 @@ export default Route.extend({
     logout(transition, errorMsg) {
       let session = get(this, 'session');
       let access = get(this, 'access');
-      const isEmbedded = window.top !== window;
 
-      if ( isEmbedded ) {
-        window.top.postMessage({ action: 'logout' });
+      if ( isEmbedded() ) {
+        dashboardWindow().postMessage({ action: 'logout' });
 
         return;
       }
@@ -221,10 +221,8 @@ export default Route.extend({
 
   notifyAction(action, state) {
     // If embedded, notify outer frame
-    const isEmbedded = window !== window.top;
-
-    if (isEmbedded) {
-      window.top.postMessage({
+    if (isEmbedded()) {
+      dashboardWindow().postMessage({
         action,
         state
       });

--- a/app/authenticated/controller.js
+++ b/app/authenticated/controller.js
@@ -5,6 +5,7 @@ import Controller, { inject as controller } from '@ember/controller';
 import C from 'ui/utils/constants';
 import { computed } from '@ember/object';
 import { on } from '@ember/object/evented';
+import { isEmbedded } from 'shared/utils/util';
 
 export default Controller.extend({
   settings:    service(),
@@ -33,9 +34,7 @@ export default Controller.extend({
       }
 
       // Add class to hide Page Header and Footer when embedded
-      const embedded = window.top !== window;
-
-      if (embedded) {
+      if (isEmbedded()) {
         $('BODY').addClass('embedded'); // eslint-disable-line
       }
     });

--- a/app/authenticated/embed/route.js
+++ b/app/authenticated/embed/route.js
@@ -1,12 +1,13 @@
 import Route from '@ember/routing/route';
+import { isEmbedded, dashboardWindow } from 'shared/utils/util';
 
 export default Route.extend({
   redirect(params) {
     if (params.path.indexOf('dashboard') === 0) {
-      if (window.top !== window) {
+      if (isEmbedded()) {
         const page = params.path.substr(9);
 
-        window.top.postMessage({
+        dashboardWindow().postMessage({
           action: 'dashboard',
           page
         });

--- a/app/authenticated/project/controller.js
+++ b/app/authenticated/project/controller.js
@@ -3,6 +3,7 @@ import { computed, observer } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import C from 'ui/utils/constants';
+import { isEmbedded } from 'shared/utils/util';
 
 // const NONE = 'none';
 // const WORKLOAD = 'workload';
@@ -29,10 +30,7 @@ export default Controller.extend({
     this._super(...arguments);
     this.set('nodes', this.get('store').all('node'));
     this.set('expandedInstances', []);
-
-    const notEmbedded = window.top === window;
-
-    this.set('notEmbedded', notEmbedded);
+    this.set('notEmbedded', !isEmbedded());
   },
 
   actions: {

--- a/app/authenticated/route.js
+++ b/app/authenticated/route.js
@@ -7,6 +7,7 @@ import { all as PromiseAll, resolve } from 'rsvp';
 import { compare, isDevBuild } from 'shared/utils/parse-version';
 import Preload from 'ui/mixins/preload';
 import C from 'ui/utils/constants';
+import { isEmbedded } from 'shared/utils/util';
 
 const CHECK_AUTH_TIMER = 60 * 10 * 1000;
 
@@ -150,7 +151,6 @@ export default Route.extend(Preload, {
     }
 
     // Don't show any modals when embedded
-    const isEmbedded = window.top !== window;
 
     if ( !get(this, `cookies.${ C.COOKIE.REDIRECTED }`) ) {
       // Send users to dashboard, if there's no redirect cookie, and not embedded
@@ -158,7 +158,7 @@ export default Route.extend(Preload, {
       this.cookies.set(C.COOKIE.REDIRECTED, true);
 
       // If isEmbedded then you're already in Dashboard, so just set the cookie.
-      if ( !isEmbedded ) {
+      if ( !isEmbedded() ) {
         window.location.href = get(this, 'scope.dashboardBase');
 
         return;

--- a/app/components/security-header/component.js
+++ b/app/components/security-header/component.js
@@ -1,8 +1,9 @@
 import Component from '@ember/component';
+import { isEmbedded } from 'shared/utils/util';
 
 import layout from './template';
 
 export default Component.extend({
   layout,
-  showLegacyMessage: window.top !== window,
+  showLegacyMessage: isEmbedded(),
 });

--- a/app/initializers/route-spy.js
+++ b/app/initializers/route-spy.js
@@ -1,21 +1,20 @@
 import Router from '@ember/routing/router';
+import { isEmbedded, dashboardWindow } from 'shared/utils/util';
 
 export function initialize() {
-  const isEmbedded = window !== window.top;
-
   let stylesheet = null;
 
-  if (isEmbedded) {
+  if (isEmbedded()) {
     Router.reopen({
       notifyTopFrame: function() {
-        window.top.postMessage({
+        dashboardWindow().postMessage({
           action: 'did-transition',
           url:    this.currentURL
         })
       }.on('didTransition'),
 
       willTranstionNotify: function(transition) {
-        window.top.postMessage({
+        dashboardWindow().postMessage({
           action: 'before-navigation',
           target: transition.targetName,
         })
@@ -32,7 +31,7 @@ export function initialize() {
 
         // If the route being asked for is already loaded, send a did-transition event
         if (router.currentRouteName === msg.name) {
-          window.top.postMessage({
+          dashboardWindow().postMessage({
             action: 'did-transition',
             url:    router.urlFor(msg.name)
           })

--- a/lib/istio/addon/components/modal-delete-istio/component.js
+++ b/lib/istio/addon/components/modal-delete-istio/component.js
@@ -6,6 +6,7 @@ import ModalBase from 'ui/mixins/modal-base';
 import layout from './template';
 import { all as PromiseAll } from 'rsvp';
 import $ from 'jquery';
+import { isEmbedded, dashboardWindow } from 'shared/utils/util';
 
 export default Component.extend(ModalBase, {
   settings:       service(),
@@ -46,10 +47,8 @@ export default Component.extend(ModalBase, {
       }
 
       PromiseAll(promises).then(() => {
-        const isEmbedded = window.top !== window;
-
-        if (isEmbedded) {
-          window.top.postMessage({ action: 'reload' });
+        if (isEmbedded()) {
+          dashboardWindow().postMessage({ action: 'reload' });
         } else {
           setTimeout(() => {
             window.location.href = window.location.href; // eslint-disable-line no-self-assign

--- a/lib/monitoring/addon/components/cluster-dashboard-tabs/component.js
+++ b/lib/monitoring/addon/components/cluster-dashboard-tabs/component.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { get, computed, set } from '@ember/object';
 import layout from './template';
 import { inject as service } from '@ember/service';
+import { isEmbedded } from 'shared/utils/util';
 
 export default Component.extend({
   scope:    service(),
@@ -16,9 +17,7 @@ export default Component.extend({
   init() {
     this._super(...arguments);
 
-    const embedded = window.top !== window;
-
-    set(this, 'isEmbedded', embedded);
+    set(this, 'isEmbedded', isEmbedded());
   },
 
   largeScale: computed('scope.currentCluster.nodes.length', function() {

--- a/lib/monitoring/addon/components/cluster-dashboard/component.js
+++ b/lib/monitoring/addon/components/cluster-dashboard/component.js
@@ -11,6 +11,8 @@ import CatalogUpgrade from 'shared/mixins/catalog-upgrade';
 import { next } from '@ember/runloop';
 const MONITORING_TEMPLATE = 'system-library-rancher-monitoring';
 
+import { isEmbedded } from 'shared/utils/util';
+
 export default Component.extend(CatalogUpgrade, {
   intl:        service(),
   scope:       service(),
@@ -32,9 +34,7 @@ export default Component.extend(CatalogUpgrade, {
   init() {
     this._super(...arguments);
 
-    const embedded = window.top !== window;
-
-    set(this, 'isEmbedded', embedded);
+    set(this, 'isEmbedded', isEmbedded());
   },
 
   actions: {

--- a/lib/monitoring/addon/index/controller.js
+++ b/lib/monitoring/addon/index/controller.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { get, set, computed } from '@ember/object';
 import Controller from '@ember/controller';
 import C from 'shared/utils/constants';
+import { isEmbedded } from 'shared/utils/util';
 
 const BANNER_NAME = 'dashboard-explorer';
 
@@ -42,8 +43,7 @@ export default Controller.extend({
 
   showBanner: computed(`prefs.${ C.PREFS.CLOSED_BANNER }`, function() {
     const closed = get(this, `prefs.${ C.PREFS.CLOSED_BANNER }`) || [];
-    const embedded = window !== window.top;
 
-    return !embedded && !closed.includes(BANNER_NAME);
+    return !isEmbedded() && !closed.includes(BANNER_NAME);
   }),
 });

--- a/lib/shared/addon/components/accordion-list-item/component.js
+++ b/lib/shared/addon/components/accordion-list-item/component.js
@@ -70,6 +70,8 @@ export default Component.extend({
   expandAll:    false,
   everExpanded: false,
 
+  componentId: null,
+
   init() {
     this._super(...arguments);
     scheduleOnce('render', this, this.setupExpandOnInit);

--- a/lib/shared/addon/components/accordion-list-item/template.hbs
+++ b/lib/shared/addon/components/accordion-list-item/template.hbs
@@ -1,4 +1,4 @@
-<div class="accordion-header" {{action "doExpand"}}>
+<div class="accordion-header" {{action "doExpand"}} data-testid="{{componentId}}__header">
   <div class="expand">
     {{#if showExpand}}
       <i role="button" class="icon icon-play eased btn bg-transparent {{if expanded 'icon-rotate-90'}}">
@@ -23,7 +23,7 @@
     </div>
   {{/if}}
 </div>
-<div class="accordion-content {{unless expanded 'hide'}}">
+<div class="accordion-content {{unless expanded 'hide'}}" data-testid="{{componentId}}__content">
   {{#if everExpanded}}
     {{yield this}}
   {{/if}}

--- a/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-rke/template.hbs
@@ -1414,6 +1414,7 @@
          expandOnInit=true
          expandAll=al.expandAll
          expand=(action expandFn)
+         componentId="cluster-driver__role"
       }}
         <CustomCommand @token={{token}} @isLinux={{isLinux}}/>
       {{/accordion-list-item}}
@@ -1479,7 +1480,7 @@
   {{/if}}
 {{else}}
   <div class="footer-actions">
-    <button class="btn bg-primary" type="button" {{action "close"}}>
+    <button data-testid="driver-rke__done" class="btn bg-primary" type="button" {{action "close"}}>
       {{t "clusterNew.rke.done"}}
     </button>
   </div>

--- a/lib/shared/addon/components/cru-cluster/template.hbs
+++ b/lib/shared/addon/components/cru-cluster/template.hbs
@@ -48,6 +48,7 @@
        everExpanded=true
        expanded=expanded
        expand=(action expandFn)
+       componentId="cru-cluster__members"
     }}
       {{#if model.cluster.internal}}
         <BannerMessage
@@ -76,6 +77,7 @@
         @roles={{model.roleTemplates}}
         @type="cluster"
         @users={{model.users}}
+        data-testid="cru-cluster__members__form"
       />
     {{/accordion-list-item}}
 

--- a/lib/shared/addon/components/form-members/template.hbs
+++ b/lib/shared/addon/components/form-members/template.hbs
@@ -10,14 +10,14 @@
     </thead>
     <tbody>
       {{#if isNew}}
-        {{#each defaultRoles as |defRole|}}
-          <ProjectMemberRow @principal={{creator}} @roleTemplate={{defRole}} @pageType={{primaryResource.type}}
+        {{#each defaultRoles as |defRole index|}}
+          <ProjectMemberRow data-testid="form-members__default__{{index}}" @principal={{creator}} @roleTemplate={{defRole}} @pageType={{primaryResource.type}}
             @noUpdate={{true}} @isCreatorMember={{true}} />
         {{/each}}
       {{/if}}
-      {{#each memberArray as |member|}}
+      {{#each memberArray as |member index|}}
         {{#unless member.pendingDelete}}
-          <ProjectMemberRow @member={{member}} @editing={{editing}} @resource={{primaryResource}}
+          <ProjectMemberRow data-testid="form-members__pending__{{index}}" @member={{member}} @editing={{editing}} @resource={{primaryResource}}
             @roles={{filteredRoles}} @users={{filteredUsers}} @pageType={{primaryResource.type}}
             @remove={{action "removeMember" }} />
         {{/unless}}

--- a/lib/shared/addon/components/form-name-description/template.hbs
+++ b/lib/shared/addon/components/form-name-description/template.hbs
@@ -1,8 +1,8 @@
 {{#if editing}}
   <div class="{{rowClass}}">
-    <div class="{{if (or hasBlock descriptionExpanded) bothColClass colClass}}">
+    <div class="{{if (or hasBlock descriptionExpanded) bothColClass colClass}}" data-testId="form-name-description__name">
 
-      <label for="{{concat elementId "-form-name"}}" class="acc-label pb-5">
+      <label for="{{concat elementId "-form-name"}}" class="acc-label pb-5" >
         {{t nameLabel}}{{#if nameRequired}}{{field-required}}{{/if}}
       </label>
         {{#if (and descriptionShown (not descriptionExpanded))}}

--- a/lib/shared/addon/components/modal-add-custom-roles/template.hbs
+++ b/lib/shared/addon/components/modal-add-custom-roles/template.hbs
@@ -44,6 +44,7 @@
      detail=(t "formScopedRoles.description" type=type)
      expandOnInit=true
      showExpand=false
+     componentId="modal-add-custom-roles__accordion"
   }}
     <div class="pl-20">
       {{#each filteredRoles as |row idx|}}

--- a/lib/shared/addon/growl/service.js
+++ b/lib/shared/addon/growl/service.js
@@ -4,7 +4,7 @@ import 'jgrowl';
 import { setProperties } from '@ember/object';
 import { escapeHtml } from 'shared/utils/util';
 import { set } from '@ember/object';
-
+import { isEmbedded } from 'shared/utils/util';
 
 export default Service.extend({
   app:  service(),
@@ -16,9 +16,8 @@ export default Service.extend({
   init() {
     this._super(...arguments);
     this.initjGrowlDefaults();
-    const isEmbedded = window !== window.top;
 
-    set(this, 'isEmbedded', isEmbedded);
+    set(this, 'isEmbedded', isEmbedded());
   },
 
   initjGrowlDefaults() {

--- a/lib/shared/addon/scope/service.js
+++ b/lib/shared/addon/scope/service.js
@@ -6,6 +6,7 @@ import SubscribeGlobal from 'shared/utils/subscribe-global';
 import SubscribeCluster from 'shared/utils/subscribe-cluster';
 import SubscribeProject from 'shared/utils/subscribe-project';
 import { Promise as EmberPromise } from 'rsvp';
+import { isEmbedded } from 'shared/utils/util';
 
 export default Service.extend({
   access:           service(),
@@ -216,7 +217,7 @@ export default Service.extend({
     } else {
       link = '/dashboard/';
 
-      if (window.top !== window) {
+      if (isEmbedded()) {
         link = '/k/dashboard/';
       }
     }
@@ -236,7 +237,7 @@ export default Service.extend({
 
     // When embedded, we don't want to open dashboard links in the iframe
     // this mechanism provides a way for us to intercept those
-    if (window.top !== window) {
+    if (isEmbedded()) {
       link = '/k/dashboard/';
     }
 

--- a/lib/shared/addon/user-theme/service.js
+++ b/lib/shared/addon/user-theme/service.js
@@ -3,6 +3,7 @@ import { cancel, later } from '@ember/runloop';
 import Service, { inject as service } from '@ember/service';
 import C from 'shared/utils/constants';
 import { isEmpty } from '@ember/utils';
+import { isEmbedded } from 'shared/utils/util';
 
 export default Service.extend({
   prefs:        service(),
@@ -18,12 +19,11 @@ export default Service.extend({
     const personalTheme = cachedTheme ? `ui-${ cachedTheme }` : undefined;
     var defaultTheme = this.get('session').get(C.PREFS.THEME) || personalTheme;
     var userTheme    = this.get(`prefs.${ C.PREFS.THEME }`);
-    const isEmbedded = window.top !== window;
 
     if ( userTheme ) {
       this.setTheme(userTheme, false);
     } else { // no user pref'd theme
-      if (isEmbedded && isEmpty(defaultTheme)) {
+      if (isEmbedded() && isEmpty(defaultTheme)) {
         // on an upgrade if the user theme pref was never set and we're in the dashboard which defaults to ui-auto
         defaultTheme = 'ui-auto';
       }

--- a/lib/shared/addon/utils/util.js
+++ b/lib/shared/addon/utils/util.js
@@ -427,6 +427,17 @@ export function isNumeric(str) {
   return (`${ str }`).match(/^([0-9]+\.)?[0-9]*$/);
 }
 
+export function isEmbedded() {
+  // window.top will either be ember, dashboard... or the cypress runner
+  // Only time in which we're not embedded is if top window has Ember
+  return !window.top.Ember
+}
+
+export function dashboardWindow() {
+  // window.parent will always be the dashboard (only used in embedded mode)
+  return window.parent;
+}
+
 export function hostname(str) {
   return (str || '').trim().replace(/^[a-z0-9]+:\/+/i, '').replace(/\/.*$/g, '');
 }
@@ -604,6 +615,7 @@ var Util = {
   camelToTitle,
   convertToMillis,
   constructUrl,
+  dashboardWindow,
   download,
   deepCopy,
   escapeHtml,
@@ -616,6 +628,7 @@ var Util = {
   formatPercent,
   hostname,
   isBadTld,
+  isEmbedded,
   isNumeric,
   isPrivate,
   keysToCamel,

--- a/lib/shared/app/utils/util.js
+++ b/lib/shared/app/utils/util.js
@@ -29,6 +29,8 @@ export {
   uniqKeys,
   camelToTitle,
   isNumeric,
+  isEmbedded,
+  dashboardWindow,
   requiredError,
   parseCamelcase,
   extractUniqueStrings,


### PR DESCRIPTION
- Create helper functions to determine if running in embedded mode, and the target window for dashboard messages
  - Wasn't sure where to put this, hopefully choice the right location
- isEmbedded `window.top !== window` weirdly didn't work in cypress runner, so now we check if window.top has ember available (only scenario where isEmbedded is false)
- window used for messaging dashboard is now window.parent, window.top can be cypress runner

Note - This should merge after we release /  branch 2.7q2

Note 2 - Snuck in some identifiers for e2e tests. There must be a nice way to assign attributes to top level elements used by elemental components... stooped to use the easier class one instead 