### PR TITLE
new: Represent region-specific pricing when configuring LKE Node Pools

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-linodelke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-linodelke/component.js
@@ -112,7 +112,17 @@ export default Component.extend(ClusterDriver, {
             errors:      [],
             step:        2,
             regions:     responses.regions.data.filter((region) => (region.status === 'ok' && region.capabilities.includes('Kubernetes'))),
-            nodeTypes:   responses.nodeTypes.data.filter((type) => (['standard', 'highmem', 'dedicated'].includes(type.class))),
+            nodeTypes:   responses.nodeTypes.data.filter(
+              (type) => (['standard', 'highmem', 'dedicated'].includes(type.class))
+            ).map((type) => {
+              // We need to set default values for effective prices
+              return {
+                ...type,
+                isException:      false,
+                effectiveHourly:  type.price.hourly,
+                effectiveMonthly: type.price.monthly
+              }
+            }),
             k8sVersions: responses.k8sVersions.data,
           });
 
@@ -239,14 +249,37 @@ export default Component.extend(ClusterDriver, {
     const selectedNodePoolList = get(this, 'selectedNodePoolList');
     const nodePools = selectedNodePoolList.map((np) => {
       return `${ np.id }=${ np.count }`
-    })
+    });
 
+    set(this, 'configHasRegionException', selectedNodePoolList.filter((type) => type.isException).length > 0)
     set(this, 'cluster.lkeEngineConfig.nodePools', nodePools);
   }),
 
   // to prefil selected node pool list for edit mode
   prefillSelectedNodePoolListObserver: observer('nodeTypes.[]', function() {
     this.prefillSelectedNodePoolList();
+  }),
+
+  updateEffectiveTypePrices: observer('cluster.lkeEngineConfig.region', function() {
+    // We need special handling for regional price exceptions
+    const nodeTypes = this.nodeTypes.map((type) => {
+      let override = undefined;
+
+      if (type['region_prices'] !== undefined) {
+        override = type.region_prices.find((override) => override.id === this.cluster.lkeEngineConfig.region);
+      }
+
+      const isException = override !== undefined;
+
+      return {
+        ...type,
+        isException,
+        effectiveHourly:  isException ? override.hourly : type.price.hourly,
+        effectiveMonthly: isException ? override.monthly : type.price.monthly
+      }
+    });
+
+    set(this, 'nodeTypes', nodeTypes);
   }),
 
   // Any computed properties or custom logic can go here

--- a/lib/shared/addon/components/cluster-driver/driver-linodelke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-linodelke/template.hbs
@@ -191,13 +191,13 @@
             <div class="acc-label pb-15">
               {{t "clusterNew.linodelke.nodePoolConfig.monthly"}}:
             </div>
-            {{format-number this.selectedNodePoolObj.price.monthly style='currency' currency='USD' allowEmpty=true}}
+            {{format-number this.selectedNodePoolObj.effectiveMonthly style='currency' currency='USD' allowEmpty=true}}
           </div>
           <div class="col span-1">
             <div class="acc-label pb-15">
               {{t "clusterNew.linodelke.nodePoolConfig.hourly"}}:
             </div>
-            {{format-number this.selectedNodePoolObj.price.hourly style='currency' currency='USD' allowEmpty=true}}
+            {{format-number this.selectedNodePoolObj.effectiveHourly style='currency' currency='USD' allowEmpty=true}}
           </div>
           <div class="col span-1">
             <div class="acc-label pb-15">
@@ -255,6 +255,13 @@
               </h2>
             </div>
           </div>
+          {{# if this.configHasRegionException}}
+            {{banner-message
+              icon="icon-alert"
+              color="bg-warning mb-10"
+              message=(t "clusterNew.linodelke.selectedNodePoolType.regionPriceWarning")
+            }}
+          {{/if}}
           {{#sortable-table
             classNames="grid fixed mb-0 sortable-table"
             sortBy=sortBy
@@ -274,10 +281,10 @@
                   {{member.label}}
                 </td>
                 <td data-title="{{dt.priceMonthly}}">
-                  {{format-number member.price.monthly style='currency' currency='USD' allowEmpty=true}}
+                  {{format-number member.effectiveMonthly style='currency' currency='USD' allowEmpty=true}}
                 </td>
                 <td data-title="{{dt.priceHourly}}">
-                  {{format-number member.price.hourly style='currency' currency='USD' allowEmpty=true}}
+                  {{format-number member.effectiveHourly style='currency' currency='USD' allowEmpty=true}}
                 </td>
                 <td data-title="{{dt.ram}}">
                   {{member.memoryGb}} {{t "generic.gigabyte"}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4396,7 +4396,7 @@ clusterNew:
     selectedNodePoolType:
       label: Select type
       placeholder: Select a node pool type
-      regionPriceWarning: One or more node pool in this configuration is subject to region-specific pricing. These prices are reflected in the displayed configuration below.
+      regionPriceWarning: One or more node pools in this configuration are subject to region-specific pricing. These prices are reflected in the displayed configuration below.
     shortLabel: Linode LKE
     tags:
       label: Tags

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3347,7 +3347,7 @@ clusterNew:
       fleet: Fleet Agent Configuration
     accordionDetail:
       cluster: Customize scheduling fields and resource limits for the Rancher cluster agent
-      fleet: Customize scheduling fields and resource limits for the Rancher fleet agent  
+      fleet: Customize scheduling fields and resource limits for the Rancher fleet agent
     banners:
       advanced: These are advanced configuration options. Generally, they should be left as-is.
       resourceRequests: Pod Requests and Limits do not have a default configuration.
@@ -3621,7 +3621,7 @@ clusterNew:
         parsedDockerBridgeCidr: Docker bridge address can not overlap with the selected Virtual Network or the Kubernetes service address range
         parsedServiceCidr: Kubernetes service address range must fall within the selected Virtual Network range.
         serviceCidr: Kubernetes service address range must be valid CIDR format.
-      nodeResourceGroup: 
+      nodeResourceGroup:
         length: "{key} name cannot exceed 80 characters."
         chars: "{key} name may only consist of underscores, periods, hyphens, parentheses, and letters or digits."
         periodEnd: "{key} name cannot end with a period."
@@ -4396,6 +4396,7 @@ clusterNew:
     selectedNodePoolType:
       label: Select type
       placeholder: Select a node pool type
+      regionPriceWarning: One or more node pool in this configuration is subject to region-specific pricing. These prices are reflected in the displayed configuration below.
     shortLabel: Linode LKE
     tags:
       label: Tags


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
This change adjusts the LKE cluster creation UI to represent upcoming LKE Node Pool pricing changes. 


Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

- Adjusts the displayed hourly and monthly pricing for each LKE Node Pool plan to reflect region-specific pricing exceptions.
- Adds a notice displayed when a user's Node Pool configuration is affected by any region-specific pricing exceptions.

Linked Issues
======

Related issue https://github.com/rancher/rancher/issues/42702


Preview
======

Configuring node pools in a region with pricing exceptions (id-cgk):

<img width="1290" alt="Configuring node pools in a region with pricing exceptions" src="https://github.com/rancher/ui/assets/114949949/8dd4113d-09aa-48b2-8215-4a884583d5e5">
