### PR TITLE
add aks node resource group input field and length validation

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-aks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-aks/component.js
@@ -610,15 +610,17 @@ export default Component.extend(ClusterDriver, {
     let model = get(this, 'cluster');
     let clusterErrors = model.validationErrors() || [];
     const nodePoolErrors = this.validateNodePools();
-
     const vnetSet = !!get(this, 'config.virtualNetwork');
-
     if (vnetSet) {
       clusterErrors = clusterErrors.concat(this.validateVnetInputs());
     }
 
     if ( this.isNew && !get(this, 'config.resourceGroup') ) {
       clusterErrors.push(intl.t('validation.required', { key: intl.t('clusterNew.azureaks.resourceGroup.label') }));
+    }
+
+    if(get(this, 'config.nodeResourceGroup') && get(this, 'config.nodeResourceGroup')?.length > 80) {
+      clusterErrors.push(intl.t('clusterNew.azureaks.errors.nodeResourceGroup'))
     }
 
     if ( this.isNew && !get(this, 'config.dnsPrefix') ) {

--- a/lib/shared/addon/components/cluster-driver/driver-aks/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-aks/template.hbs
@@ -174,6 +174,36 @@
                 />
               </InputOrDisplay>
             </div>
+            <div class="col span-6">
+              <label class="acc-label" for="azureaks-node-resource-group">
+                {{t "clusterNew.azureaks.nodeResourceGroup.label"}}
+                <TooltipElement
+                  @type="tooltip-basic"
+                  @model={{t "clusterNew.azureaks.nodeResourceGroup.helpText"}}
+                  @tooltipTemplate="tooltip-static"
+                  @aria-describedby="tooltip-base"
+                  @tooltipFor="nodeResourceGroup"
+                  @placement="top"
+                >
+                  <i class="icon icon-info"></i>
+                </TooltipElement>
+              </label>
+              <InputOrDisplay
+                @editable={{isNewOrEditable}}
+                @value={{config.nodeResourceGroup}}
+                @classesForDisplay="form-control-static"
+              >
+                <Input
+                  @classNames="form-control"
+                  @id="azureaks-node-resource-group"
+                  @placeholder={{t
+                    "clusterNew.azureaks.nodeResourceGroup.placeholder"
+                  }}
+                  @type="text"
+                  @value={{mut config.nodeResourceGroup}}
+                />
+              </InputOrDisplay>
+            </div>
             {{! removed until windows support returns }}
             {{!-- <div class="col span-6">
               <label class="acc-label" for="azureaks-windows-admin-username">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3612,6 +3612,7 @@ clusterNew:
         parsedDockerBridgeCidr: Docker bridge address can not overlap with the selected Virtual Network or the Kubernetes service address range
         parsedServiceCidr: Kubernetes service address range must fall within the selected Virtual Network range.
         serviceCidr: Kubernetes service address range must be valid CIDR format.
+      nodeResourceGroup: Node resource group name cannot exceed 80 characters.
     image:
       label: Image
       placeholder: canonical:UbuntuServer:18.04-LTS:latest
@@ -3722,6 +3723,10 @@ clusterNew:
         primary: Primary Pool - System
         system: System
         user: User
+    nodeResourceGroup:
+      helpText: The cluster resource group contains the Kubernetes Service resource. The node resource group contains all infrastructure resources associated with the cluster. If left blank, Azure will automatically create a name in the format MC_<resource-group1>_<cluster-name>_<location>. This value cannot exceed 80 characters.
+      label: Node Resource Group
+      placeholder: aks-node-resource-group
     openPort:
       label: Open Port
       placeholder: Comma-separated, e.g. 80,443


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/8980

This PR adds an input to the AKS provisioning form for the new `nodeResourceGroup` field.  You can read more about what this field is here https://github.com/rancher/aks-operator/pull/210. Per the backend issue, this field is only editable on create (available "when creating a new aks cluster"); this is in line with the cluster resource group name.

To test the new field:
1. Begin provisioning a new AKS cluster: required fields are name, resource group and dns prefix - use something like `<initials>-resource-group` and `<initials>-dns-prefix`
2. Add a node resource group value that exceeds 80 characters
3. Verify that the cluster does not save and an error is shown
4. Reduce the length of the node resource group 
5. Save and verify that the POST request payload and response both include `aksConfig.nodeResourceGroup`
6. Once the cluster begins provisioning, navigate to https://portal.azure.com/#view/HubsExtension/BrowseResourceGroups and observe that both the cluster and node resource group names you configured have been created
7. Edit the cluster and verify that the field is displayed, but uneditable

To test default behavior, verify that an AKS cluster will provision without configuring the node resource group field. 

![Screen Shot 2023-07-14 at 12 12 02 PM](https://github.com/rancher/ui/assets/42977925/3722d8f3-4f0c-44ff-b616-bac388eb6936)
![Screen Shot 2023-07-14 at 12 12 10 PM](https://github.com/rancher/ui/assets/42977925/8d253d3f-9b57-4bd5-b0cd-d5c1cf7359ee)
![Screen Shot 2023-07-14 at 12 12 49 PM](https://github.com/rancher/ui/assets/42977925/99b7ff50-c9b1-4d0c-b031-5a26cbbca130)

view mode:
![Screen Shot 2023-07-14 at 12 11 05 PM](https://github.com/rancher/ui/assets/42977925/f94f1363-ad21-478c-92d7-7223694e2242)