### PR TITLE
[WIP]Allow saving AKS node pools that dont have taints

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -187,7 +187,6 @@ export const DEFAULT_AKS_NODE_POOL_CONFIG = {
   mode:                'System',
   name:                '',
   nodeLabels:          {},
-  nodeTaints:          [],
   orchestratorVersion: '',
   osDiskSizeGB:        128,
   osDiskType:          'Managed',

--- a/lib/shared/addon/components/aks-node-pool-row/component.js
+++ b/lib/shared/addon/components/aks-node-pool-row/component.js
@@ -85,7 +85,7 @@ export default Component.extend({
           return `${ t.key }=${ t.value }:${ t.effect }`;
         }));
       } else {
-        set(this, 'nodePool.nodeTaints', []);
+        delete this.nodePool.nodeTaints
       }
     }
   },


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/41927

I'm not sure what a complete solution here would be. This PR fixes the scenario outlined in the issue above. It creates a new problem in which taints can't be removed from node pools. Initially it looked like taints were removed but after a few minutes they re-appeared.

 This has to do with how AKS/EKS/GKE clusters are saved: only changed values are sent in the request (https://github.com/rancher/ui/pull/4161) and other existing values are preserved. So if we edit a node pool with taints and delete the `nodeTaints` key, the previous configuration of taints remains. I got around this with agent configs by sending `null` instead of deleting the key; however, [this function](https://github.com/rancher/ui/pull/4161) will replace the `null` nodeTaint value with an empty array, and we're back to the problem described in https://github.com/rancher/rancher/issues/41927. I'm reluctant to mess with that null->[] behavior because I don't understand why it's been done in the first place; it was added in the same PR linked above but the PR description doesn't seem to justify it.