### PR TITLE
[2.8] fix aws-external warning banner visibility

### DIFF
--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -114,6 +114,7 @@ export default Component.extend({
     } else if (get(this, 'unsupportedProviderSelected')){
       setProperties(this, {
         unsupportedProviderSelected: false,
+        showChangedToAmazonExternal: false,
         selectedCloudProvider:       get(this, 'initialCloudProvider'),
         configAnswers:               get(this, 'initialConfigAnswers')
       })


### PR DESCRIPTION
Backport of https://github.com/rancher/ui/pull/5105

GH issue for the backport is https://github.com/rancher/dashboard/issues/10298