### PR TITLE
Set cloud provider to external-aws when upgrading from <1.27

### DIFF
--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -107,7 +107,7 @@ export default Component.extend({
 
     if (selectedCloudProvider === 'amazonec2' && Semver.gte(Semver.coerce(kubernetesVersion), '1.27.0')){
       set(this, 'unsupportedProviderSelected', true)
-      set(this, 'selectedCloudProvider', 'external')
+      set(this, 'selectedCloudProvider', 'external-aws')
       this.constructConfig()
     } else if (get(this, 'unsupportedProviderSelected')){
       setProperties(this, {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3164,11 +3164,11 @@ cloudProvider:
   title: Cloud Provider
   amazon: Amazon (In-Tree)
   externalAmazon: 
-    label: External Amazon (Out-of-tree) 
+    label: External Amazon (Out-Of-Tree) 
     helpText: External Amazon enables use of useInstanceMetadataHostname. When useInstanceMetadataHostname is enabled, RKE will configure node name from ec2 metadata service. Configuring a Cloud Provider in your cluster without configuring the prerequisites will cause your cluster to not provision correctly. Prerequisites needed for supported cloud providers can be found in the documentation.
   azure: Azure (In-Tree)
   external:
-    label: External (Out-of-tree)
+    label: External (Out-Of-Tree)
     helpText: 'Please edit the YAML to specify the required addon for cloud controller manager.'
     vsphereHelpText: 'Out-of-tree cloud provider for vsphere is available through the vsphere-csi and vsphere-cpi helm charts. Please refer to the <a href="{docsBase}/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree" target="_blank" rel="nofollow noopener noreferrer">docs</a> for installation.'
   name: Cloud Provider Name

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3182,7 +3182,7 @@ cloudProvider:
 
   helpText: |
      Read more about the state of the <a href="https://kubernetes.io/blog/2019/04/17/the-future-of-cloud-providers-in-kubernetes/" target="_blank" rel="nofollow noopener noreferrer">Kubernetes in-tree cloud providers</a>
-  unsupported: The current Cloud Provider is not supported by this version of Kubernetes. The Cloud Provider has been changed to External. Please use the Cloud Provider Config to supply an out-of-tree configuration as needed.
+  unsupported: The current Cloud Provider is not supported by this version of Kubernetes. The Cloud Provider has been changed to External Amazon. Please use the Cloud Provider Config to supply an out-of-tree configuration as needed.
   warning:
     Configuring a Cloud Provider in your cluster without configuring the prerequisites will cause your cluster to not provision correctly. Prerequisites needed for supported cloud providers can be found in the documentation.
   azureCloudConfig:


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/9204#issuecomment-1773556413


upgrading when the cloud provider was set to amazon in-tree:
https://github.com/rancher/ui/assets/42977925/56b91165-e6cc-4da1-8e0c-f6a617499e0d

upgrading without cloud provider set:
https://github.com/rancher/ui/assets/42977925/6890578f-e331-4e95-bff2-4beeac00da8e