### PR TITLE
Ensure new EKS regions can be selected when validating creds

### DIFF
--- a/lib/shared/addon/utils/amazon.js
+++ b/lib/shared/addon/utils/amazon.js
@@ -624,8 +624,9 @@ export const INSTANCE_TYPES = [
   },
 ];
 
-// These need to match the supported list in docker-machine:
-// https://github.com/docker/machine/blob/master/drivers/amazonec2/region.go
+// Supports
+// 1) Validating AWS creds (used in both EC2 and EKS world)
+// 2) Managing EC2 Nodes. See https://cloud-images.ubuntu.com/locator/ec2/ (and https://github.com/rancher/machine/blob/master/drivers/amazonec2/region.go#L13)
 export const REGIONS = [
   'af-south-1',
   'ap-northeast-1',
@@ -633,9 +634,12 @@ export const REGIONS = [
   'ap-southeast-1',
   'ap-southeast-2',
   'ap-southeast-3',
+  'ap-southeast-4',
   'ap-east-1',
   'ap-south-1',
+  'ap-south-2',
   'me-south-1',
+  'me-central-1',
   'ca-central-1',
   'cn-north-1',
   'cn-northwest-1',
@@ -644,7 +648,9 @@ export const REGIONS = [
   'eu-west-2',
   'eu-west-3',
   'eu-central-1',
+  'eu-central-2',
   'eu-south-1',
+  'eu-south-2',
   'sa-east-1',
   'us-east-1',
   'us-east-2',
@@ -654,6 +660,8 @@ export const REGIONS = [
   'us-gov-east-1',
 ];
 
+// Supports
+// 1) Managing EKS clusters. See https://docs.aws.amazon.com/general/latest/gr/eks.html
 export const EKS_REGIONS = [
   'af-south-1',
   'ap-northeast-1',


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
- This means when users create creds they can be validated against one of the new regions 
- This also means users can select these creds when creating EC2 based RKE1 clusters

Linked Issues
======
https://github.com/rancher/dashboard/issues/8701

Further comments
======
I haven't managed to successfully test EKS OR RKE1 EC2 in these regions, they're blocked to me