### PR TITLE
fix azure error message formatting

### DIFF
--- a/lib/shared/addon/components/cluster-driver/driver-import-aks/component.js
+++ b/lib/shared/addon/components/cluster-driver/driver-import-aks/component.js
@@ -124,7 +124,14 @@ export default Component.extend(ClusterDriver, {
           cb(true);
         }
       } catch (err) {
-        errors.pushObject(`Failed to load Clusters from Azure: ${ err.message }`);
+        let msg = ''
+
+        if (err.message){
+          msg = err.message
+        } else if (err?.body?.error){
+          msg = err.body.error
+        }
+        errors.pushObject(`Failed to load Clusters from Azure: ${ msg }`);
 
         // Azure List Clusters API fails sometimes to list this, user cnn input a cluster name though so dont fail
         setProperties(this, {


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/7913#issuecomment-2220495013

The catch block in driver-import-aks is expecting errors in a different format than the UI receives when an invalid credential is used. I wasn't sure if the expected format would show up if a different error were produced, so I have added onto the logic rather than replacing it entirely.