### PR TITLE
Syncing node version with cluster version

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-gke/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/template.hbs
@@ -659,7 +659,7 @@
               @nodePool={{nodePool}}
               @removeNodePool={{action "removeNodePool"}}
               @nodeVersions={{versions.validNodeVersions}}
-              @controlPlaneVersion={{config.kubernetesVersion}}
+              @clusterVersion={{config.kubernetesVersion}}
               @cluster={{cluster}}
               @versionChoices={{versionChoices}}
             />

--- a/lib/shared/addon/components/gke-node-pool-row/component.js
+++ b/lib/shared/addon/components/gke-node-pool-row/component.js
@@ -6,8 +6,7 @@ import { on } from '@ember/object/evented';
 import { next } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
-import Semver/* , { coerce, minor } */ from 'semver';
-// import { coerceVersion } from 'shared/utils/parse-version';
+import Semver from 'semver';
 import { sortableNumericSuffix } from 'shared/utils/util';
 import layout from './template';
 
@@ -26,13 +25,17 @@ export default Component.extend({
   imageTypeContent:        null,
   machineTypes:            null,
   nodeVersions:            null,
-  controlPlaneVersion:     null,
+  clusterVersion:          null,
   upgradeVersion:          false,
 
   init() {
     this._super(...arguments);
 
-    const { nodePool, maxVersion } = this;
+    const {
+      nodePool,
+      clusterVersion,
+      defaultClusterVersion
+    } = this;
 
     setProperties(this, {
       scopeConfig:            {},
@@ -51,8 +54,8 @@ export default Component.extend({
         }
       }
 
-      if (isEmpty(nodePool?.version) && !isEmpty(maxVersion)) {
-        set(this, 'nodePool.version', maxVersion);
+      if (isEmpty(nodePool?.version) && !isEmpty(clusterVersion)) {
+        set(this, 'nodePool.version', defaultClusterVersion);
       }
     } else {
       setProperties(this, {
@@ -84,12 +87,11 @@ export default Component.extend({
     this.send('updateScopes');
   }),
 
-  editingUpdateNodeVersion: observer('isNewNodePool', 'clusterVersionIsLessThanMax', 'controlPlaneVersion', function() {
-    const { isNewNodePool, clusterVersionIsLessThanMax } = this;
-    const clusterVersion = get(this, 'controlPlaneVersion');
+  editingUpdateNodeVersion: observer('isNewNodePool', 'clusterVersion', function() {
+    const { isNewNodePool, clusterVersion } = this;
     const nodeVersion    = get(this, 'nodePool.version');
 
-    if (isNewNodePool && clusterVersion !== nodeVersion && clusterVersionIsLessThanMax) {
+    if (isNewNodePool && clusterVersion !== nodeVersion) {
       set(this, 'nodePool.version', clusterVersion);
     }
   }),
@@ -130,6 +132,18 @@ export default Component.extend({
     set(this.nodePool.config, 'oauthScopes', this.google.mapOauthScopes(this.oauthScopesSelection, this.scopeConfig));
   })),
 
+  // In create mode, the cluster version can fallback to the first item in the versionChoices array.
+  // Similarly, defaultClusterVersion is used to synchronize the node version.
+  defaultClusterVersion: computed('versionChoices', 'clusterVersion', function() {
+    const { clusterVersion, versionChoices } = this;
+
+    if (versionChoices.some((v) => v?.value === clusterVersion)) {
+      return clusterVersion;
+    } else {
+      return versionChoices[0]?.value;
+    }
+  }),
+
   regionalTotalNodeCounts: computed('locationType', 'nodePool.initialNodeCount', 'locationContent.@each.checked', function() {
     const { locationType } = this;
     let totalLocations = this.locationContent.filterBy('checked').length;
@@ -167,32 +181,18 @@ export default Component.extend({
     return '';
   }),
 
-  maxVersion: computed('versionChoices', 'controlPlaneVersion', function() {
-    const clusterVersion = get(this, 'controlPlaneVersion');
-    const versionChoices = get(this, 'versionChoices');
-
-    return versionChoices?.[0]?.value || clusterVersion;
-  }),
-
-  clusterVersionIsLessThanMax: computed('maxVersion', 'controlPlaneVersion', function() {
-    const clusterVersion = get(this, 'controlPlaneVersion');
-    const maxVersion     = get(this, 'maxVersion');
-
-    return Semver.lte(clusterVersion, maxVersion, { includePrerelease: true });
-  }),
-
-  upgradeAvailable: computed('controlPlaneVersion', 'clusterVersionIsLessThanMax', 'mode', 'nodePool.version', 'originalClusterVersion', function() {
-    const clusterVersion              = get(this, 'controlPlaneVersion');
-    const nodeVersion                 = get(this, 'nodePool.version');
-    const clusterVersionIsLessThanMax = get(this, 'clusterVersionIsLessThanMax');
+  upgradeAvailable: computed('clusterVersion', 'mode', 'nodePool.version', 'defaultClusterVersion', function() {
+    const { clusterVersion, defaultClusterVersion } = this;
+    const nodeVersion = get(this, 'nodePool.version');
 
     if (isEmpty(clusterVersion) || isEmpty(nodeVersion)) {
       return false;
     }
 
     const nodeIsLess = Semver.lt(nodeVersion, clusterVersion, { includePrerelease: true });
+    const clusterVersionIsAlsoTheMaxVersion = clusterVersion === defaultClusterVersion;
 
-    if (nodeIsLess && clusterVersionIsLessThanMax) {
+    if (nodeIsLess && clusterVersionIsAlsoTheMaxVersion) {
       return true;
     }
 
@@ -221,44 +221,12 @@ export default Component.extend({
     return out.sortBy('sortName')
   }),
 
-  // versionChoices: computed('nodeVersions.[]', 'controlPlaneVersion', 'mode', function() {
-  //   // google gke console allows the node version to be anything less than master version
-  //   const {
-  //     nodeVersions,
-  //     controlPlaneVersion,
-  //     mode,
-  //   } = this;
 
-  //   const coerceedVersion = coerceVersion(controlPlaneVersion);
-  //   const maxVersionRange = `<= ${ coerceedVersion }`;
-  //   let newVersions = this.serviceVersions.parseCloudProviderVersionChoices(nodeVersions, controlPlaneVersion, mode, maxVersionRange);
-
-  //   const controlPlaneVersionMatch = newVersions.findBy('value', controlPlaneVersion);
-
-  //   if (!isEmpty(controlPlaneVersionMatch)) {
-  //     set(controlPlaneVersionMatch, 'label', `${ controlPlaneVersionMatch.label } (control plane version)`);
-
-  //     set(this, 'nodePool.version', controlPlaneVersionMatch.value);
-
-  //     const indexOfMatch = newVersions.indexOf(controlPlaneVersionMatch);
-
-  //     if (indexOfMatch > 0) {
-  //       // gke returns a semver like 1.17.17-gke.2800, 1.17.17-gke.3000
-  //       // semver logic sorts these correctly but because we have to coerce the version, all versions in the 1.17.17 comebace
-  //       // since they are sorted lets just find our CP master match index and cut everything off before that
-  //       newVersions = newVersions.slice(indexOfMatch);
-  //     }
-  //   }
-
-  //   return newVersions;
-  // }),
-
-  shouldUpgradeVersion: on('init', observer('upgradeVersion', 'clusterVersionIsLessThanMax', 'controlPlaneVersion', function() {
-    const { upgradeVersion, clusterVersionIsLessThanMax } = this;
-    const clusterVersion = get(this, 'controlPlaneVersion');
+  shouldUpgradeVersion: on('init', observer('upgradeVersion', 'clusterVersion', function() {
+    const { upgradeVersion, clusterVersion } = this;
     const nodeVersion    = get(this, 'nodePool.version');
 
-    if (upgradeVersion && clusterVersion !== nodeVersion && clusterVersionIsLessThanMax) {
+    if (upgradeVersion && clusterVersion !== nodeVersion) {
       set(this, 'nodePool.version', clusterVersion);
     }
   })),

--- a/lib/shared/addon/components/gke-node-pool-row/template.hbs
+++ b/lib/shared/addon/components/gke-node-pool-row/template.hbs
@@ -19,6 +19,11 @@
       <label class="acc-label">
         {{t "clusterNew.googlegke.masterVersion.label"}}
       </label>
+      {{!-- <NewSelect
+        @classNames="form-control"
+        @content={{versionChoices}}
+        @value={{mut nodePool.version}}
+      /> --}}
       {{#if upgradeAvailable}}
         <div class="checkbox form-control-static">
           <label class="acc-label">
@@ -30,7 +35,7 @@
             {{t
               "nodeGroupRow.version.upgrade"
               from=nodePool.version
-              version=controlPlaneVersion
+              version=clusterVersion
             }}
           </label>
         </div>

--- a/lib/shared/addon/components/gke-node-pool-row/template.hbs
+++ b/lib/shared/addon/components/gke-node-pool-row/template.hbs
@@ -19,11 +19,6 @@
       <label class="acc-label">
         {{t "clusterNew.googlegke.masterVersion.label"}}
       </label>
-      {{!-- <NewSelect
-        @classNames="form-control"
-        @content={{versionChoices}}
-        @value={{mut nodePool.version}}
-      /> --}}
       {{#if upgradeAvailable}}
         <div class="checkbox form-control-static">
           <label class="acc-label">


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/9507

Within the `driver-gke` logic, if the cluster version is not present in the list of available version choices, the first item (maximum version) is automatically selected. However, the same behavior was not extended to the node version.