### PR TITLE
[backport v2.7.patch1] Show info banner when upgrading Kubernetes 1.27 or greater

### DIFF
--- a/lib/shared/addon/components/managed-import-cluster-info/component.js
+++ b/lib/shared/addon/components/managed-import-cluster-info/component.js
@@ -19,7 +19,24 @@ export default Component.extend({
   editing:     false,
   configField: 'k3sConfig',
 
+  initialKubernetesVersion: null,
   supportedK8sVersionRange: alias(`settings.${ C.SETTING.VERSION_K8S_SUPPORTED_RANGE }`),
+
+  init() {
+    this._super(...arguments);
+
+    this.set('initialKubernetesVersion', get(this, `config.kubernetesVersion`))
+  },
+
+  showKubernetesVersionBanner: computed('config.kubernetesVersion', 'initialKubernetesVersion', function() {
+    const initialVersion = get(this, 'initialKubernetesVersion');
+    const selectedVersion = get(this, 'config.kubernetesVersion');
+
+    const initialIsLt127 = initialVersion && Semver.lt(initialVersion, '1.27.0');
+    const selectedIsGte127 = selectedVersion && Semver.gte(selectedVersion, '1.27.0');
+
+    return initialIsLt127 && selectedIsGte127;
+  }),
 
   config: computed('cluster.{k3sConfig,rke2Config}', 'configField', function() {
     return get(this, `cluster.${ this.configField }`);

--- a/lib/shared/addon/components/managed-import-cluster-info/template.hbs
+++ b/lib/shared/addon/components/managed-import-cluster-info/template.hbs
@@ -1,3 +1,11 @@
+{{#if showKubernetesVersionBanner}}
+  <div class="banner bg-info">
+    <div class="banner-icon"><i class="icon icon-info"></i></div>
+    <div class="banner-message pt-10 pb-10">
+      {{t 'managedImportClusterInfo.kubernetesVersionBanner' htmlSafe=true}}
+    </div>
+  </div>
+{{/if}}
 <div class="row">
   <div class="col span-6">
     <label class="acc-label">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -7991,6 +7991,7 @@ managedImportClusterInfo:
   title: "{provider} Options"
   detail: "Customize the {provider} cluster options"
   kubernetesVersion: Kubernetes Version
+  kubernetesVersionBanner: On Kubernetes 1.27 or greater, the Amazon Cloud Provider requires additional configuration.<br><br>See <a href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/migrate-to-an-out-of-tree-cloud-provider/migrate-to-out-of-tree-amazon" target="_blank">the documentation</a> for more information.
   workerConcurrency: Worker Concurrency
   serverConcurrency: Control Plane Concurrency
   drainServerNodes: Drain Control Plane Nodes


### PR DESCRIPTION
This displays an info banner that informs users about changes regarding in-tree cloud providers when upgrading to a version of Kubernetes >=1.27 from a version that is <=1.27.

![image](https://github.com/rancher/ui/assets/835961/45552cb9-3252-4867-8c5f-68395ac15d75)

backports rancher/dashboard#10414
closes rancher/dashboard#10419