### PR TITLE
Add docker 24.0.x support

### DIFF
--- a/lib/shared/addon/components/form-engine-opts/component.js
+++ b/lib/shared/addon/components/form-engine-opts/component.js
@@ -48,6 +48,10 @@ export default Component.extend({
 
     let out           = [
       {
+        label: 'v24.0.x',
+        value: 'https://releases.rancher.com/install-docker/24.0.sh'
+      },
+      {
         label: 'v23.0.x',
         value: 'https://releases.rancher.com/install-docker/23.0.sh'
       },


### PR DESCRIPTION
fixes rancher/dashboard#10806

This PR adds Docker 24.0.x support - so when 24 is added, this will come from the backend as the default version and will be added to the list. Docker 24 is currently the default, so adding 24 here will ensure that when it is no longer the default, it will continue to be listed.

Code added in the previous release ensures that if a hard-code entry in the list is also the default, it will only be shown once. 