### PR TITLE
Fix GKE default version and tweak node pool upgrade versioning logic

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-gke/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-gke/component.js
@@ -242,9 +242,6 @@ export default Component.extend(ClusterDriver, {
           }
         }
 
-        if (isEmpty(config.kubernetesVersion)) {
-          set(this, 'config.kubernetesVersion', versions?.defaultClusterVersion);
-        }
 
         cb(true);
       }).catch((err) => {
@@ -274,6 +271,14 @@ export default Component.extend(ClusterDriver, {
       set(this, 'config.masterAuthorizedNetworks.cidrBlocks', cidrBlocks);
     },
   },
+
+  versionChoicesChanged: observer('versionChoices.[]', 'config.kubernetesVersion', 'versions.{validMasterVersions,channels}', function(){
+    const { config, versionChoices } = this;
+
+    if (isEmpty(config.kubernetesVersion)) {
+      set(this, 'config.kubernetesVersion', versionChoices[0].value);
+    }
+  }),
 
   networkPolicyEnabledChanged: observer('config.networkPolicyEnabled', function() {
     if (get(this, 'isNew') && get(this, 'config.networkPolicyEnabled')) {
@@ -860,9 +865,7 @@ export default Component.extend(ClusterDriver, {
       }
     }
 
-    if (isEmpty(initialVersion)) {
-      initialVersion = validMasterVersions[0];
-    }
+
 
     if (this.editing && !validMasterVersions.includes(initialVersion)) {
       validMasterVersions.unshift(initialVersion);
@@ -870,6 +873,11 @@ export default Component.extend(ClusterDriver, {
 
     Semver.rsort(validMasterVersions, { includePrerelease: true });
     const versionChoices = this.serviceVersions.parseCloudProviderVersionChoicesV2(validMasterVersions.slice(), initialVersion, mode, null, false, MINIMUM_VERSION);
+
+    if (isEmpty(initialVersion)) {
+      initialVersion = versionChoices[0]?.value;
+    }
+
 
     if (this.editing) {
       try {

--- a/lib/shared/addon/components/gke-node-pool-row/component.js
+++ b/lib/shared/addon/components/gke-node-pool-row/component.js
@@ -84,16 +84,6 @@ export default Component.extend({
     this.send('updateScopes');
   }),
 
-  editingUpdateNodeVersion: observer('isNewNodePool', 'clusterWillUpgrade', 'controlPlaneVersion', function() {
-    const { isNewNodePool, clusterWillUpgrade } = this;
-    const clusterVersion = get(this, 'controlPlaneVersion');
-    const nodeVersion    = get(this, 'nodePool.version');
-
-    if (isNewNodePool && !!clusterVersion && clusterVersion !== nodeVersion && clusterWillUpgrade) {
-      set(this, 'nodePool.version', clusterVersion);
-    }
-  }),
-
   autoscalingChanged: observer('nodePool.autoscaling.enabled', function() {
     if (this.isDestroyed || this.isDestroying) {
       return;
@@ -122,28 +112,28 @@ export default Component.extend({
     }
   }),
 
-  // if true, set np.version to controlPlaneVersion
+  // if true, set np.version to latest version <= cp version
   // if false, revert np.version
-  upgradeVersionChanged: observer('upgradeVersion', 'controlPlaneVersion', function()  {
+  upgradeVersionChanged: observer('upgradeVersion', 'maxAvailableVersion', function()  {
     const {
-      upgradeVersion, originalPoolVersion, controlPlaneVersion, nodePool
+      upgradeVersion, originalPoolVersion, nodePool, maxAvailableVersion
     } = this
 
     if (upgradeVersion){
-      set(nodePool, 'version', controlPlaneVersion)
+      set(nodePool, 'version', maxAvailableVersion)
     } else {
       set(nodePool, 'version', originalPoolVersion)
     }
   }),
 
   // if the pool is new, keep version in sync with cp version
-  controlPlaneVersionChanged: on('init', observer('controlPlaneVersion', function(){
+  controlPlaneVersionChanged: on('init', observer('controlPlaneVersion', 'maxAvailableVersion', function(){
     const {
-      controlPlaneVersion, isNewNodePool, nodePool
+      maxAvailableVersion, isNewNodePool, nodePool
     } = this;
 
-    if (isNewNodePool && controlPlaneVersion !== nodePool.version){
-      set(nodePool, 'version', controlPlaneVersion)
+    if (isNewNodePool && maxAvailableVersion !== nodePool.version){
+      set(nodePool, 'version', maxAvailableVersion)
     }
   })),
 
@@ -207,8 +197,6 @@ export default Component.extend({
   clusterWillUpgrade: computed('controlPlaneVersion', 'originalClusterVersion', function(){
     const { controlPlaneVersion, originalClusterVersion } = this;
 
-    // gke versions have a long suffix eg 1.26.15-gke.1900000 and 1.26.15-gke.1900001 may both be options so we use a simple equality check instead of semver package
-    // logic in driver-gke ensures that if a new version is selected it must be an upgrade from original version
     return !!controlPlaneVersion && !!originalClusterVersion && controlPlaneVersion !== originalClusterVersion
   }),
 
@@ -218,13 +206,31 @@ export default Component.extend({
 
   /**
    * This property is used to show/hide a np version upgrade checkbox
-   * when the box is checked the np is upgraded to match the cp version
+   * when the box is checked the np is upgraded to latest node version that is <= cp version
    * with new node pools, the version is always kept in sync with the cp version so no checkbox shown
    */
   upgradeAvailable: computed('isNewNodePool', 'clusterWillUpgrade', function(){
     const { isNewNodePool, clusterWillUpgrade } = this;
 
     return !isNewNodePool && clusterWillUpgrade
+  }),
+
+
+  // GCP api provides a separate list of versions for node pools, which can be upgraded to anything <= control plane version
+  maxAvailableVersion: computed('controlPlaneVersion', 'nodeVersions.[]', function() {
+    const { controlPlaneVersion, nodeVersions } = this;
+
+    const availableVersions = nodeVersions.filter((nv) => {
+      try {
+        const lteCP = Semver.lte(nv, controlPlaneVersion, { includePreRelease: true })
+
+        return lteCP
+      } catch {
+        return
+      }
+    })
+
+    return availableVersions[0]
   }),
 
   editedMachineChoice: computed('nodePool.config.machineType', 'machineChoices', function() {
@@ -244,15 +250,5 @@ export default Component.extend({
 
     return out.sortBy('sortName')
   }),
-
-  // shouldUpgradeVersion: on('init', observer('upgradeVersion', 'controlPlaneVersion', function() {
-  //   const { upgradeVersion } = this;
-  //   const clusterVersion = get(this, 'controlPlaneVersion');
-  //   const nodeVersion    = get(this, 'nodePool.version');
-
-  //   if (upgradeVersion && clusterVersion !== nodeVersion ) {
-  //     set(this, 'nodePool.version', clusterVersion);
-  //   }
-  // })),
 
 });

--- a/lib/shared/addon/components/gke-node-pool-row/component.js
+++ b/lib/shared/addon/components/gke-node-pool-row/component.js
@@ -27,15 +27,12 @@ export default Component.extend({
   nodeVersions:            null,
   clusterVersion:          null,
   upgradeVersion:          false,
+  originalPoolVersion:     null,
 
   init() {
     this._super(...arguments);
 
-    const {
-      nodePool,
-      clusterVersion,
-      defaultClusterVersion
-    } = this;
+    const { nodePool } = this;
 
     setProperties(this, {
       scopeConfig:            {},
@@ -54,8 +51,8 @@ export default Component.extend({
         }
       }
 
-      if (isEmpty(nodePool?.version) && !isEmpty(clusterVersion)) {
-        set(this, 'nodePool.version', defaultClusterVersion);
+      if (nodePool.version){
+        set(this, 'originalPoolVersion', nodePool.version)
       }
     } else {
       setProperties(this, {
@@ -87,11 +84,12 @@ export default Component.extend({
     this.send('updateScopes');
   }),
 
-  editingUpdateNodeVersion: observer('isNewNodePool', 'clusterVersion', function() {
-    const { isNewNodePool, clusterVersion } = this;
+  editingUpdateNodeVersion: observer('isNewNodePool', 'clusterWillUpgrade', 'controlPlaneVersion', function() {
+    const { isNewNodePool, clusterWillUpgrade } = this;
+    const clusterVersion = get(this, 'controlPlaneVersion');
     const nodeVersion    = get(this, 'nodePool.version');
 
-    if (isNewNodePool && clusterVersion !== nodeVersion) {
+    if (isNewNodePool && !!clusterVersion && clusterVersion !== nodeVersion && clusterWillUpgrade) {
       set(this, 'nodePool.version', clusterVersion);
     }
   }),
@@ -123,6 +121,31 @@ export default Component.extend({
       });
     }
   }),
+
+  // if true, set np.version to controlPlaneVersion
+  // if false, revert np.version
+  upgradeVersionChanged: observer('upgradeVersion', 'controlPlaneVersion', function()  {
+    const {
+      upgradeVersion, originalPoolVersion, controlPlaneVersion, nodePool
+    } = this
+
+    if (upgradeVersion){
+      set(nodePool, 'version', controlPlaneVersion)
+    } else {
+      set(nodePool, 'version', originalPoolVersion)
+    }
+  }),
+
+  // if the pool is new, keep version in sync with cp version
+  controlPlaneVersionChanged: on('init', observer('controlPlaneVersion', function(){
+    const {
+      controlPlaneVersion, isNewNodePool, nodePool
+    } = this;
+
+    if (isNewNodePool && controlPlaneVersion !== nodePool.version){
+      set(nodePool, 'version', controlPlaneVersion)
+    }
+  })),
 
   scopeConfigChanged: on('init', observer('scopeConfig', function() {
     if (this.isDestroyed || this.isDestroying) {
@@ -181,26 +204,27 @@ export default Component.extend({
     return '';
   }),
 
-  upgradeAvailable: computed('clusterVersion', 'mode', 'nodePool.version', 'defaultClusterVersion', function() {
-    const { clusterVersion, defaultClusterVersion } = this;
-    const nodeVersion = get(this, 'nodePool.version');
+  clusterWillUpgrade: computed('controlPlaneVersion', 'originalClusterVersion', function(){
+    const { controlPlaneVersion, originalClusterVersion } = this;
 
-    if (isEmpty(clusterVersion) || isEmpty(nodeVersion)) {
-      return false;
-    }
-
-    const nodeIsLess = Semver.lt(nodeVersion, clusterVersion, { includePrerelease: true });
-    const clusterVersionIsAlsoTheMaxVersion = clusterVersion === defaultClusterVersion;
-
-    if (nodeIsLess && clusterVersionIsAlsoTheMaxVersion) {
-      return true;
-    }
-
-    return false;
+    // gke versions have a long suffix eg 1.26.15-gke.1900000 and 1.26.15-gke.1900001 may both be options so we use a simple equality check instead of semver package
+    // logic in driver-gke ensures that if a new version is selected it must be an upgrade from original version
+    return !!controlPlaneVersion && !!originalClusterVersion && controlPlaneVersion !== originalClusterVersion
   }),
 
   isNewNodePool: computed('nodePool.isNew', function() {
     return this?.nodePool?.isNew ? true : false;
+  }),
+
+  /**
+   * This property is used to show/hide a np version upgrade checkbox
+   * when the box is checked the np is upgraded to match the cp version
+   * with new node pools, the version is always kept in sync with the cp version so no checkbox shown
+   */
+  upgradeAvailable: computed('isNewNodePool', 'clusterWillUpgrade', function(){
+    const { isNewNodePool, clusterWillUpgrade } = this;
+
+    return !isNewNodePool && clusterWillUpgrade
   }),
 
   editedMachineChoice: computed('nodePool.config.machineType', 'machineChoices', function() {
@@ -221,14 +245,14 @@ export default Component.extend({
     return out.sortBy('sortName')
   }),
 
+  // shouldUpgradeVersion: on('init', observer('upgradeVersion', 'controlPlaneVersion', function() {
+  //   const { upgradeVersion } = this;
+  //   const clusterVersion = get(this, 'controlPlaneVersion');
+  //   const nodeVersion    = get(this, 'nodePool.version');
 
-  shouldUpgradeVersion: on('init', observer('upgradeVersion', 'clusterVersion', function() {
-    const { upgradeVersion, clusterVersion } = this;
-    const nodeVersion    = get(this, 'nodePool.version');
-
-    if (upgradeVersion && clusterVersion !== nodeVersion) {
-      set(this, 'nodePool.version', clusterVersion);
-    }
-  })),
+  //   if (upgradeVersion && clusterVersion !== nodeVersion ) {
+  //     set(this, 'nodePool.version', clusterVersion);
+  //   }
+  // })),
 
 });

--- a/lib/shared/addon/components/gke-node-pool-row/component.js
+++ b/lib/shared/addon/components/gke-node-pool-row/component.js
@@ -127,7 +127,7 @@ export default Component.extend({
   }),
 
   // if the pool is new, keep version in sync with cp version
-  controlPlaneVersionChanged: on('init', observer('controlPlaneVersion', 'maxAvailableVersion', function(){
+  clusterVersionChanged: on('init', observer('clusterVersion', 'maxAvailableVersion', function(){
     const {
       maxAvailableVersion, isNewNodePool, nodePool
     } = this;
@@ -194,10 +194,10 @@ export default Component.extend({
     return '';
   }),
 
-  clusterWillUpgrade: computed('controlPlaneVersion', 'originalClusterVersion', function(){
-    const { controlPlaneVersion, originalClusterVersion } = this;
+  clusterWillUpgrade: computed('clusterVersion', 'originalClusterVersion', function(){
+    const { clusterVersion, originalClusterVersion } = this;
 
-    return !!controlPlaneVersion && !!originalClusterVersion && controlPlaneVersion !== originalClusterVersion
+    return !!clusterVersion && !!originalClusterVersion && clusterVersion !== originalClusterVersion
   }),
 
   isNewNodePool: computed('nodePool.isNew', function() {
@@ -217,12 +217,12 @@ export default Component.extend({
 
 
   // GCP api provides a separate list of versions for node pools, which can be upgraded to anything <= control plane version
-  maxAvailableVersion: computed('controlPlaneVersion', 'nodeVersions.[]', function() {
-    const { controlPlaneVersion, nodeVersions } = this;
+  maxAvailableVersion: computed('clusterVersion', 'nodeVersions.[]', function() {
+    const { clusterVersion, nodeVersions } = this;
 
     const availableVersions = nodeVersions.filter((nv) => {
       try {
-        const lteCP = Semver.lte(nv, controlPlaneVersion, { includePreRelease: true })
+        const lteCP = Semver.lte(nv, clusterVersion, { includePreRelease: true })
 
         return lteCP
       } catch {

--- a/lib/shared/addon/components/gke-node-pool-row/template.hbs
+++ b/lib/shared/addon/components/gke-node-pool-row/template.hbs
@@ -30,7 +30,7 @@
             {{t
               "nodeGroupRow.version.upgrade"
               from=originalPoolVersion
-              version=controlPlaneVersion
+              version=maxAvailableVersion
             }}
           </label>
         </div>

--- a/lib/shared/addon/components/gke-node-pool-row/template.hbs
+++ b/lib/shared/addon/components/gke-node-pool-row/template.hbs
@@ -19,11 +19,6 @@
       <label class="acc-label">
         {{t "clusterNew.googlegke.masterVersion.label"}}
       </label>
-      {{!-- <NewSelect
-        @classNames="form-control"
-        @content={{versionChoices}}
-        @value={{mut nodePool.version}}
-      /> --}}
       {{#if upgradeAvailable}}
         <div class="checkbox form-control-static">
           <label class="acc-label">
@@ -34,8 +29,8 @@
             />
             {{t
               "nodeGroupRow.version.upgrade"
-              from=nodePool.version
-              version=clusterVersion
+              from=originalPoolVersion
+              version=controlPlaneVersion
             }}
           </label>
         </div>


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/11357


There are two semi-related issues in 11357
1. The cluster kubernetes version (sometimes called control plane version in the code) is being set to the latest version google provides (1.29 right now) instead of the latest version Rancher supports (1.28 in 2.8-head)
2. The node pool versions are being set to the latest available version instead of syncing with the control plane version

Fix for problem 1 was fairly straightforward: instead of using the defaultClusterVersion from the GCP API call we set the cluster version to the latest version shown in the version dropdown. In addition to respecting Rancher-specific versioning limitations this has the added bonus of ensuring that the cluster version is _never_ automatically set to something not shown in the UI.

The fix for problem 1 resulted in a few errors in the node pool component because the cluster version was no longer set before the rest of the page (including np components) rendered. Between that and needing to tweak the node pool version selection logic I ended up rewriting a bunch of observers/computed props around the node pool versioning

Expected node pool version behavior:
1. New node pools will have the same version as the cluster. When the cluster version changes, new node pool versions should be updated as well.
2. When the cluster version is updated, existing node pools will have the option of updating to the latest node pool version that is <= the cluster version (this is the restriction present when editing node pools through the google UI)
3. When the node pool upgrade checkbox is _un_checked, the node pool version should revert back

Note about node pool versions:
Technically the gcp api provides a list of node versions and a list of control plane versions. In my own testing I did not find an example of a version present in the control plane list and _not_ the node pool list. Nevertheless, the version offered in the node pool upgrade input is from the node pool list: we're using the highest node pool version that is <= the current cluster (control plane) version. It just happens that this is always equal to the control plane version.

