### PR TITLE
[2.7] Show banner that Weave is deprecated for k8s >= 1.27

### DIFF
--- a/lib/shared/addon/components/form-network-config/component.js
+++ b/lib/shared/addon/components/form-network-config/component.js
@@ -55,6 +55,7 @@ export default Component.extend({
   enableNetworkPolicy:     null,
   clusterTemplateRevision: null,
   applyClusterTemplate:    null,
+  weaveDeprecated:         false,
 
   windowsSupportOverrideAvailable: false,
 
@@ -64,6 +65,8 @@ export default Component.extend({
     this._super(...arguments);
 
     this.setFlannelLables();
+
+    this.checkWeaveDeprecation();
   },
 
   windowsSupportAvailableDidChange: observer('windowsSupportAvailable', function() {
@@ -115,6 +118,10 @@ export default Component.extend({
     }
   }),
 
+  k8sVersionDidChange: observer('config.kubernetesVersion', function() {
+    this.checkWeaveDeprecation();
+  }),
+
   networkPluginDidChange: observer('config.network.plugin', function() {
     let plugin = get(this, 'config.network.plugin');
 
@@ -131,6 +138,8 @@ export default Component.extend({
       } else if (plugin !== WEAVE && get(this, 'config.network.weaveNetworkProvider.password')) {
         set(this, 'config.network.weaveNetworkProvider', null);
       }
+
+      this.checkWeaveDeprecation();
     }
   }),
 
@@ -157,5 +166,14 @@ export default Component.extend({
     } else {
       set(flannel, 'label', 'clusterNew.rke.network.flannel');
     }
+  },
+
+  // Weave networking is deprecated as of Kubernetes 1.27 - show a banner to the user when they select Weave and >= 1.27
+  checkWeaveDeprecation() {
+    const plugin = get(this, 'config.network.plugin');
+    const kubernetesVersion = get(this, 'config.kubernetesVersion');
+    const deprecated = (plugin === WEAVE && gte(coerceVersion(kubernetesVersion), 'v1.27.0'));
+
+    set(this, 'weaveDeprecated', deprecated);
   },
 });

--- a/lib/shared/addon/components/form-network-config/component.js
+++ b/lib/shared/addon/components/form-network-config/component.js
@@ -115,10 +115,6 @@ export default Component.extend({
     }
   }),
 
-  k8sVersionDidChange: observer('config.kubernetesVersion', function() {
-    this.checkWeaveDeprecation();
-  }),
-
   networkPluginDidChange: observer('config.network.plugin', function() {
     let plugin = get(this, 'config.network.plugin');
 
@@ -135,8 +131,6 @@ export default Component.extend({
       } else if (plugin !== WEAVE && get(this, 'config.network.weaveNetworkProvider.password')) {
         set(this, 'config.network.weaveNetworkProvider', null);
       }
-
-      this.checkWeaveDeprecation();
     }
   }),
 

--- a/lib/shared/addon/components/form-network-config/component.js
+++ b/lib/shared/addon/components/form-network-config/component.js
@@ -155,6 +155,15 @@ export default Component.extend({
     return networkPolicySafe.includes(plugin);
   }),
 
+  // Weave networking is deprecated as of Kubernetes 1.27 - show a banner to the user when they select Weave and >= 1.27
+  weaveDeprecated: computed('config.network.plugin', 'config.kubernetesVersion', function() {
+    const plugin = get(this, 'config.network.plugin');
+    const kubernetesVersion = get(this, 'config.kubernetesVersion');
+    const deprecated = (plugin === WEAVE && gte(coerceVersion(kubernetesVersion), 'v1.27.0'));
+
+    return deprecated;
+  }),
+
   setFlannelLables() {
     let flannel = this.networkContent.findBy('value', 'flannel');
 
@@ -164,13 +173,4 @@ export default Component.extend({
       set(flannel, 'label', 'clusterNew.rke.network.flannel');
     }
   },
-
-  // Weave networking is deprecated as of Kubernetes 1.27 - show a banner to the user when they select Weave and >= 1.27
-  weaveDeprecated: computed('config.network.plugin', 'config.kubernetesVersion', function() {
-    const plugin = get(this, 'config.network.plugin');
-    const kubernetesVersion = get(this, 'config.kubernetesVersion');
-    const deprecated = (plugin === WEAVE && gte(coerceVersion(kubernetesVersion), 'v1.25.0'));
-
-    return deprecated;
-  }),
 });

--- a/lib/shared/addon/components/form-network-config/component.js
+++ b/lib/shared/addon/components/form-network-config/component.js
@@ -55,7 +55,6 @@ export default Component.extend({
   enableNetworkPolicy:     null,
   clusterTemplateRevision: null,
   applyClusterTemplate:    null,
-  weaveDeprecated:         false,
 
   windowsSupportOverrideAvailable: false,
 
@@ -65,8 +64,6 @@ export default Component.extend({
     this._super(...arguments);
 
     this.setFlannelLables();
-
-    this.checkWeaveDeprecation();
   },
 
   windowsSupportAvailableDidChange: observer('windowsSupportAvailable', function() {
@@ -169,11 +166,11 @@ export default Component.extend({
   },
 
   // Weave networking is deprecated as of Kubernetes 1.27 - show a banner to the user when they select Weave and >= 1.27
-  checkWeaveDeprecation() {
+  weaveDeprecated: computed('config.network.plugin', 'config.kubernetesVersion', function() {
     const plugin = get(this, 'config.network.plugin');
     const kubernetesVersion = get(this, 'config.kubernetesVersion');
-    const deprecated = (plugin === WEAVE && gte(coerceVersion(kubernetesVersion), 'v1.27.0'));
+    const deprecated = (plugin === WEAVE && gte(coerceVersion(kubernetesVersion), 'v1.25.0'));
 
-    set(this, 'weaveDeprecated', deprecated);
-  },
+    return deprecated;
+  }),
 });

--- a/lib/shared/addon/components/form-network-config/template.hbs
+++ b/lib/shared/addon/components/form-network-config/template.hbs
@@ -33,6 +33,11 @@
       {{/input-or-display}}
     </CheckOverrideAllowed>
 
+    {{#if weaveDeprecated}}
+      {{#banner-message color="bg-warning"}}
+        <p>{{t 'clusterNew.rke.network.banners.weaveDeprecation' htmlSafe=true}}</p>
+      {{/banner-message}}
+    {{/if}}
   </div>
 
   {{!-- disabled for now --}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4706,6 +4706,8 @@ clusterNew:
     monitoring:
       label: Metrics Server Monitoring
     network:
+      banners:
+        weaveDeprecation: The Weave CNI plugin is deprecated as of Kubernetes 1.27 and will be removed in 1.30
       calico: Calico
       canal: Canal
       detail: Configure the networking for the cluster


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/10291

Backport of https://github.com/rancher/ui/pull/5062