### PR TITLE
Swap out docker install URL 26.0 to 26.1

### DIFF
--- a/lib/shared/addon/components/form-engine-opts/component.js
+++ b/lib/shared/addon/components/form-engine-opts/component.js
@@ -48,8 +48,8 @@ export default Component.extend({
 
     let out           = [
       {
-        label: 'v26.0.x',
-        value: 'https://releases.rancher.com/install-docker/26.0.sh'
+        label: 'v26.1.x',
+        value: 'https://releases.rancher.com/install-docker/26.1.sh'
       },
       {
         label: 'v25.0.x',


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/10996

Swaps out Docker Install URL 26.0 for 26.1