### PR TITLE
Update Windows Container Samples Repository URL

### DIFF
--- a/app/components/container/form-image/component.js
+++ b/app/components/container/form-image/component.js
@@ -5,7 +5,7 @@ import layout from './template';
 import { get, set, observer, computed } from '@ember/object'
 
 const LINUX_LAST_CONTAINER = 'ubuntu:xenial'
-const WINDOWS_LAST_CONTAINER = 'mcr.microsoft.com/dotnet/core/samples:aspnetapp'
+const WINDOWS_LAST_CONTAINER = 'mcr.microsoft.com/dotnet/samples:aspnetapp'
 // Remember the last value and use that for new one
 var lastContainer;
 


### PR DESCRIPTION
Update to the current samples repo. The old samples repro will be deleted.

See: https://github.com/dotnet/dotnet-docker/issues/4755

FYI on other breaking changes: https://github.com/dotnet/dotnet-docker/discussions/4764