### PR TITLE
Add 26.0.x docker version into the managed list

### DIFF
--- a/lib/shared/addon/components/form-engine-opts/component.js
+++ b/lib/shared/addon/components/form-engine-opts/component.js
@@ -52,6 +52,10 @@ export default Component.extend({
         value: 'https://releases.rancher.com/install-docker/26.1.sh'
       },
       {
+        label: 'v26.0.x',
+        value: 'https://releases.rancher.com/install-docker/26.0.sh'
+      },
+      {
         label: 'v25.0.x',
         value: 'https://releases.rancher.com/install-docker/25.0.sh'
       },


### PR DESCRIPTION
Addresses [#10996](https://github.com/rancher/dashboard/issues/10996)

Ensure we have both 26.1.x and 26.0.x in the managed list.