### PR TITLE
Fix GKE range name and CidrBlock conflict

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-gke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/component.js
@@ -755,13 +755,21 @@ export default Component.extend(ClusterDriver, {
     if (subnetworkMatch) {
       const { secondaryIpRanges = [] } = subnetworkMatch;
 
-      return secondaryIpRanges.map((s) => {
+      const items = secondaryIpRanges.map((s) => {
         return {
           label:       `${ s.rangeName }(${ s.ipCidrRange })`,
           value:       s.rangeName,
           ipCidrRange: s.ipCidrRange,
         }
       });
+
+      items.unshift({
+        label: this.intl.t('clusterNew.googlegke.ipAllocationPolicy.noSecondaryRange'),
+        value: null,
+        ipCidrRange: '',
+      });
+
+      return items;
     }
 
     return [];
@@ -952,6 +960,14 @@ export default Component.extend(ClusterDriver, {
 
         return false;
       }
+    }
+
+    if (get(config, 'ipAllocationPolicy.clusterSecondaryRangeName') && get(config, 'ipAllocationPolicy.clusterIpv4CidrBlock')) {
+      set(config, 'ipAllocationPolicy.clusterIpv4CidrBlock', null);
+    }
+
+    if (get(config, 'ipAllocationPolicy.servicesSecondaryRangeName') && get(config, 'ipAllocationPolicy.servicesIpv4CidrBlock')) {
+      set(config, 'ipAllocationPolicy.servicesIpv4CidrBlock', null);
     }
 
     if (!get(config, 'masterAuthorizedNetworks.enabled')) {

--- a/lib/shared/addon/components/cluster-driver/driver-gke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/component.js
@@ -764,8 +764,8 @@ export default Component.extend(ClusterDriver, {
       });
 
       items.unshift({
-        label: this.intl.t('clusterNew.googlegke.ipAllocationPolicy.noSecondaryRange'),
-        value: null,
+        label:       this.intl.t('clusterNew.googlegke.ipAllocationPolicy.noSecondaryRange'),
+        value:       null,
         ipCidrRange: '',
       });
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3975,6 +3975,7 @@ clusterNew:
         cidrLabel: Service Secondary CIDR Block
         nameLabel: Services Secondary Range Name
       title: IP Allocation Policy
+      noSecondaryRange: "<None>"
     ipPolicyClusterIpv4CidrBlock:
       label: Pod address range
       placeholder: e.g. 10.96.0.0/11


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/8749

This PR fixes the above bug:

- Ensures that if you use a range name, we do NOT also send the ipv4 cidr block as well
- Ensures that we add a '<None>' option to the range selector, so that a user can clear the range name and set the ipv4 cidr block if they select a range - currently once you select a range name, there is no way to clear it

This requires manual test as you need access to GKE.

Instructions to test are in the issue at the top - you need to create a VPN with subnets that have secondary ranges. Then create a cluster, selecting a secondary range name and validate that the cluster creates okay.