### PR TITLE
Fix issue handling error from GKE zone list request

### DIFF
--- a/lib/shared/addon/google/service.js
+++ b/lib/shared/addon/google/service.js
@@ -6,6 +6,7 @@ import { isEmpty } from '@ember/utils';
 import { addQueryParams } from 'ui/utils/util';
 
 export default Service.extend({
+  intl:               service(),
   globalStore:        service(),
   maintenanceWindows: [
     {
@@ -340,7 +341,10 @@ export default Service.extend({
 
       return out;
     } catch (error) {
-      return reject([error.body.error ?? error.body]);
+      const intl = get(this, 'intl');
+      const msg = error.body ? error.body.error ?? error.body : intl.t('clusterNew.googlegke.zone.fetchError');
+
+      return reject([msg]);
     }
   },
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4158,6 +4158,7 @@ clusterNew:
     zone:
       label: Zone
       prompt: Choose a Zone...
+      fetchError: Unable to fetch zones - check the Project ID and ensure the Cloud Credential has the appropriate permissions 
 
   header: Select Cluster Type
   huaweicce:


### PR DESCRIPTION
Addresses: https://github.com/rancher/dashboard/issues/9401

I recreated this issue with an invalid Project ID and a valid cloud credential:

- Add a valid GKE cloud credential
- Go to create a GKE Cluser
- Select the credential
- Enter project ID `"TEST//"`(with the quotes)
- You'll get the 500 and the error message

Note: It appears you get the 500 error from Google if you use a project ID that does match up with the selected cloud credential.
 
This PR fixes this issue - in some cases we can't parse the response error from Google, so it is returned as a string and not an object - hence when we access `error.body`, it fails.

With this PR, we fall back to a generic error message if we can not parse the error response.

![image](https://github.com/rancher/ui/assets/1955897/29708b62-eedb-41cc-9049-c4727adf0953)
