### PR TITLE
Allowing users to disable project network isolation when editing an aks cluster

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-aks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-aks/component.js
@@ -83,6 +83,7 @@ export default Component.extend(ClusterDriver, {
   versions:                  null,
   vmSizes:                   null,
   originalSecret:            null,
+  originalNetworkPolicy:     null,
   regionsWithAZs,
 
   defaultNodePoolConfig: DEFAULT_AKS_NODE_POOL_CONFIG,
@@ -127,6 +128,7 @@ export default Component.extend(ClusterDriver, {
         }
       }
     }
+    set(this, 'originalNetworkPolicy', !!this.cluster?.enableNetworkPolicy);
 
     let cur = config?.azureCredentialSecret;
 

--- a/lib/shared/addon/components/cluster-driver/driver-aks/template.hbs
+++ b/lib/shared/addon/components/cluster-driver/driver-aks/template.hbs
@@ -592,20 +592,10 @@
                     <Input
                       @type="checkbox"
                       @checked={{mut cluster.enableNetworkPolicy}}
-                      @disabled={{or editing (not config.networkPolicy)}}
+                      @disabled={{or (not config.networkPolicy) (and editing (not originalNetworkPolicy) )}}
                     />
                     {{t "clusterNew.rke.networkPolicy.label"}}
-                    {{#if editing}}
-                      <TooltipElement
-                        @type="tooltip-basic"
-                        @model={{t "clusterNew.rke.networkPolicy.editHelp"}}
-                        @tooltipTemplate="tooltip-static"
-                        @aria-describedby="tooltip-base"
-                        @placement="top"
-                      >
-                        <i class="acc-label icon icon-info"></i>
-                      </TooltipElement>
-                    {{else if (not config.networkPolicy)}}
+                    {{#if (not config.networkPolicy)}}
                       <TooltipElement
                           @type="tooltip-basic"
                           @model={{t "clusterNew.rke.networkPolicy.selectNetworkPolicyHelp"}}
@@ -615,6 +605,11 @@
                         >
                           <i class="acc-label icon icon-info"></i>
                         </TooltipElement>
+                    {{else if (and editing (not originalNetworkPolicy))}}
+                    <TooltipElement @type="tooltip-basic" @model={{t "clusterNew.rke.networkPolicy.editHelp" }}
+                      @tooltipTemplate="tooltip-static" @aria-describedby="tooltip-base" @placement="top">
+                      <i class="acc-label icon icon-info"></i>
+                    </TooltipElement>
                     {{/if}}
                   </label>
                 </div>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -4720,7 +4720,7 @@ clusterNew:
       label: CNI Plugin MTU Override
     networkPolicy:
       label: Project Network Isolation
-      editHelp: The Project Network Isolation option cannot be changed after the cluster is created
+      editHelp: The Project Network Isolation option cannot be enabled after the cluster is created
       selectNetworkPolicyHelp: You must have a Network Policy selected to use Project Network Isolation
     nodeName:
       detail: Optionally configure the node name as identification instead of the actual hostname


### PR DESCRIPTION

<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
Allowing users to disable project network isolation when editing an aks cluster


![Screenshot 2024-02-20 100919](https://github.com/rancher/ui/assets/55104481/ddf8df91-9a3b-40fa-965a-cd8a564f3e4d)
![Screenshot 2024-02-20 100808](https://github.com/rancher/ui/assets/55104481/fb56e961-8c94-4b49-ba4b-defca62a5e15)
![Screenshot 2024-02-20 100524](https://github.com/rancher/ui/assets/55104481/e66e7c2d-98c3-4abe-842f-1b51dfe60558)

Types of changes
- Bugfix (non-breaking change which fixes an issue)


Linked Issues
======
Specifically addressing the comment here https://github.com/rancher/dashboard/issues/9905#issuecomment-1921549735


Further comments
======
Reading the jira issue I think there may be more to the original issue because the comment only addresses aks. I do think that this change will be necessary but I suspect more changes will follow in separate PRs.


Dev Testing
======

I do not currently have access to AKS. In order to test this I modified the driver-aks component directly by touching these fields
![Screenshot 2024-02-20 101219](https://github.com/rancher/ui/assets/55104481/1b257baf-c454-4c2f-b103-4228e339102c)
