### PR TITLE
Fix external Amazon banners

### DIFF
--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -35,7 +35,8 @@ export default Component.extend({
   azureDefaults,
   azureDescriptions:           AzureInfo,
   unsupportedProviderSelected: false,
-  // track the original configuration to revert the switch to 'external' when the selected provider isnt supported
+  showChangedToAmazonExternal: false,
+  // track the original configuration to revert the switch to 'external' when the selected provider is not supported
   initialCloudProvider:        null,
   initialConfigAnswers:        null,
 
@@ -101,13 +102,14 @@ export default Component.extend({
     }
   }),
 
-  k8sVersionDidChage: observer( 'cluster.rancherKubernetesEngineConfig.kubernetesVersion', function(){
+  k8sVersionDidChange: observer( 'cluster.rancherKubernetesEngineConfig.kubernetesVersion', function(){
     const kubernetesVersion = get(this, 'cluster.rancherKubernetesEngineConfig.kubernetesVersion')
     const selectedCloudProvider = get(this, 'selectedCloudProvider')
 
     if (selectedCloudProvider === 'amazonec2' && Semver.gte(Semver.coerce(kubernetesVersion), '1.27.0')){
-      set(this, 'unsupportedProviderSelected', true)
-      set(this, 'selectedCloudProvider', 'external-aws')
+      set(this, 'unsupportedProviderSelected', true);
+      set(this, 'selectedCloudProvider', 'external-aws');
+      set(this, 'showChangedToAmazonExternal', true);
       this.constructConfig()
     } else if (get(this, 'unsupportedProviderSelected')){
       setProperties(this, {
@@ -152,6 +154,7 @@ export default Component.extend({
     'applyClusterTemplate', 'clusterTemplateCreate', 'clusterTemplateRevision.{id,questions}', 'configName', 'selectedCloudProvider', 'isDestroying', 'isDestroyed',
     function() {
       let { clusterTemplateRevision, applyClusterTemplate } = this;
+
 
       if (applyClusterTemplate && clusterTemplateRevision) {
         if (clusterTemplateRevision.questions) {
@@ -383,6 +386,10 @@ export default Component.extend({
 
   addOverride() {
     throw new Error('addOverride action is required!');
+  },
+
+  cloudProviderUserChange() {
+    set(this, 'showChangedToAmazonExternal', false);
   },
 
   getHarvesterCluster() {

--- a/lib/shared/addon/components/cru-cloud-provider/template.hbs
+++ b/lib/shared/addon/components/cru-cloud-provider/template.hbs
@@ -56,6 +56,7 @@
               {{radio-button
                 selection=selectedCloudProvider
                 value="none"
+                chosen=(action cloudProviderUserChange)
               }} {{t "generic.none"}}
             </label>
           </div>
@@ -74,6 +75,7 @@
                   {{radio-button
                     selection=selectedCloudProvider
                     value="amazonec2"
+                    chosen=(action cloudProviderUserChange)
                   }} {{t "cloudProvider.amazon"}}
                 </label>
               </div>
@@ -167,6 +169,7 @@
                   {{radio-button
                     selection=selectedCloudProvider
                     value="external-aws"
+                    chosen=(action cloudProviderUserChange)
                   }} {{t "cloudProvider.externalAmazon.label"}}
                 </label>
               </div>
@@ -186,6 +189,7 @@
               {{radio-button
                 selection=selectedCloudProvider
                 value="external"
+                chosen=(action cloudProviderUserChange)
               }} {{t "cloudProvider.external.label"}}
             </label>
           </div>
@@ -193,7 +197,7 @@
       </div>
     {{/input-or-display}}
   </CheckComputedOverride>
-  {{#if unsupportedProviderSelected}}
+  {{#if showChangedToAmazonExternal}}
     <div class="col span-12">
       <BannerMessage
         @color="bg-info mt-0 mb-0"
@@ -202,7 +206,7 @@
       />
     </div>
   {{/if}}
-  {{#if (and (not-eq selectedCloudProvider "none") (eq mode "new"))}}
+  {{#if (not-eq selectedCloudProvider "none")}}
     {{#if (eq selectedCloudProvider "external-aws")}}
       <div class="col span-12">
         <BannerMessage

--- a/lib/shared/addon/components/radio-button/component.js
+++ b/lib/shared/addon/components/radio-button/component.js
@@ -14,6 +14,9 @@ export default Component.extend({
   }),
   click() {
     this.set('selection', this.get('value'));
+
+    this.chosen();
   },
 
+  chosen() {}
 });

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3182,7 +3182,7 @@ cloudProvider:
 
   helpText: |
      Read more about the state of the <a href="https://kubernetes.io/blog/2019/04/17/the-future-of-cloud-providers-in-kubernetes/" target="_blank" rel="nofollow noopener noreferrer">Kubernetes in-tree cloud providers</a>
-  unsupported: The current Cloud Provider is not supported by this version of Kubernetes. The Cloud Provider has been changed to External Amazon. Please use the Cloud Provider Config to supply an out-of-tree configuration as needed.
+  unsupported: The current Cloud Provider is not supported by this version of Kubernetes. The Cloud Provider has been changed to External Amazon.
   warning:
     Configuring a Cloud Provider in your cluster without configuring the prerequisites will cause your cluster to not provision correctly. Prerequisites needed for supported cloud providers can be found in the documentation.
   azureCloudConfig:


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/9204

This PR:

- Splits out the banner so that the banner telling you that we changed the cloud provider to 'External Amazon' is seperate
- Shows the banners telling you that you need to configure for external Amazon or external for both create and edit
- Hides the banner that we changed for External Amazon when the user subsequently changes it

To Test:

- Go to create a AWS RKE1 cluster with k8s 1.26 and the 'Amazon (In-Tree)' cloud procider
- On this form, if you change to External Amazon or External, the banner telling you extra config is needed - 

![image](https://github.com/rancher/ui/assets/1955897/74576a90-7dec-44eb-8096-e6c3dc3c311e)

![image](https://github.com/rancher/ui/assets/1955897/2658be45-19d6-47ba-93d7-2ef94602b62e)

- Go ahead and create the cluser
- You don't have to wait for create to complete - go to edit the cluster
- Change the k8s version to 1.27,  you should see 2 banners:
![image](https://github.com/rancher/ui/assets/1955897/f8dc9b0e-799f-4a1d-9b39-ec9f83a27349)

- Change the cloud provider - the first banner will go away and the appropriate banner will stay for External Amazon and External (same as above)


