### PR TITLE
Added deprecation warnings to embedded Secrets and Config Maps tabs

### DIFF
--- a/app/authenticated/project/config-maps/index/controller.js
+++ b/app/authenticated/project/config-maps/index/controller.js
@@ -1,6 +1,7 @@
 import { alias } from '@ember/object/computed';
 import { get, computed } from '@ember/object';
 import Controller, { inject as controller } from '@ember/controller';
+import { isEmbedded } from 'shared/utils/util';
 
 export const headers = [
   {
@@ -47,6 +48,7 @@ export default Controller.extend({
   resource:    ['configmap'],
 
   headers,
+  showLegacyMessage: isEmbedded(),
 
   group:        alias('projectController.group'),
   groupTableBy: alias('projectController.groupTableBy'),

--- a/app/authenticated/project/config-maps/index/template.hbs
+++ b/app/authenticated/project/config-maps/index/template.hbs
@@ -1,3 +1,12 @@
+{{#if showLegacyMessage}}
+  {{#banner-message color="bg-info"}}
+    <p>{{t 'banner.configmaps'}}</p>
+  {{/banner-message}}
+  {{#banner-message color="bg-warning"}}
+    <p>{{t 'banner.configmapsDeprecated' htmlSafe=true}}</p>
+  {{/banner-message}}
+{{/if}}
+
 <section class="header">
   <h1>{{t 'configMapsPage.index.header'}}</h1>
   <div class="right-buttons">

--- a/app/components/security-header/template.hbs
+++ b/app/components/security-header/template.hbs
@@ -2,6 +2,9 @@
   {{#banner-message color="bg-info"}}
     <p>{{t 'banner.secrets'}}</p>
   {{/banner-message}}
+  {{#banner-message color="bg-warning"}}
+    <p>{{t 'banner.secretsDeprecated' htmlSafe=true}}</p>
+  {{/banner-message}}
 {{/if}}
 <section class="has-tabs clearfix p-0">
   <ul class="tab-nav">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1015,13 +1015,16 @@ banner:
   pipeline: Pipelines has been deprecated as of Rancher 2.5.0 - check out the <a href="{docsBase}/faq/deprecated-features-25x" target="_blank">FAQ</a>. For continuous delivery capabilities check out <a href="{dashboardBase}c/local/fleet">Rancher Continuous Delivery</a> in the new view.
   pipeline21: Pipelines in Kubernetes 1.21+ are no longer supported.
   upgrade21: The legacy feature flag is enabled and not all legacy features are supported in Kubernetes 1.21+.
-  secrets: Legacy project functionality can be used to manage secrets that need to be available to all namespaces in a project
+  secrets: Legacy project functionality can be used to manage secrets that need to be available to all namespaces in a project.
   globalDnsProviders: Global DNS Providers have been deprecated as of Rancher v2.7.0 and will be removed in a future release - check out the <a href="https://github.com/rancher/rancher/releases/tag/v2.7.0" target="_blank">Release Notes</a>.
   globalDnsEntries: Global DNS Entries have been deprecated as of Rancher v2.7.0 and will be removed in a future release - check out the <a href="https://github.com/rancher/rancher/releases/tag/v2.7.0" target="_blank">Release Notes</a>.
   globalCatalogs: Global Catalogs have been deprecated as of Rancher v2.7.0 and will be removed in a future release - check out the <a href="https://github.com/rancher/rancher/releases/tag/v2.7.0" target="_blank">Release Notes</a>.
   catalogs: Catalogs have been deprecated as of Rancher v2.7.0 and will be removed in a future release - check out the <a href="https://github.com/rancher/rancher/releases/tag/v2.7.0" target="_blank">Release Notes</a>.
   apps: Legacy Apps have been deprecated as of Rancher v2.7.0 and will be removed in a future release - check out the <a href="https://github.com/rancher/rancher/releases/tag/v2.7.0" target="_blank">Release Notes</a>.
+  secretsDeprecated: Project-scoped Secrets have been deprecated as of Rancher v2.9.0 and will be removed in a future release - check out the <a href="https://github.com/rancher/rancher/releases/tag/v2.9.0" target="_blank">Release Notes</a>.
   longhorn: For more information on how to migrate the Longhorn chart installed in the legacy Rancher UI to the chart for the new Rancher UI see <a href="https://longhorn.io/kb/how-to-migrate-longhorn-chart-installed-in-old-rancher-ui-to-the-chart-in-new-rancher-ui/" target="_blank">here</a>.
+  configmaps: Legacy project functionality can be used to manage config maps that need to be available to all namespaces in a project.
+  configmapsDeprecated: Project-scoped Config Maps have been deprecated as of Rancher v2.9.0 and will be removed in a future release - check out the <a href="https://github.com/rancher/rancher/releases/tag/v2.9.0" target="_blank">Release Notes</a>.
 
 catalogPage:
   istio:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
- Added deprecation warning to Secrets tab
- Added deprecation warning and an info banner to Config Maps tab

Linked Issues
======
Fixes https://github.com/rancher/dashboard/issues/10321