### PR TITLE
RKE1 gracefulShutdownTimeout option for vSphere node template

### DIFF
--- a/lib/nodes/addon/components/driver-vmwarevsphere/template.hbs
+++ b/lib/nodes/addon/components/driver-vmwarevsphere/template.hbs
@@ -127,7 +127,7 @@
     </div>
 
     <div class="row">
-      <div class="col span-12">
+      <div class="col span-6">
         <label class="acc-label">
           {{t "nodeDriver.vmwarevsphere.host.label"}}
         </label>
@@ -141,6 +141,24 @@
           {{t "nodeDriver.vmwarevsphere.host.help"}}
         </p>
         <SelectValueCheck @values={{config.hostsystem}} @options={{hostContent}} />
+      </div>
+      <div class="col span-6">
+        <label class="acc-label">
+          {{t "nodeDriver.vmwarevsphere.gracefulShutdownTimeout.label"}}
+        </label>
+        <div class="input-group">
+          {{input-integer
+            min=0
+            value=config.gracefulShutdownTimeout
+            classNames="form-control"
+          }}
+          <div class="input-group-addon bg-default">
+            {{t "nodeDriver.vmwarevsphere.gracefulShutdownTimeout.unit"}}
+          </div>
+        </div>
+        <p class="help-block">
+          {{t "nodeDriver.vmwarevsphere.gracefulShutdownTimeout.help"}}
+        </p>
       </div>
     </div>
   {{/accordion-list-item}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -9531,6 +9531,10 @@ nodeDriver:
       label: Host
       placeholder: "e.g. cluster_name/host_name"
       help: "Specific host to create VM on (leave blank for standalone ESXi or for cluster with DRS)"
+    gracefulShutdownTimeout:
+      label: Graceful Shutdown Timeout
+      help: The time in seconds to wait before forcing deleting VMs in the infrastructure. Zero means disable graceful shutdown.
+      unit: Seconds
     network:
       addActionLabel: "Add Network"
       valueLabel: "Networks"


### PR DESCRIPTION
Linked Issues
======
Fixes RKE1 part of [this issue](https://github.com/rancher/dashboard/issues/9620).

Videos
======

https://github.com/rancher/ui/assets/135728925/fe408a9e-2f5f-4bbe-be8c-6aedc7a10d36


https://github.com/rancher/ui/assets/135728925/e0775fee-06b4-4010-bb4c-3e6dcafaeb63


