### PR TITLE
update drone jobs to run on v2.8.* tags

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -74,7 +74,7 @@ steps:
       - tag
     ref:
       include:
-      - "refs/tags/v2.7.*"
+      - "refs/tags/v2.8.*"
 
 
 - name: upload-release
@@ -93,7 +93,7 @@ steps:
       - tag
     ref:
       include:
-      - "refs/tags/v2.7.*"
+      - "refs/tags/v2.8.*"
 
 - name: upload-release-tar
   pull: default
@@ -111,7 +111,7 @@ steps:
       - tag
     ref:
       include:
-      - "refs/tags/v2.7.*"
+      - "refs/tags/v2.8.*"
 
 - name: create-pr-in-rancher
   image: curlimages/curl:7.81.0
@@ -129,7 +129,7 @@ steps:
     - tag
     ref:
       include:
-      - "refs/tags/v2.7.*"
+      - "refs/tags/v2.8.*"
 
 volumes:
 - name: docker


### PR DESCRIPTION
2.7 update for reference - https://github.com/rancher/ui/pull/4897 
We need to update drone.yml so UI builds are triggered when v2..8 tags are made.