### PR TITLE
Add v1.27 k8s versions to EKS hardcoded list

### DIFF
--- a/lib/shared/addon/utils/amazon.js
+++ b/lib/shared/addon/utils/amazon.js
@@ -697,7 +697,7 @@ export const EKS_REGIONS = [
 ];
 
 // from https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-export const EKS_VERSIONS = ['1.26', '1.25', '1.24', '1.23']; // sort newest->oldest so we dont have to run any logic to sort like other provider versions
+export const EKS_VERSIONS = ['1.27', '1.26', '1.25', '1.24', '1.23']; // sort newest->oldest so we dont have to run any logic to sort like other provider versions
 
 export const nameFromResource = function(r, idField) {
   let id = r[idField];


### PR DESCRIPTION
Updates v1.27 k8s versions list with newer versions based on https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html

https://github.com/rancher/eks-operator/issues/264