### PR TITLE
Fixing Misspelling 

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3509,7 +3509,7 @@ clusterNew:
           helpBlock: Optionally limit access to the public endpoint via explicit CIDR blocks. If you limit access to specific CIDR blocks, then it is recommended that you also enable private access to avoid losing network communication to the cluster.
           label: Public Access Endpoints
           valueLabel: Endpoints
-        help: Configuring Public/Priavte API access is an advanced use case. Users are encouraged to read the EKS cluster endpoint access control <a href="https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html" target="_blank"  rel="nofollow noopener noreferrer">documentation</a>.
+        help: Configuring Public/Private API access is an advanced use case. Users are encouraged to read the EKS cluster endpoint access control <a href="https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html" target="_blank"  rel="nofollow noopener noreferrer">documentation</a>.
         private:
           label: Private Access
         public:


### PR DESCRIPTION
Fix Typo

![image](https://github.com/rancher/ui/assets/91494226/ac5513ce-dc33-4101-9df7-2c211d56a025)


Proposed changes
======
Smallest of small changes. Just noticed a small typo when running through through a manual deployment of cluster on AWS. 

In the networking section, fixed the incorrect spelling of 'private'. 

Types of changes
======
Spelling. 

Linked Issues
======
No linked issues. 

Further comments
======
Nothing else, not a dramatic change, no functional changes.