### PR TITLE
fix aws-external warning banner visibility

### DIFF
--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -114,6 +114,7 @@ export default Component.extend({
     } else if (get(this, 'unsupportedProviderSelected')){
       setProperties(this, {
         unsupportedProviderSelected: false,
+        showChangedToAmazonExternal: false,
         selectedCloudProvider:       get(this, 'initialCloudProvider'),
         configAnswers:               get(this, 'initialConfigAnswers')
       })


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/10290 - the banner warning the user that the cloud provider has been changed should be hidden when the cloud provider change is reverted.


https://github.com/rancher/ui/assets/42977925/23de0233-4bca-46be-b56d-0d3cc36addb4

