### PR TITLE
Add node pool/group duplicate name validation for hosted providers

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-aks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-aks/component.js
@@ -649,6 +649,7 @@ export default Component.extend(ClusterDriver, {
 
     if (!isEmpty(nodePools)) {
       const nodePoolErrors = [];
+      const nodePoolNames = {};
 
       nodePools.forEach((np) => {
         const npErr = np.validationErrors();
@@ -700,7 +701,19 @@ export default Component.extend(ClusterDriver, {
         }
 
         nodePoolErrors.push(npErr)
+
+        // Update map of names to count of occurrences (for duplication check)
+        if (npName) {
+          nodePoolNames[npName] = (nodePoolNames[npName] || 0) + 1;
+        }
       });
+
+      // Node pool names must be unique
+      const names = Object.keys(nodePoolNames).filter((name) => nodePoolNames[name] > 1).join(', ');
+
+      if (names.length) {
+        nodePoolErrors.push(this.intl.t('clusterNew.nodePools.errors.namesNotUnique', { names }));
+      }
 
       if (!isEmpty(nodePoolErrors)) {
         errors.pushObjects(nodePoolErrors.flat());

--- a/lib/shared/addon/components/cluster-driver/driver-eks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-eks/component.js
@@ -769,12 +769,25 @@ export default Component.extend(ClusterDriver, {
 
     if (!isEmpty(nodeGroups)) {
       const nodeGroupErrors = [];
+      const nodeGroupNames = {};
 
       nodeGroups.forEach((ng) => {
         const ngErr = ng.validationErrors();
 
         nodeGroupErrors.push(ngErr)
+
+        // Update map of names to count of occurrences (for duplication check)
+        if (ng.name) {
+          nodeGroupNames[ng.name] = (nodeGroupNames[ng.name] || 0) + 1;        
+        }
       });
+
+      // Node group names must be unique
+      const names = Object.keys(nodeGroupNames).filter((name) => nodeGroupNames[name] > 1).join(', ');
+
+      if (names.length) {
+        nodePoolErrors.push(this.intl.t('clusterNew.nodeGroups.errors.namesNotUnique', { names }));
+      }
 
       if (!isEmpty(nodeGroupErrors)) {
         errors.pushObjects(nodeGroupErrors.flat());

--- a/lib/shared/addon/components/cluster-driver/driver-eks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-eks/component.js
@@ -778,7 +778,7 @@ export default Component.extend(ClusterDriver, {
 
         // Update map of names to count of occurrences (for duplication check)
         if (ng.name) {
-          nodeGroupNames[ng.name] = (nodeGroupNames[ng.name] || 0) + 1;        
+          nodeGroupNames[ng.name] = (nodeGroupNames[ng.name] || 0) + 1;
         }
       });
 
@@ -786,7 +786,7 @@ export default Component.extend(ClusterDriver, {
       const names = Object.keys(nodeGroupNames).filter((name) => nodeGroupNames[name] > 1).join(', ');
 
       if (names.length) {
-        nodePoolErrors.push(this.intl.t('clusterNew.nodeGroups.errors.namesNotUnique', { names }));
+        nodeGroupErrors.push(this.intl.t('clusterNew.nodeGroups.errors.namesNotUnique', { names }));
       }
 
       if (!isEmpty(nodeGroupErrors)) {

--- a/lib/shared/addon/components/cluster-driver/driver-gke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/component.js
@@ -988,12 +988,25 @@ export default Component.extend(ClusterDriver, {
 
     if (!isEmpty(nodePools)) {
       const nodePoolErrors = [];
+      const nodePoolNames = {};
 
       nodePools.forEach((np) => {
         const npErr = np.validationErrors();
 
         nodePoolErrors.push(npErr)
+
+        // Update map of names to count of occurrences (for duplication check)
+        if (np.name) {
+          nodePoolNames[np.name] = (nodePoolNames[np.name] || 0) + 1;
+        }
       });
+
+      // Node pool names must be unique
+      const names = Object.keys(nodePoolNames).filter((name) => nodePoolNames[name] > 1).join(', ');
+
+      if (names.length) {
+        nodePoolErrors.push(this.intl.t('clusterNew.nodePools.errors.namesNotUnique', { names }));
+      }
 
       if (!isEmpty(nodePoolErrors)) {
         errors.pushObjects(nodePoolErrors.flat());

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4404,9 +4404,13 @@ clusterNew:
     label: Cluster Name
     placeholder: e.g. sandbox
     required: '"Cluster Name" is required'
+  nodeGroups:
+    errors:
+      namesNotUnique: "Node group names must be unique - duplicate names detected: {names}"
   nodePools:
     errors:
       hostnamePrefix: Node pools must have unique name prefixes
+      namesNotUnique: "Node pool names must be unique - duplicate names detected: {names}"
   nodes:
     detail: Customize the nodes that will be created
     title: Node Options


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/9987
Addresses https://github.com/rancher/dashboard/issues/4465

This PR adds node pool/group duplicate name validation for gke, aks and eks.

Same pattern is used in each - for simplicity, added to each provider, rather than attempt to factor into some common code. Ember code is legacy, so this feels like a reasonable approach to address this issue.

Code is straight-forward - adds to the validation method to check each node pool/group name - adds an error with the names of the duplicates if found.

To test, for each provider, add several node pools/groups with some duplicates and validate that you see the error message. Pleas also test with node groups without names.