### PR TITLE
Add docker 26 option

### DIFF
--- a/lib/shared/addon/components/form-engine-opts/component.js
+++ b/lib/shared/addon/components/form-engine-opts/component.js
@@ -48,6 +48,14 @@ export default Component.extend({
 
     let out           = [
       {
+        label: 'v26.0.x',
+        value: 'https://releases.rancher.com/install-docker/26.0.sh'
+      },
+      {
+        label: 'v25.0.x',
+        value: 'https://releases.rancher.com/install-docker/25.0.sh'
+      },
+      {
         label: 'v24.0.x',
         value: 'https://releases.rancher.com/install-docker/24.0.sh'
       },


### PR DESCRIPTION
Address https://github.com/rancher/dashboard/issues/10841

This PR adds docker 26 to the dropdown list.

It also adds in 25, which is the current version.

Note that the UI retrieves the current version (the one marked as recommended) from a setting - so 25 is not currently in the list, but appears via the setting. 26 is now added, so we have to add 25 to the maintained list.

Also adding 26, although this will now come from the setting - the UI will de-dup from the hard-coded list and the setting, so 26 will only show once as recommened.