### PR TITLE
update constructConfig to handle external-aws cloud provider

### DIFF
--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -345,6 +345,15 @@ export default Component.extend({
 
       break;
 
+    case 'external-aws':
+
+      set(config, 'cloudProvider', get(this, 'globalStore').createRecord({
+        type:             'cloudProvider',
+        name:             'external-aws',
+      }));
+
+      break;
+
     case 'external':
 
       set(config, 'cloudProvider', get(this, 'globalStore').createRecord({


### PR DESCRIPTION
[#9933](https://github.com/rancher/dashboard/issues/9933) 

I botched this - cloud provider form inputs aren't setting cluster config fields directly; those are set in the `constructConfig` function which defaults to an empty object

https://github.com/rancher/ui/assets/42977925/ed64ffb7-6f14-4b17-a428-2d57212d7905

