### PR TITLE
Fix issue where labels are not shown for clusters

### DIFF
--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -220,6 +220,7 @@ export default Resource.extend(Grafana, ResourceUsage, {
   roleTemplateBindings:        alias('clusterRoleTemplateBindings'),
   isAKS:                       equal('driver', 'azureKubernetesService'),
   isGKE:                       equal('driver', 'googleKubernetesEngine'),
+  canHaveLabels:               true,
 
   runningClusterScans: computed.filterBy('clusterScans', 'isRunning', true),
 

--- a/app/models/cluster.js
+++ b/app/models/cluster.js
@@ -214,13 +214,13 @@ export default Resource.extend(Grafana, ResourceUsage, {
   grafanaDashboardName:        'Cluster',
   isMonitoringReady:           false,
   _cachedConfig:               null,
+  canHaveLabels:               true,
   clusterTemplate:             reference('clusterTemplateId'),
   clusterTemplateRevision:     reference('clusterTemplateRevisionId'),
   machines:                    alias('nodes'),
   roleTemplateBindings:        alias('clusterRoleTemplateBindings'),
   isAKS:                       equal('driver', 'azureKubernetesService'),
   isGKE:                       equal('driver', 'googleKubernetesEngine'),
-  canHaveLabels:               true,
 
   runningClusterScans: computed.filterBy('clusterScans', 'isRunning', true),
 


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/10105

Fixes issue where cluster labels are not shown when editing a cluster and the cluster being edited does not support labels being edited - currently in this case, the labels are not shown and only the annotations are presented to the user.
