### PR TITLE
9507 - [GKE] Fixed inconsistency between node and cluster versions

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-gke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/template.hbs
@@ -661,6 +661,7 @@
               @nodeVersions={{versions.validNodeVersions}}
               @controlPlaneVersion={{config.kubernetesVersion}}
               @cluster={{cluster}}
+              @versionChoices={{versionChoices}}
             />
           {{else}}
             <div class="p-20">

--- a/lib/shared/addon/components/gke-node-pool-row/component.js
+++ b/lib/shared/addon/components/gke-node-pool-row/component.js
@@ -178,7 +178,7 @@ export default Component.extend({
     const clusterVersion = get(this, 'controlPlaneVersion');
     const maxVersion     = get(this, 'maxVersion');
 
-    return Semver.lt(clusterVersion, maxVersion, { includePrerelease: true });
+    return Semver.lte(clusterVersion, maxVersion, { includePrerelease: true });
   }),
 
   upgradeAvailable: computed('controlPlaneVersion', 'clusterVersionIsLessThanMax', 'mode', 'nodePool.version', 'originalClusterVersion', function() {

--- a/lib/shared/addon/components/gke-node-pool-row/component.js
+++ b/lib/shared/addon/components/gke-node-pool-row/component.js
@@ -32,7 +32,7 @@ export default Component.extend({
   init() {
     this._super(...arguments);
 
-    const { nodePool } = this;
+    const { nodePool, maxVersion } = this;
 
     setProperties(this, {
       scopeConfig:            {},
@@ -51,8 +51,8 @@ export default Component.extend({
         }
       }
 
-      if (isEmpty(this?.nodePool?.version) && !isEmpty(this?.cluster?.gkeConfig?.kubernetesVersion)) {
-        set(this, 'nodePool.version', this?.cluster?.gkeConfig?.kubernetesVersion);
+      if (isEmpty(nodePool?.version) && !isEmpty(maxVersion)) {
+        set(this, 'nodePool.version', maxVersion);
       }
     } else {
       setProperties(this, {
@@ -84,12 +84,12 @@ export default Component.extend({
     this.send('updateScopes');
   }),
 
-  editingUpdateNodeVersion: observer('isNewNodePool', 'controlPlaneVersion', function() {
-    const { isNewNodePool } = this;
-    const clusterVersion           = get(this, 'controlPlaneVersion');
-    const nodeVersion              = get(this, 'nodePool.version');
+  editingUpdateNodeVersion: observer('isNewNodePool', 'clusterVersionIsLessThanMax', 'controlPlaneVersion', function() {
+    const { isNewNodePool, clusterVersionIsLessThanMax } = this;
+    const clusterVersion = get(this, 'controlPlaneVersion');
+    const nodeVersion    = get(this, 'nodePool.version');
 
-    if (isNewNodePool && clusterVersion !== nodeVersion) {
+    if (isNewNodePool && clusterVersion !== nodeVersion && clusterVersionIsLessThanMax) {
       set(this, 'nodePool.version', clusterVersion);
     }
   }),
@@ -167,9 +167,24 @@ export default Component.extend({
     return '';
   }),
 
-  upgradeAvailable: computed('controlPlaneVersion', 'mode', 'nodePool.version', 'originalClusterVersion', function() {
-    const clusterVersion  = get(this, 'controlPlaneVersion');
-    const nodeVersion     = get(this, 'nodePool.version');
+  maxVersion: computed('versionChoices', 'controlPlaneVersion', function() {
+    const clusterVersion = get(this, 'controlPlaneVersion');
+    const versionChoices = get(this, 'versionChoices');
+
+    return versionChoices?.[0]?.value || clusterVersion;
+  }),
+
+  clusterVersionIsLessThanMax: computed('maxVersion', 'controlPlaneVersion', function() {
+    const clusterVersion = get(this, 'controlPlaneVersion');
+    const maxVersion     = get(this, 'maxVersion');
+
+    return Semver.lt(clusterVersion, maxVersion, { includePrerelease: true });
+  }),
+
+  upgradeAvailable: computed('controlPlaneVersion', 'clusterVersionIsLessThanMax', 'mode', 'nodePool.version', 'originalClusterVersion', function() {
+    const clusterVersion              = get(this, 'controlPlaneVersion');
+    const nodeVersion                 = get(this, 'nodePool.version');
+    const clusterVersionIsLessThanMax = get(this, 'clusterVersionIsLessThanMax');
 
     if (isEmpty(clusterVersion) || isEmpty(nodeVersion)) {
       return false;
@@ -177,7 +192,7 @@ export default Component.extend({
 
     const nodeIsLess = Semver.lt(nodeVersion, clusterVersion, { includePrerelease: true });
 
-    if (nodeIsLess) {
+    if (nodeIsLess && clusterVersionIsLessThanMax) {
       return true;
     }
 
@@ -238,12 +253,12 @@ export default Component.extend({
   //   return newVersions;
   // }),
 
-  shouldUpgradeVersion: on('init', observer('upgradeVersion', 'controlPlaneVersion', function() {
-    const { upgradeVersion } = this;
-    const clusterVersion           = get(this, 'controlPlaneVersion');
-    const nodeVersion              = get(this, 'nodePool.version');
+  shouldUpgradeVersion: on('init', observer('upgradeVersion', 'clusterVersionIsLessThanMax', 'controlPlaneVersion', function() {
+    const { upgradeVersion, clusterVersionIsLessThanMax } = this;
+    const clusterVersion = get(this, 'controlPlaneVersion');
+    const nodeVersion    = get(this, 'nodePool.version');
 
-    if (upgradeVersion && clusterVersion !== nodeVersion) {
+    if (upgradeVersion && clusterVersion !== nodeVersion && clusterVersionIsLessThanMax) {
       set(this, 'nodePool.version', clusterVersion);
     }
   })),


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Set the initial node version to the cluster's max valid version, also disabled upgradeVersion when cluster version is higher than the max valid version.

Fixes [#9507](https://github.com/rancher/dashboard/issues/9507)


https://github.com/rancher/ui/assets/135728925/b08fccff-2fa3-49aa-ac80-a11a7ebf3b5f


