### PR TITLE
Use `initialCloudProvider` for comparison when upgrading Kubernetes from <1.27

### DIFF
--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -104,9 +104,9 @@ export default Component.extend({
 
   k8sVersionDidChange: observer( 'cluster.rancherKubernetesEngineConfig.kubernetesVersion', function(){
     const kubernetesVersion = get(this, 'cluster.rancherKubernetesEngineConfig.kubernetesVersion')
-    const selectedCloudProvider = get(this, 'selectedCloudProvider')
+    const initialCloudProvider = get(this, 'initialCloudProvider')
 
-    if (selectedCloudProvider === 'amazonec2' && Semver.gte(Semver.coerce(kubernetesVersion), '1.27.0')){
+    if (initialCloudProvider === 'amazonec2' && Semver.gte(Semver.coerce(kubernetesVersion), '1.27.0')){
       set(this, 'unsupportedProviderSelected', true);
       set(this, 'selectedCloudProvider', 'external-aws');
       set(this, 'showChangedToAmazonExternal', true);


### PR DESCRIPTION
This uses the `initialCloudProvider` to determine if the cloud provider needs to be set to `external-aws` when changing Kubernetes versions.

The previous implementation that used the selected cloud provider would toggle `selectedCloudProvider` between `external-aws` and `amazonec2` when selecting different kubernetes versions that are >= 1.27.0.

closes rancher/dashboard#10516
