### PR TITLE
Bump versions for `release-2.7` branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,7 +33,7 @@ steps:
     path: /var/run/docker.sock
   when:
     branch:
-    - release-2.7.7
+    - release-2.7
     event:
       exclude:
       - pull_request
@@ -46,13 +46,13 @@ steps:
     acl:
     - allUsers:READER
     cache_control: "no-cache,must-revalidate"
-    source: dist/static/release-2.7.7
-    target: releases.rancher.com/ui/release-2.7.7
+    source: dist/static/release-2.7
+    target: releases.rancher.com/ui/release-2.7
     token:
       from_secret: google_auth_key
   when:
     branch:
-    - release-2.7.7
+    - release-2.7
     event:
       exclude:
       - pull_request

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Rancher UI supports localization via translations files. You can swap translatio
 If you want to customize the UI, re-packaging all of Rancher to distribute the UI is possible but not terribly convenient. Instead you can change Cattle to load the UI source from a remote web server:
 
 - Build with `./scripts/build-static -l -c 'your-server.com'`
-- Upload `./dist/static/release-2.7.7` so that it's available at https://your-server.com/release-2.7.7
+- Upload `./dist/static/release-2.7` so that it's available at https://your-server.com/release-2.7
   - It must be available over HTTPS.
-  - You can rename the "release-2.7.7" part with the `-v` flag
-- Change the value of https://your-rancher/v3/settings/ui-index to the same `https://your-server.com/release-2.7.7` URL
+  - You can rename the "release-2.7" part with the `-v` flag
+- Change the value of https://your-rancher/v3/settings/ui-index to the same `https://your-server.com/release-2.7` URL
 
 ### Running Tests
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "2.7.7-dev",
+  "version": "2.7-dev",
   "private": true,
   "repository": "https://github.com/rancher/ui",
   "license": "Apache-2.0",

--- a/scripts/build-static
+++ b/scripts/build-static
@@ -30,7 +30,7 @@ function printHelp() {
 build-static Usage:
   -d - Build debug instead of production build
   -f - Force: Turn off checks that prevent you from doing bad things
-  -l - Build as "release-2.7.7" instead of the version in package.json
+  -l - Build as "release-2.7" instead of the version in package.json
   -t - Tag and push tag
   -u - Upload to GCE
   -s - Skip tests
@@ -125,7 +125,7 @@ if [[ `git status --porcelain` ]]; then
 fi
 
 # UPLOAD_LATEST=true is set by Drone for auto upload to CDN
-if [[ "${BRANCH}" == "release-2.7.7" ]] && [[ "${UPLOAD_LATEST}" == "true" ]]; then
+if [[ "${BRANCH}" == "release-2.7" ]] && [[ "${UPLOAD_LATEST}" == "true" ]]; then
   UPLOAD=2
   LATEST=1
 fi
@@ -138,8 +138,8 @@ if [[ $LATEST -eq 1 ]] && [[ $TAG -eq 1 ]]; then
   fi
 fi
 
-if ( [[ $TAG -eq 1 ]] || [[ $UPLOAD -ne 0 ]] ) && [[ "${BRANCH}" != "release-2.7.7" ]]; then
-  echo "You can only tag or upload the release-2.7.7 branch (you are on '${BRANCH}')."
+if ( [[ $TAG -eq 1 ]] || [[ $UPLOAD -ne 0 ]] ) && [[ "${BRANCH}" != "release-2.7" ]]; then
+  echo "You can only tag or upload the release-2.7 branch (you are on '${BRANCH}')."
   if [[ $FORCE -ne 1 ]]; then
     exit 1;
   fi
@@ -157,7 +157,7 @@ if [[ "${FORCE_VERSION}" != "" ]]; then
   VERSION=${FORCE_VERSION}
 else
   if [[ $LATEST -eq 1 ]]; then
-    VERSION="release-2.7.7"
+    VERSION="release-2.7"
   else
     VERSION=${PKG_VERSION}
   fi

--- a/scripts/ci
+++ b/scripts/ci
@@ -34,7 +34,7 @@ fi
 
 if [[ "${BUILD_LATEST}" == "true" ]]; then
   echo "Building latest..."
-  ./scripts/build-static -l -v release-2.7.7
+  ./scripts/build-static -l -v release-2.7
   # (build-static contains a call to test & build)
 elif [[ ! -z "${CI_BUILD_TAG}" ]]; then
   echo "Building v${CI_BUILD_TAG}..."


### PR DESCRIPTION
This updates environment values for CI scripts so that they target the `release-2.7` branch.