### PR TITLE
add eks m6&c6 instance types

### DIFF
--- a/lib/shared/addon/utils/amazon.js
+++ b/lib/shared/addon/utils/amazon.js
@@ -88,282 +88,282 @@ export const INSTANCE_TYPES = [
 
   {
     group: 'M6a - General Purpose (AMD)',
-    name: 'm6a.large'
+    name:  'm6a.large'
   },
   {
     group: 'M6a - General Purpose (AMD)',
-    name: 'm6a.xlarge'
+    name:  'm6a.xlarge'
   },
   {
     group: 'M6a - General Purpose (AMD)',
-    name: 'm6a.2xlarge'
+    name:  'm6a.2xlarge'
   },
   {
     group: 'M6a - General Purpose (AMD)',
-    name: 'm6a.4xlarge'
+    name:  'm6a.4xlarge'
   },
   {
     group: 'M6a - General Purpose (AMD)',
-    name: 'm6a.8xlarge'
+    name:  'm6a.8xlarge'
   },
   {
     group: 'M6a - General Purpose (AMD)',
-    name: 'm6a.12xlarge'
+    name:  'm6a.12xlarge'
   },
   {
     group: 'M6a - General Purpose (AMD)',
-    name: 'm6a.16xlarge'
+    name:  'm6a.16xlarge'
   },
   {
     group: 'M6a - General Purpose (AMD)',
-    name: 'm6a.24xlarge'
+    name:  'm6a.24xlarge'
   },
   {
     group: 'M6a - General Purpose (AMD)',
-    name: 'm6a.32xlarge'
+    name:  'm6a.32xlarge'
   },
   {
     group: 'M6a - General Purpose (AMD)',
-    name: 'm6a.48xlarge'
+    name:  'm6a.48xlarge'
   },
   {
     group: 'M6a - General Purpose (AMD)',
-    name: 'm6a.metal'
+    name:  'm6a.metal'
   },
 
   {
     group: 'M6g - General Purpose (ARM)',
-    name: 'm6g.medium'
+    name:  'm6g.medium'
   },
   {
     group: 'M6g - General Purpose (ARM)',
-    name: 'm6g.large'
+    name:  'm6g.large'
   },
   {
     group: 'M6g - General Purpose (ARM)',
-    name: 'm6g.xlarge'
+    name:  'm6g.xlarge'
   },
   {
     group: 'M6g - General Purpose (ARM)',
-    name: 'm6g.2xlarge'
+    name:  'm6g.2xlarge'
   },
   {
     group: 'M6g - General Purpose (ARM)',
-    name: 'm6g.4xlarge'
+    name:  'm6g.4xlarge'
   },
   {
     group: 'M6g - General Purpose (ARM)',
-    name: 'm6g.8xlarge'
+    name:  'm6g.8xlarge'
   },
   {
     group: 'M6g - General Purpose (ARM)',
-    name: 'm6g.12xlarge'
+    name:  'm6g.12xlarge'
   },
   {
     group: 'M6g - General Purpose (ARM)',
-    name: 'm6g.16xlarge'
+    name:  'm6g.16xlarge'
   },
   {
     group: 'M6g - General Purpose (ARM)',
-    name: 'm6g.metal'
+    name:  'm6g.metal'
   },
- 
+
   {
     group: 'M6gd - General Purpose (ARM, Local SSD)',
-    name: 'm6gd.medium'
-  },
-  {
-    group: 'M6gd - General Purpose (ARM, Local SSD)',
-    name: 'm6gd.large'
+    name:  'm6gd.medium'
   },
   {
     group: 'M6gd - General Purpose (ARM, Local SSD)',
-    name: 'm6gd.xlarge'
+    name:  'm6gd.large'
   },
   {
     group: 'M6gd - General Purpose (ARM, Local SSD)',
-    name: 'm6gd.2xlarge'
+    name:  'm6gd.xlarge'
   },
   {
     group: 'M6gd - General Purpose (ARM, Local SSD)',
-    name: 'm6gd.4xlarge'
+    name:  'm6gd.2xlarge'
   },
   {
     group: 'M6gd - General Purpose (ARM, Local SSD)',
-    name: 'm6gd.8xlarge'
+    name:  'm6gd.4xlarge'
   },
   {
     group: 'M6gd - General Purpose (ARM, Local SSD)',
-    name: 'm6gd.12xlarge'
+    name:  'm6gd.8xlarge'
   },
   {
     group: 'M6gd - General Purpose (ARM, Local SSD)',
-    name: 'm6gd.16xlarge'
+    name:  'm6gd.12xlarge'
   },
   {
     group: 'M6gd - General Purpose (ARM, Local SSD)',
-    name: 'm6gd.metal'
-  },
-   
-  {
-    group: 'M6i - General Purpose (Intel)',
-    name: 'm6i.large'
+    name:  'm6gd.16xlarge'
   },
   {
-    group: 'M6i - General Purpose (Intel)',
-    name: 'm6i.xlarge'
+    group: 'M6gd - General Purpose (ARM, Local SSD)',
+    name:  'm6gd.metal'
   },
+
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6i.2xlarge'
+    name:  'm6i.large'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6i.4xlarge'
+    name:  'm6i.xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6i.8xlarge'
+    name:  'm6i.2xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6i.12xlarge'
+    name:  'm6i.4xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6i.16xlarge'
+    name:  'm6i.8xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6i.24xlarge'
+    name:  'm6i.12xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6i.32xlarge'
+    name:  'm6i.16xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6i.metal'
+    name:  'm6i.24xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6id.large'
+    name:  'm6i.32xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6id.xlarge'
+    name:  'm6i.metal'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6id.2xlarge'
+    name:  'm6id.large'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6id.4xlarge'
+    name:  'm6id.xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6id.8xlarge'
+    name:  'm6id.2xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6id.12xlarge'
+    name:  'm6id.4xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6id.16xlarge'
+    name:  'm6id.8xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6id.24xlarge'
+    name:  'm6id.12xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6id.32xlarge'
+    name:  'm6id.16xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6id.metal'
+    name:  'm6id.24xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6idn.large'
+    name:  'm6id.32xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6idn.xlarge'
+    name:  'm6id.metal'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6idn.2xlarge'
+    name:  'm6idn.large'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6idn.4xlarge'
+    name:  'm6idn.xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6idn.8xlarge'
+    name:  'm6idn.2xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6idn.12xlarge'
+    name:  'm6idn.4xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6idn.16xlarge'
+    name:  'm6idn.8xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6idn.24xlarge'
+    name:  'm6idn.12xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6idn.32xlarge'
+    name:  'm6idn.16xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6idn.metal'
+    name:  'm6idn.24xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6in.large'
+    name:  'm6idn.32xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6in.xlarge'
+    name:  'm6idn.metal'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6in.2xlarge'
+    name:  'm6in.large'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6in.4xlarge'
+    name:  'm6in.xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6in.8xlarge'
+    name:  'm6in.2xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6in.12xlarge'
+    name:  'm6in.4xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6in.16xlarge'
+    name:  'm6in.8xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6in.24xlarge'
+    name:  'm6in.12xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6in.32xlarge'
+    name:  'm6in.16xlarge'
   },
   {
     group: 'M6i - General Purpose (Intel)',
-    name: 'm6in.metal'
+    name:  'm6in.24xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name:  'm6in.32xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name:  'm6in.metal'
   },
 
   {
@@ -540,274 +540,274 @@ export const INSTANCE_TYPES = [
 
   {
     group: 'C6g - High CPU (ARM)',
-    name: 'c6g.medium'
+    name:  'c6g.medium'
   },
   {
     group: 'C6g - High CPU (ARM)',
-    name: 'c6g.large'
+    name:  'c6g.large'
   },
   {
     group: 'C6g - High CPU (ARM)',
-    name: 'c6g.xlarge'
+    name:  'c6g.xlarge'
   },
   {
     group: 'C6g - High CPU (ARM)',
-    name: 'c6g.2xlarge'
+    name:  'c6g.2xlarge'
   },
   {
     group: 'C6g - High CPU (ARM)',
-    name: 'c6g.4xlarge'
+    name:  'c6g.4xlarge'
   },
   {
     group: 'C6g - High CPU (ARM)',
-    name: 'c6g.8xlarge'
+    name:  'c6g.8xlarge'
   },
   {
     group: 'C6g - High CPU (ARM)',
-    name: 'c6g.12xlarge'
+    name:  'c6g.12xlarge'
   },
   {
     group: 'C6g - High CPU (ARM)',
-    name: 'c6g.16xlarge'
+    name:  'c6g.16xlarge'
   },
   {
     group: 'C6g - High CPU (ARM)',
-    name: 'c6g.metal'
+    name:  'c6g.metal'
   },
 
   {
     group: 'C6gd - High CPU (ARM, Local SSD)',
-    name: 'c6gd.medium'
+    name:  'c6gd.medium'
   },
   {
     group: 'C6gd - High CPU (ARM, Local SSD)',
-    name: 'c6gd.large'
+    name:  'c6gd.large'
   },
   {
     group: 'C6gd - High CPU (ARM, Local SSD)',
-    name: 'c6gd.xlarge'
+    name:  'c6gd.xlarge'
   },
   {
     group: 'C6gd - High CPU (ARM, Local SSD)',
-    name: 'c6gd.2xlarge'
+    name:  'c6gd.2xlarge'
   },
   {
     group: 'C6gd - High CPU (ARM, Local SSD)',
-    name: 'c6gd.4xlarge'
+    name:  'c6gd.4xlarge'
   },
   {
     group: 'C6gd - High CPU (ARM, Local SSD)',
-    name: 'c6gd.8xlarge'
+    name:  'c6gd.8xlarge'
   },
   {
     group: 'C6gd - High CPU (ARM, Local SSD)',
-    name: 'c6gd.12xlarge'
+    name:  'c6gd.12xlarge'
   },
   {
     group: 'C6gd - High CPU (ARM, Local SSD)',
-    name: 'c6gd.16xlarge'
+    name:  'c6gd.16xlarge'
   },
   {
     group: 'C6gd - High CPU (ARM, Local SSD)',
-    name: 'c6gd.metal'
+    name:  'c6gd.metal'
   },
 
   {
     group: 'C6gn - High CPU (ARM)',
-    name: 'c6gn.medium'
+    name:  'c6gn.medium'
   },
   {
     group: 'C6gn - High CPU (ARM)',
-    name: 'c6gn.large'
+    name:  'c6gn.large'
   },
   {
     group: 'C6gn - High CPU (ARM)',
-    name: 'c6gn.xlarge'
+    name:  'c6gn.xlarge'
   },
   {
     group: 'C6gn - High CPU (ARM)',
-    name: 'c6gn.2xlarge'
+    name:  'c6gn.2xlarge'
   },
   {
     group: 'C6gn - High CPU (ARM)',
-    name: 'c6gn.4xlarge'
+    name:  'c6gn.4xlarge'
   },
   {
     group: 'C6gn - High CPU (ARM)',
-    name: 'c6gn.8xlarge'
+    name:  'c6gn.8xlarge'
   },
   {
     group: 'C6gn - High CPU (ARM)',
-    name: 'c6gn.12xlarge'
+    name:  'c6gn.12xlarge'
   },
   {
     group: 'C6gn - High CPU (ARM)',
-    name: 'c6gn.16xlarge'
+    name:  'c6gn.16xlarge'
   },
-  
+
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6i.large'
-  },
-  {
-    group: 'C6i - High-CPU (Intel)',
-    name: 'c6i.xlarge'
+    name:  'c6i.large'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6i.2xlarge'
+    name:  'c6i.xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6i.4xlarge'
+    name:  'c6i.2xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6i.8xlarge'
+    name:  'c6i.4xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6i.12xlarge'
+    name:  'c6i.8xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6i.16xlarge'
+    name:  'c6i.12xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6i.24xlarge'
+    name:  'c6i.16xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6i.32xlarge'
+    name:  'c6i.24xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6i.metal'
+    name:  'c6i.32xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6a.large'
+    name:  'c6i.metal'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6a.xlarge'
+    name:  'c6a.large'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6a.2xlarge'
+    name:  'c6a.xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6a.4xlarge'
+    name:  'c6a.2xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6a.8xlarge'
+    name:  'c6a.4xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6a.12xlarge'
+    name:  'c6a.8xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6a.16xlarge'
+    name:  'c6a.12xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6a.24xlarge'
+    name:  'c6a.16xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6a.32xlarge'
+    name:  'c6a.24xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6a.48xlarge'
+    name:  'c6a.32xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6a.metal'
+    name:  'c6a.48xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6id.large'
+    name:  'c6a.metal'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6id.xlarge'
+    name:  'c6id.large'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6id.2xlarge'
+    name:  'c6id.xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6id.4xlarge'
+    name:  'c6id.2xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6id.8xlarge'
+    name:  'c6id.4xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6id.12xlarge'
+    name:  'c6id.8xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6id.16xlarge'
+    name:  'c6id.12xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6id.24xlarge'
+    name:  'c6id.16xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6id.32xlarge'
+    name:  'c6id.24xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6id.metal'
+    name:  'c6id.32xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6in.large'
+    name:  'c6id.metal'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6in.xlarge'
+    name:  'c6in.large'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6in.2xlarge'
+    name:  'c6in.xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6in.4xlarge'
+    name:  'c6in.2xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6in.8xlarge'
+    name:  'c6in.4xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6in.12xlarge'
+    name:  'c6in.8xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6in.16xlarge'
+    name:  'c6in.12xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6in.24xlarge'
+    name:  'c6in.16xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6in.32xlarge'
+    name:  'c6in.24xlarge'
   },
   {
     group: 'C6i - High-CPU (Intel)',
-    name: 'c6in.metal'
+    name:  'c6in.32xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name:  'c6in.metal'
   },
 
   {

--- a/lib/shared/addon/utils/amazon.js
+++ b/lib/shared/addon/utils/amazon.js
@@ -87,6 +87,286 @@ export const INSTANCE_TYPES = [
   },
 
   {
+    group: 'M6a - General Purpose (AMD)',
+    name: 'm6a.large'
+  },
+  {
+    group: 'M6a - General Purpose (AMD)',
+    name: 'm6a.xlarge'
+  },
+  {
+    group: 'M6a - General Purpose (AMD)',
+    name: 'm6a.2xlarge'
+  },
+  {
+    group: 'M6a - General Purpose (AMD)',
+    name: 'm6a.4xlarge'
+  },
+  {
+    group: 'M6a - General Purpose (AMD)',
+    name: 'm6a.8xlarge'
+  },
+  {
+    group: 'M6a - General Purpose (AMD)',
+    name: 'm6a.12xlarge'
+  },
+  {
+    group: 'M6a - General Purpose (AMD)',
+    name: 'm6a.16xlarge'
+  },
+  {
+    group: 'M6a - General Purpose (AMD)',
+    name: 'm6a.24xlarge'
+  },
+  {
+    group: 'M6a - General Purpose (AMD)',
+    name: 'm6a.32xlarge'
+  },
+  {
+    group: 'M6a - General Purpose (AMD)',
+    name: 'm6a.48xlarge'
+  },
+  {
+    group: 'M6a - General Purpose (AMD)',
+    name: 'm6a.metal'
+  },
+
+  {
+    group: 'M6g - General Purpose (ARM)',
+    name: 'm6g.medium'
+  },
+  {
+    group: 'M6g - General Purpose (ARM)',
+    name: 'm6g.large'
+  },
+  {
+    group: 'M6g - General Purpose (ARM)',
+    name: 'm6g.xlarge'
+  },
+  {
+    group: 'M6g - General Purpose (ARM)',
+    name: 'm6g.2xlarge'
+  },
+  {
+    group: 'M6g - General Purpose (ARM)',
+    name: 'm6g.4xlarge'
+  },
+  {
+    group: 'M6g - General Purpose (ARM)',
+    name: 'm6g.8xlarge'
+  },
+  {
+    group: 'M6g - General Purpose (ARM)',
+    name: 'm6g.12xlarge'
+  },
+  {
+    group: 'M6g - General Purpose (ARM)',
+    name: 'm6g.16xlarge'
+  },
+  {
+    group: 'M6g - General Purpose (ARM)',
+    name: 'm6g.metal'
+  },
+ 
+  {
+    group: 'M6gd - General Purpose (ARM, Local SSD)',
+    name: 'm6gd.medium'
+  },
+  {
+    group: 'M6gd - General Purpose (ARM, Local SSD)',
+    name: 'm6gd.large'
+  },
+  {
+    group: 'M6gd - General Purpose (ARM, Local SSD)',
+    name: 'm6gd.xlarge'
+  },
+  {
+    group: 'M6gd - General Purpose (ARM, Local SSD)',
+    name: 'm6gd.2xlarge'
+  },
+  {
+    group: 'M6gd - General Purpose (ARM, Local SSD)',
+    name: 'm6gd.4xlarge'
+  },
+  {
+    group: 'M6gd - General Purpose (ARM, Local SSD)',
+    name: 'm6gd.8xlarge'
+  },
+  {
+    group: 'M6gd - General Purpose (ARM, Local SSD)',
+    name: 'm6gd.12xlarge'
+  },
+  {
+    group: 'M6gd - General Purpose (ARM, Local SSD)',
+    name: 'm6gd.16xlarge'
+  },
+  {
+    group: 'M6gd - General Purpose (ARM, Local SSD)',
+    name: 'm6gd.metal'
+  },
+   
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6i.large'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6i.xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6i.2xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6i.4xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6i.8xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6i.12xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6i.16xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6i.24xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6i.32xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6i.metal'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6id.large'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6id.xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6id.2xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6id.4xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6id.8xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6id.12xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6id.16xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6id.24xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6id.32xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6id.metal'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6idn.large'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6idn.xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6idn.2xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6idn.4xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6idn.8xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6idn.12xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6idn.16xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6idn.24xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6idn.32xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6idn.metal'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6in.large'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6in.xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6in.2xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6in.4xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6in.8xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6in.12xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6in.16xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6in.24xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6in.32xlarge'
+  },
+  {
+    group: 'M6i - General Purpose (Intel)',
+    name: 'm6in.metal'
+  },
+
+  {
     group: 'M5 - General Purpose',
     name:  'm5.large'
   },
@@ -256,6 +536,278 @@ export const INSTANCE_TYPES = [
   {
     group: 'M3 - General Purpose',
     name:  'm3.2xlarge'
+  },
+
+  {
+    group: 'C6g - High CPU (ARM)',
+    name: 'c6g.medium'
+  },
+  {
+    group: 'C6g - High CPU (ARM)',
+    name: 'c6g.large'
+  },
+  {
+    group: 'C6g - High CPU (ARM)',
+    name: 'c6g.xlarge'
+  },
+  {
+    group: 'C6g - High CPU (ARM)',
+    name: 'c6g.2xlarge'
+  },
+  {
+    group: 'C6g - High CPU (ARM)',
+    name: 'c6g.4xlarge'
+  },
+  {
+    group: 'C6g - High CPU (ARM)',
+    name: 'c6g.8xlarge'
+  },
+  {
+    group: 'C6g - High CPU (ARM)',
+    name: 'c6g.12xlarge'
+  },
+  {
+    group: 'C6g - High CPU (ARM)',
+    name: 'c6g.16xlarge'
+  },
+  {
+    group: 'C6g - High CPU (ARM)',
+    name: 'c6g.metal'
+  },
+
+  {
+    group: 'C6gd - High CPU (ARM, Local SSD)',
+    name: 'c6gd.medium'
+  },
+  {
+    group: 'C6gd - High CPU (ARM, Local SSD)',
+    name: 'c6gd.large'
+  },
+  {
+    group: 'C6gd - High CPU (ARM, Local SSD)',
+    name: 'c6gd.xlarge'
+  },
+  {
+    group: 'C6gd - High CPU (ARM, Local SSD)',
+    name: 'c6gd.2xlarge'
+  },
+  {
+    group: 'C6gd - High CPU (ARM, Local SSD)',
+    name: 'c6gd.4xlarge'
+  },
+  {
+    group: 'C6gd - High CPU (ARM, Local SSD)',
+    name: 'c6gd.8xlarge'
+  },
+  {
+    group: 'C6gd - High CPU (ARM, Local SSD)',
+    name: 'c6gd.12xlarge'
+  },
+  {
+    group: 'C6gd - High CPU (ARM, Local SSD)',
+    name: 'c6gd.16xlarge'
+  },
+  {
+    group: 'C6gd - High CPU (ARM, Local SSD)',
+    name: 'c6gd.metal'
+  },
+
+  {
+    group: 'C6gn - High CPU (ARM)',
+    name: 'c6gn.medium'
+  },
+  {
+    group: 'C6gn - High CPU (ARM)',
+    name: 'c6gn.large'
+  },
+  {
+    group: 'C6gn - High CPU (ARM)',
+    name: 'c6gn.xlarge'
+  },
+  {
+    group: 'C6gn - High CPU (ARM)',
+    name: 'c6gn.2xlarge'
+  },
+  {
+    group: 'C6gn - High CPU (ARM)',
+    name: 'c6gn.4xlarge'
+  },
+  {
+    group: 'C6gn - High CPU (ARM)',
+    name: 'c6gn.8xlarge'
+  },
+  {
+    group: 'C6gn - High CPU (ARM)',
+    name: 'c6gn.12xlarge'
+  },
+  {
+    group: 'C6gn - High CPU (ARM)',
+    name: 'c6gn.16xlarge'
+  },
+  
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6i.large'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6i.xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6i.2xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6i.4xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6i.8xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6i.12xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6i.16xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6i.24xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6i.32xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6i.metal'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6a.large'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6a.xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6a.2xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6a.4xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6a.8xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6a.12xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6a.16xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6a.24xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6a.32xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6a.48xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6a.metal'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6id.large'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6id.xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6id.2xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6id.4xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6id.8xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6id.12xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6id.16xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6id.24xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6id.32xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6id.metal'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6in.large'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6in.xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6in.2xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6in.4xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6in.8xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6in.12xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6in.16xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6in.24xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6in.32xlarge'
+  },
+  {
+    group: 'C6i - High-CPU (Intel)',
+    name: 'c6in.metal'
   },
 
   {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed, dealers choice. They are present simply to guide you on your pull-request journey. --> 
Proposed changes
======
<!-- 
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

-->
Fixes https://github.com/rancher/dashboard/issues/11132


Types of changes
======
<!-- 

What types of changes does your code introduce to Rancher?
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

-->

Linked Issues
======
<!--

Link any related issues, pull-requests, or commit hashes that are relavent to this pull-request.

If you are opening a PR without a corresponding issue create an issue before you do. This will help QA massively. PR's opened without linked issues will not be merged until an issue is created and linked here. 

--> 

Further comments
======
<!-- 

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... 

-->
In rancher 2.8.x/2.7.x version, region, and instance type are hardcoded in the old EKS form.
EKS  cluster provisioning UI uses the iFramed Ember page ... 

Currently, an issue rancher/dashboard gh#8083 to provision public cloud clusters (AKS, EKS & GKE), the cloud provisioning pages are iFramed from Ember into Vue. which dynamically updates these values from rancher-2.9.0(targetted version)... 