### PR TITLE
[2.7] Backport AWS external cloud provider support; removal of aws in-tree cloud provider

### DIFF
--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -231,6 +231,12 @@ export default Component.extend({
     return !get(this, 'model.harvesterNodeTemplateId') || !get(this, 'cluster.name') || isExternalCredential
   }),
 
+  awsSupported: computed('cluster.rancherKubernetesEngineConfig.kubernetesVersion', function(){
+    const kubernetesVersion = get(this, 'cluster.rancherKubernetesEngineConfig.kubernetesVersion')
+
+    return Semver.lt(Semver.coerce(kubernetesVersion), '1.27.0')
+  }),
+
   checkDefaults(record) {
     get(this, 'azureDefaults').forEach((def) => {
       if (isEmpty(record[def])) {

--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -10,6 +10,7 @@ import C from 'ui/utils/constants';
 import { azure as AzureInfo } from './cloud-provider-info';
 import { next } from '@ember/runloop';
 import { debouncedObserver } from 'ui/utils/debounce';
+import Semver from 'semver';
 
 const azureDefaults = C.AZURE_DEFAULTS;
 const GENERIC_PATH  = 'cluster.rancherKubernetesEngineConfig.cloudProvider.cloudConfig';
@@ -17,22 +18,26 @@ const AWS_PATH      = 'cluster.rancherKubernetesEngineConfig.cloudProvider.awsCl
 const AZURE_PATH    = 'cluster.rancherKubernetesEngineConfig.cloudProvider.azureCloudProvider';
 
 export default Component.extend({
-  globalStore:           service(),
-  settings:              service(),
-  growl:                 service(),
+  globalStore:            service(),
+  settings:               service(),
+  growl:                  service(),
   layout,
-  configType:            null,
-  cluster:               null,
-  driver:                null,
-  selectedCloudProvider: 'none',
-  mode:                  'new',
-  hasBuiltIn:            false,
-  configAnswers:         null,
-  clusterTemplateCreate: false,
-  configVariable:        null,
-  questions:             null,
+  configType:             null,
+  cluster:                null,
+  driver:                 null,
+  selectedCloudProvider:  'none',
+  mode:                   'new',
+  hasBuiltIn:             false,
+  configAnswers:          null,
+  clusterTemplateCreate:  false,
+  configVariable:         null,
+  questions:              null,
   azureDefaults,
-  azureDescriptions:     AzureInfo,
+  azureDescriptions:      AzureInfo,
+  showDeprecationWarning: false,
+  // track the original configuration to revert the switch to 'external' when the selected provider isnt supported
+  initialCloudProvider:   null,
+  initialConfigAnswers:   null,
 
   configName: alias('cluster.rancherKubernetesEngineConfig.cloudProvider.name'),
 
@@ -45,7 +50,9 @@ export default Component.extend({
     if ( cloudProviderName === 'aws' ) {
       setProperties(this, {
         selectedCloudProvider: 'amazonec2',
-        configAnswers:         get(this, AWS_PATH)
+        configAnswers:         get(this, AWS_PATH),
+        initialCloudProvider:  'amazonec2',
+        initialConfigAnswers:         get(this, AWS_PATH)
       });
     } else if ( cloudProviderName === 'azure' ) {
       const reorderedAnswers = this.sortAzureFields(this.globalStore.getById('schema', 'azurecloudprovider'), get(this, AZURE_PATH));
@@ -55,13 +62,17 @@ export default Component.extend({
       setProperties(this, {
         selectedCloudProvider: 'azure',
         configAnswers:         reorderedAnswers,
+        initialCloudProvider:  'azure',
+        initialConfigAnswers:         reorderedAnswers
       });
     } else if ( !cloudProviderName ) {
       set(this, 'selectedCloudProvider', 'none');
     } else {
       setProperties(this, {
         selectedCloudProvider: 'generic',
-        configAnswers:         get(this, GENERIC_PATH)
+        configAnswers:         get(this, GENERIC_PATH),
+        initialCloudProvider:  'generic',
+        initialConfigAnswers:         get(this, GENERIC_PATH)
       });
     }
   },
@@ -87,6 +98,23 @@ export default Component.extend({
   harvesterCloudProviderDisabledChange: observer('harvesterCloudProviderDisabled', function() {
     if (get(this, 'harvesterCloudProviderDisabled')) {
       set(this, 'selectedCloudProvider', 'none')
+    }
+  }),
+
+  k8sVersionDidChage: observer( 'cluster.rancherKubernetesEngineConfig.kubernetesVersion', function(){
+    const kubernetesVersion = get(this, 'cluster.rancherKubernetesEngineConfig.kubernetesVersion')
+    const selectedCloudProvider = get(this, 'selectedCloudProvider')
+
+    if (selectedCloudProvider === 'amazonec2' && Semver.gte(Semver.coerce(kubernetesVersion), '1.27.0')){
+      set(this, 'showDeprecationWarning', true)
+      set(this, 'selectedCloudProvider', 'external')
+      this.constructConfig()
+    } else if (get(this, 'showDeprecationWarning')){
+      setProperties(this, {
+        showDeprecationWarning: false,
+        selectedCloudProvider:  'amazonec2',
+        configAnswers:          get(this, 'initialConfigAnswers')
+      })
     }
   }),
 

--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -351,8 +351,9 @@ export default Component.extend({
     case 'external-aws':
 
       set(config, 'cloudProvider', get(this, 'globalStore').createRecord({
-        type:             'cloudProvider',
-        name:             'external-aws',
+        type:                        'cloudProvider',
+        name:                        'external-aws',
+        useInstanceMetadataHostname: true,
       }));
 
       break;

--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -107,7 +107,7 @@ export default Component.extend({
 
     if (selectedCloudProvider === 'amazonec2' && Semver.gte(Semver.coerce(kubernetesVersion), '1.27.0')){
       set(this, 'unsupportedProviderSelected', true)
-      set(this, 'selectedCloudProvider', 'external')
+      set(this, 'selectedCloudProvider', 'external-aws')
       this.constructConfig()
     } else if (get(this, 'unsupportedProviderSelected')){
       setProperties(this, {

--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -35,7 +35,8 @@ export default Component.extend({
   azureDefaults,
   azureDescriptions:           AzureInfo,
   unsupportedProviderSelected: false,
-  // track the original configuration to revert the switch to 'external' when the selected provider isnt supported
+  showChangedToAmazonExternal: false,
+  // track the original configuration to revert the switch to 'external' when the selected provider is not supported
   initialCloudProvider:        null,
   initialConfigAnswers:        null,
 
@@ -101,13 +102,14 @@ export default Component.extend({
     }
   }),
 
-  k8sVersionDidChage: observer( 'cluster.rancherKubernetesEngineConfig.kubernetesVersion', function(){
+  k8sVersionDidChange: observer( 'cluster.rancherKubernetesEngineConfig.kubernetesVersion', function(){
     const kubernetesVersion = get(this, 'cluster.rancherKubernetesEngineConfig.kubernetesVersion')
     const selectedCloudProvider = get(this, 'selectedCloudProvider')
 
     if (selectedCloudProvider === 'amazonec2' && Semver.gte(Semver.coerce(kubernetesVersion), '1.27.0')){
-      set(this, 'unsupportedProviderSelected', true)
-      set(this, 'selectedCloudProvider', 'external-aws')
+      set(this, 'unsupportedProviderSelected', true);
+      set(this, 'selectedCloudProvider', 'external-aws');
+      set(this, 'showChangedToAmazonExternal', true);
       this.constructConfig()
     } else if (get(this, 'unsupportedProviderSelected')){
       setProperties(this, {
@@ -152,6 +154,7 @@ export default Component.extend({
     'applyClusterTemplate', 'clusterTemplateCreate', 'clusterTemplateRevision.{id,questions}', 'configName', 'selectedCloudProvider', 'isDestroying', 'isDestroyed',
     function() {
       let { clusterTemplateRevision, applyClusterTemplate } = this;
+
 
       if (applyClusterTemplate && clusterTemplateRevision) {
         if (clusterTemplateRevision.questions) {
@@ -373,6 +376,10 @@ export default Component.extend({
 
   addOverride() {
     throw new Error('addOverride action is required!');
+  },
+
+  cloudProviderUserChange() {
+    set(this, 'showChangedToAmazonExternal', false);
   },
 
   getHarvesterCluster() {

--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -114,6 +114,7 @@ export default Component.extend({
     } else if (get(this, 'unsupportedProviderSelected')){
       setProperties(this, {
         unsupportedProviderSelected: false,
+        showChangedToAmazonExternal: false,
         selectedCloudProvider:       get(this, 'initialCloudProvider'),
         configAnswers:               get(this, 'initialConfigAnswers')
       })

--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -348,6 +348,15 @@ export default Component.extend({
 
       break;
 
+    case 'external-aws':
+
+      set(config, 'cloudProvider', get(this, 'globalStore').createRecord({
+        type:             'cloudProvider',
+        name:             'external-aws',
+      }));
+
+      break;
+
     case 'external':
 
       set(config, 'cloudProvider', get(this, 'globalStore').createRecord({

--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -18,26 +18,26 @@ const AWS_PATH      = 'cluster.rancherKubernetesEngineConfig.cloudProvider.awsCl
 const AZURE_PATH    = 'cluster.rancherKubernetesEngineConfig.cloudProvider.azureCloudProvider';
 
 export default Component.extend({
-  globalStore:            service(),
-  settings:               service(),
-  growl:                  service(),
+  globalStore:                 service(),
+  settings:                    service(),
+  growl:                       service(),
   layout,
-  configType:             null,
-  cluster:                null,
-  driver:                 null,
-  selectedCloudProvider:  'none',
-  mode:                   'new',
-  hasBuiltIn:             false,
-  configAnswers:          null,
-  clusterTemplateCreate:  false,
-  configVariable:         null,
-  questions:              null,
+  configType:                  null,
+  cluster:                     null,
+  driver:                      null,
+  selectedCloudProvider:       'none',
+  mode:                        'new',
+  hasBuiltIn:                  false,
+  configAnswers:               null,
+  clusterTemplateCreate:       false,
+  configVariable:              null,
+  questions:                   null,
   azureDefaults,
-  azureDescriptions:      AzureInfo,
-  showDeprecationWarning: false,
+  azureDescriptions:           AzureInfo,
+  unsupportedProviderSelected: false,
   // track the original configuration to revert the switch to 'external' when the selected provider isnt supported
-  initialCloudProvider:   null,
-  initialConfigAnswers:   null,
+  initialCloudProvider:        null,
+  initialConfigAnswers:        null,
 
   configName: alias('cluster.rancherKubernetesEngineConfig.cloudProvider.name'),
 
@@ -63,16 +63,16 @@ export default Component.extend({
         selectedCloudProvider: 'azure',
         configAnswers:         reorderedAnswers,
         initialCloudProvider:  'azure',
-        initialConfigAnswers:         reorderedAnswers
+        initialConfigAnswers:  reorderedAnswers
       });
     } else if ( !cloudProviderName ) {
       set(this, 'selectedCloudProvider', 'none');
     } else {
       setProperties(this, {
-        selectedCloudProvider: 'generic',
+        selectedCloudProvider: cloudProviderName ?  cloudProviderName : 'generic',
         configAnswers:         get(this, GENERIC_PATH),
-        initialCloudProvider:  'generic',
-        initialConfigAnswers:         get(this, GENERIC_PATH)
+        initialCloudProvider:  cloudProviderName ?  cloudProviderName : 'generic',
+        initialConfigAnswers:  get(this, GENERIC_PATH)
       });
     }
   },
@@ -106,14 +106,14 @@ export default Component.extend({
     const selectedCloudProvider = get(this, 'selectedCloudProvider')
 
     if (selectedCloudProvider === 'amazonec2' && Semver.gte(Semver.coerce(kubernetesVersion), '1.27.0')){
-      set(this, 'showDeprecationWarning', true)
+      set(this, 'unsupportedProviderSelected', true)
       set(this, 'selectedCloudProvider', 'external')
       this.constructConfig()
-    } else if (get(this, 'showDeprecationWarning')){
+    } else if (get(this, 'unsupportedProviderSelected')){
       setProperties(this, {
-        showDeprecationWarning: false,
-        selectedCloudProvider:  'amazonec2',
-        configAnswers:          get(this, 'initialConfigAnswers')
+        unsupportedProviderSelected: false,
+        selectedCloudProvider:       get(this, 'initialCloudProvider'),
+        configAnswers:               get(this, 'initialConfigAnswers')
       })
     }
   }),
@@ -170,21 +170,10 @@ export default Component.extend({
               if (this.isDestroyed || this.isDestroying) {
                 return;
               }
-
               set(this, 'selectedCloudProvider', this.configName);
             });
           }
         }
-      } else {
-        next(() => {
-          if (!this.configName) {
-            if (this.isDestroyed || this.isDestroying) {
-              return;
-            }
-
-            set(this, 'selectedCloudProvider', this.selectedCloudProvider === 'generic' ? 'generic' : 'none');
-          }
-        });
       }
 
       return false;
@@ -235,6 +224,10 @@ export default Component.extend({
     const kubernetesVersion = get(this, 'cluster.rancherKubernetesEngineConfig.kubernetesVersion')
 
     return Semver.lt(Semver.coerce(kubernetesVersion), '1.27.0')
+  }),
+
+  canEditProvider: computed('applyClusterTemplate', 'unsupportedProviderSelected', function(){
+    return (!!get(this, 'applyClusterTemplate') || get(this, 'unsupportedProviderSelected'))
   }),
 
   checkDefaults(record) {

--- a/lib/shared/addon/components/cru-cloud-provider/template.hbs
+++ b/lib/shared/addon/components/cru-cloud-provider/template.hbs
@@ -40,7 +40,7 @@
     @computedState={{not (eq selectedCloudProvider "none")}}
   >
     {{#input-or-display
-       editable=(or (and (eq mode "new") (or (not applyClusterTemplate) (and (eq mode "new") selectedCloudProviderOverrideAvailable))) clusterTemplateCreate)
+       editable=(or (and (eq mode "new") (or (not applyClusterTemplate) (and (eq mode "new") selectedCloudProviderOverrideAvailable))) canEditProvider)
        value=selectedCloudProvider
     }}
       <div class="col span-6">
@@ -173,7 +173,7 @@
       </div>
     {{/input-or-display}}
   </CheckComputedOverride>
-  {{#if showDeprecationWarning}}
+  {{#if unsupportedProviderSelected}}
     <div class="col span-12">
       <BannerMessage
         @color="bg-info mt-0 mb-0"

--- a/lib/shared/addon/components/cru-cloud-provider/template.hbs
+++ b/lib/shared/addon/components/cru-cloud-provider/template.hbs
@@ -56,6 +56,7 @@
               {{radio-button
                 selection=selectedCloudProvider
                 value="none"
+                chosen=(action cloudProviderUserChange)
               }} {{t "generic.none"}}
             </label>
           </div>
@@ -74,6 +75,7 @@
                   {{radio-button
                     selection=selectedCloudProvider
                     value="amazonec2"
+                    chosen=(action cloudProviderUserChange)
                   }} {{t "cloudProvider.amazon"}}
                 </label>
               </div>
@@ -154,6 +156,27 @@
           {{/if}}
         {{/if}}
 
+        {{#if (or (eq driver "amazonec2") (eq driver "custom"))}}
+          {{#if (and applyClusterTemplate (eq selectedCloudProvider "external-aws"))}}
+            <div class="radio">
+              <label>
+                {{t "cloudProvider.externalAmazon.label"}}
+              </label>
+            </div>
+          {{else if isCreateClusterOrClusterTemplate}}
+              <div class="radio">
+                <label>
+                  {{radio-button
+                    selection=selectedCloudProvider
+                    value="external-aws"
+                    chosen=(action cloudProviderUserChange)
+                  }} {{t "cloudProvider.externalAmazon.label"}}
+                </label>
+              </div>
+          {{/if}}
+        {{/if}}
+
+
         {{#if (and applyClusterTemplate (eq selectedCloudProvider "external"))}}
           <div class="radio">
             <label>
@@ -166,6 +189,7 @@
               {{radio-button
                 selection=selectedCloudProvider
                 value="external"
+                chosen=(action cloudProviderUserChange)
               }} {{t "cloudProvider.external.label"}}
             </label>
           </div>
@@ -173,7 +197,7 @@
       </div>
     {{/input-or-display}}
   </CheckComputedOverride>
-  {{#if unsupportedProviderSelected}}
+  {{#if showChangedToAmazonExternal}}
     <div class="col span-12">
       <BannerMessage
         @color="bg-info mt-0 mb-0"
@@ -182,14 +206,24 @@
       />
     </div>
   {{/if}}
-  {{#if (and (not-eq selectedCloudProvider "none") (eq mode "new"))}}
-    <div class="col span-12">
-      <BannerMessage
-        @color="bg-info mt-0 mb-0"
-        @icon="icon-alert"
-        @message={{t "cloudProvider.warning"}}
-      />
-    </div>
+  {{#if (not-eq selectedCloudProvider "none")}}
+    {{#if (eq selectedCloudProvider "external-aws")}}
+      <div class="col span-12">
+        <BannerMessage
+          @color="bg-info mt-0 mb-0"
+          @icon="icon-alert"
+          @message={{t "cloudProvider.externalAmazon.helpText"}}
+        />
+      </div>
+    {{else }}
+      <div class="col span-12">
+        <BannerMessage
+          @color="bg-info mt-0 mb-0"
+          @icon="icon-alert"
+          @message={{t "cloudProvider.warning"}}
+        />
+      </div>
+    {{/if}}
   {{/if}}
 </div>
 

--- a/lib/shared/addon/components/cru-cloud-provider/template.hbs
+++ b/lib/shared/addon/components/cru-cloud-provider/template.hbs
@@ -171,6 +171,15 @@
       </div>
     {{/input-or-display}}
   </CheckComputedOverride>
+  {{#if showDeprecationWarning}}
+    <div class="col span-12">
+      <BannerMessage
+        @color="bg-info mt-0 mb-0"
+        @icon="icon-alert"
+        @message={{t "cloudProvider.unsupported"}}
+      />
+    </div>
+  {{/if}}
   {{#if (and (not-eq selectedCloudProvider "none") (eq mode "new"))}}
     <div class="col span-6">
       <BannerMessage

--- a/lib/shared/addon/components/cru-cloud-provider/template.hbs
+++ b/lib/shared/addon/components/cru-cloud-provider/template.hbs
@@ -68,14 +68,16 @@
               </label>
             </div>
           {{else if isCreateClusterOrClusterTemplate}}
-            <div class="radio">
-              <label>
-                {{radio-button
-                  selection=selectedCloudProvider
-                  value="amazonec2"
-                }} {{t "cloudProvider.amazon"}}
-              </label>
-            </div>
+            {{#if awsSupported}}
+              <div class="radio">
+                <label>
+                  {{radio-button
+                    selection=selectedCloudProvider
+                    value="amazonec2"
+                  }} {{t "cloudProvider.amazon"}}
+                </label>
+              </div>
+            {{/if}}
           {{/if}}
         {{/if}}
         {{#if (or (eq driver "azure") (eq driver "custom"))}}
@@ -181,7 +183,7 @@
     </div>
   {{/if}}
   {{#if (and (not-eq selectedCloudProvider "none") (eq mode "new"))}}
-    <div class="col span-6">
+    <div class="col span-12">
       <BannerMessage
         @color="bg-info mt-0 mb-0"
         @icon="icon-alert"

--- a/lib/shared/addon/components/radio-button/component.js
+++ b/lib/shared/addon/components/radio-button/component.js
@@ -14,6 +14,9 @@ export default Component.extend({
   }),
   click() {
     this.set('selection', this.get('value'));
+
+    this.chosen();
   },
 
+  chosen() {}
 });

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3182,7 +3182,7 @@ cloudProvider:
 
   helpText: |
      Read more about the state of the <a href="https://kubernetes.io/blog/2019/04/17/the-future-of-cloud-providers-in-kubernetes/" target="_blank" rel="nofollow noopener noreferrer">Kubernetes in-tree cloud providers</a>
-  unsupported: The current Cloud Provider is not supported by this version of Kubernetes. The Cloud Provider has been changed to External Amazon. Please use the Cloud Provider Config to supply an out-of-tree configuration as needed.
+  unsupported: The current Cloud Provider is not supported by this version of Kubernetes. The Cloud Provider has been changed to External Amazon.
   warning:
     Configuring a Cloud Provider in your cluster without configuring the prerequisites will cause your cluster to not provision correctly. Prerequisites needed for supported cloud providers can be found in the documentation.
   azureCloudConfig:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3179,7 +3179,7 @@ cloudProvider:
 
   helpText: |
      Read more about the state of the <a href="https://kubernetes.io/blog/2019/04/17/the-future-of-cloud-providers-in-kubernetes/" target="_blank" rel="nofollow noopener noreferrer">Kubernetes in-tree cloud providers</a>
-  unsupported: The current Cloud Provider is not supported by this version of Kubernetes. The Cloud Provider has been changed to External. Please use the Cloud Provider Config to supply an out-of-tree configuration as needed.
+  unsupported: The current Cloud Provider is not supported by this version of Kubernetes. The Cloud Provider has been changed to External Amazon. Please use the Cloud Provider Config to supply an out-of-tree configuration as needed.
   warning:
     Configuring a Cloud Provider in your cluster without configuring the prerequisites will cause your cluster to not provision correctly. Prerequisites needed for supported cloud providers can be found in the documentation.
   azureCloudConfig:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3179,6 +3179,7 @@ cloudProvider:
 
   helpText: |
      Read more about the state of the <a href="https://kubernetes.io/blog/2019/04/17/the-future-of-cloud-providers-in-kubernetes/" target="_blank" rel="nofollow noopener noreferrer">Kubernetes in-tree cloud providers</a>
+  unsupported: The current Cloud Provider is not supported by this version of Kubernetes. The Cloud Provider has been changed to External. Please use the Cloud Provider Config to supply an out-of-tree configuration as needed.
   warning:
     Configuring a Cloud Provider in your cluster without configuring the prerequisites will cause your cluster to not provision correctly. Prerequisites needed for supported cloud providers can be found in the documentation.
   azureCloudConfig:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3163,9 +3163,12 @@ taintsSection:
 cloudProvider:
   title: Cloud Provider
   amazon: Amazon (In-Tree)
+  externalAmazon: 
+    label: External Amazon (Out-Of-Tree) 
+    helpText: External Amazon enables use of useInstanceMetadataHostname. When useInstanceMetadataHostname is enabled, RKE will configure node name from ec2 metadata service. Configuring a Cloud Provider in your cluster without configuring the prerequisites will cause your cluster to not provision correctly. Prerequisites needed for supported cloud providers can be found in the documentation.
   azure: Azure (In-Tree)
   external:
-    label: External (Out-of-tree)
+    label: External (Out-Of-Tree)
     helpText: 'Please edit the YAML to specify the required addon for cloud controller manager.'
     vsphereHelpText: 'Out-of-tree cloud provider for vsphere is available through the vsphere-csi and vsphere-cpi helm charts. Please refer to the <a href="{docsBase}/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree" target="_blank" rel="nofollow noopener noreferrer">docs</a> for installation.'
   name: Cloud Provider Name


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/10297
https://github.com/rancher/dashboard/issues/10266 - this issue also has an rke2 portion to be backported in rancher/dashboard.

This is a backport of a few PRs: 
https://github.com/rancher/ui/pull/5064 (remove the aws in-tree option for k8s >=1.27)
https://github.com/rancher/ui/pull/5078 (add an external-aws option)
https://github.com/rancher/ui/pull/5082 (improve the banners around the above 2 PRs)

For testing purposes, you can add 1.27 to the list of available versions by adding code [here](https://github.com/mantis-toboggan-md/ui/blob/5551da85705b1101d2cc84dadd13f73cf72e98bd/lib/shared/addon/components/form-versions/component.js#L144)
```
    mappedVersions.push({
      disbaled:     false,
      experimental: false,
      label:        'v1.27.0-rancher1-1',
      value:        'v1.27.0-rancher1-1'
    })
```