### PR TITLE
Fix small issues on RKE Template diff modal

### DIFF
--- a/app/components/modal-view-template-diff/component.js
+++ b/app/components/modal-view-template-diff/component.js
@@ -27,6 +27,8 @@ export default Component.extend(ModalBase, {
   layout,
   classNames: ['modal-container', 'large-modal', 'large-height', 'alert'],
   diff:       '',
+  leftName:   '',
+  rightName:  '',
 
   didReceiveAttrs() {
     const templates = get(this, 'modalService.modalOpts');
@@ -39,6 +41,9 @@ export default Component.extend(ModalBase, {
       const diff = jsondiffpatch.formatters.html.format(delta, templates[0]).htmlSafe();
 
       set(this, 'diff', diff);
+
+      set(this, 'leftName', templates[0].name);
+      set(this, 'rightName', templates[1].name);
     } else {
       set(this, 'diff', this.intl.t('clusterTemplatesPage.compare.error'));
     }

--- a/app/components/modal-view-template-diff/template.hbs
+++ b/app/components/modal-view-template-diff/template.hbs
@@ -1,5 +1,15 @@
-<section class="horizontal-form container-fluid">
+<section class="horizontal-form container-fluid modal-cluster-template-diff">
   <h2>{{t "clusterTemplatesPage.compare.header" }}</h2>
+
+  <div class="mt-10 template-diff-key">
+    <div>{{t "clusterTemplatesPage.compare.key" }}</div>
+    <div class="jsondiffpatch-textdiff-deleted template-diff-item">
+      {{ leftName }}
+    </div>
+    <div class="jsondiffpatch-textdiff-added template-diff-item">
+      {{ rightName }}
+    </div>
+  </div>
 
   <div class="mt-10 modal-scroll-panel">
     <pre class="bg-setting" style="margin: 0; padding: 0">

--- a/app/styles/_rancher.scss
+++ b/app/styles/_rancher.scss
@@ -67,6 +67,7 @@
 @import "app/styles/components/cluster-template-revision-upgrade-notification";
 @import "app/styles/components/node-group-row";
 @import "app/styles/components/agent-config";
+@import "app/styles/components/cluster-template-diff";
 
 
 // Vendor

--- a/app/styles/components/_cluster-template-diff.scss
+++ b/app/styles/components/_cluster-template-diff.scss
@@ -1,0 +1,12 @@
+.modal-cluster-template-diff {
+  .template-diff-key {
+    align-items: center;
+    display: flex;
+
+    > div.template-diff-item {
+      margin-left: 10px;
+      padding: 4px;
+      text-decoration: none;
+    }
+  }
+}

--- a/app/styles/components/jsondiffpatch.scss
+++ b/app/styles/components/jsondiffpatch.scss
@@ -22,13 +22,13 @@ ul.jsondiffpatch-delta {
 .jsondiffpatch-added .jsondiffpatch-value pre,
 .jsondiffpatch-modified .jsondiffpatch-right-value pre,
 .jsondiffpatch-textdiff-added {
-  background: #bbffbb;
+  background: $diff-green;
 }
 .jsondiffpatch-deleted .jsondiffpatch-property-name,
 .jsondiffpatch-deleted pre,
 .jsondiffpatch-modified .jsondiffpatch-left-value pre,
 .jsondiffpatch-textdiff-deleted {
-  background: #ffbbbb;
+  background: $diff-red;
   text-decoration: line-through;
 }
 .jsondiffpatch-unchanged,
@@ -118,7 +118,7 @@ li:last-child > .jsondiffpatch-value pre:after,
 }
 .jsondiffpatch-moved .jsondiffpatch-moved-destination {
   display: inline-block;
-  background: #ffffbb;
+  background: $diff-green;
   color: #888;
 }
 .jsondiffpatch-moved .jsondiffpatch-moved-destination:before {

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -179,3 +179,7 @@ $stroke-fill                         : black;
 $stroke-text                         : white;
 
 $project-nav-hover                   : $tab-hover;
+
+// JSON Diff colors
+$diff-green                          : #1a5c1a;
+$diff-red                            : #9b0000;

--- a/app/styles/themes/_light.scss
+++ b/app/styles/themes/_light.scss
@@ -55,3 +55,7 @@ $tooltip-link-color                  : darken($light-grey, 10);
 
 $input-color-placeholder             : lighten($text-color, 25%);
 $input-color                         : $text-color;
+
+// JSON Diff colors
+$diff-green                          : #bbffbb;
+$diff-red                            : #ffbbbb;

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1438,6 +1438,7 @@ clusterTemplatesPage:
     header: Compare RKE Template Revisions
     closeModal: Close
     error: Two RKE Template Revisions required to perform diff
+    key: "Key:"
   new:
     header: Add RKE Template
   headers:


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/5954

QA re-opened this issue asking for a few things:

1. Contrast is not compatible w/ Dark Mode - [unable to clearly view values]
2. Compare does NOT show two templates side-by-side, confusion around which color [red/green] represents which Template (requesting colored Template labels perhaps? or side-by-side comparison)
3. All fields with differences should be either red or green with values being compared from the respective Templates.
4. Currently, if null/nil, in first template, and populated in second template, compare will only show populated values in green, associated with the second template. [e.g. private_registries field from screenshot]

This PR addresses 1 and 2.

The other two are not easily addressed with the library we use - having reviewed the UX, with the changes in this PR, I believe this delivers an acceptable UX. 
