### PR TITLE
clean up l18n

### DIFF
--- a/translations/de-de.yaml
+++ b/translations/de-de.yaml
@@ -3841,7 +3841,7 @@ modalProcessError:
   header: Informationen zur Ausnahme
   cause: "Grund:"
   close: Schliessen
-modalDrainNode:
+drainNode:
   timeout:
     placeholder: z.B. 60
 modalShortcuts:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -718,6 +718,22 @@ authPage:
       help: "<span class='text-italic'>Note: Required Fields in this section are only required if you are configuring OpenLDAP Search with Shibboleth authorization.</span>"
     advanced:
       hr: Additional Configuration Parameters
+    enabled:
+      authenticated:
+        header:
+          text: Authentication
+      disableAccess:
+        header: "Danger Zone&trade;"
+        warning: '<b class="text-danger">Caution:</b> Disabling access control will give complete control over {appName} to anyone that can reach this page or the API.'
+        confirmDisable: "Are you sure?  Click again to disable access control"
+        disable: Disable access control
+      groupsField: 'Groups:'
+      displayName: 'Display Name:'
+      userName: 'Username:'
+      userId: 'User ID:'
+    disabled:
+      header: '1. Configure Shibboleth Account'
+      label: "{providerName} is not configured"
   root:
     header: Access Control
   github:

--- a/translations/es-es.yaml
+++ b/translations/es-es.yaml
@@ -4142,7 +4142,7 @@ modalProcessError:
   none: N/D
   stackTrace: "Seguimiento de la Pila:"
   close: Cerrar
-modalDrainNode:
+drainNode:
   action: Drenar
   gracePeriod:
     placeholder: ej. 60
@@ -5037,7 +5037,7 @@ pagination:
     =1 {{count} {count, plural, =1 {Puerto} other {Puertos}}}
     other {{from} - {to} of {count} Puertos}}
   service: |
-    {páginas, plural,
+    {pages, plural,
     =0 {Sin Hosts}
     =1 {{count} {count, plural, =1 {Service} other {Services}}}
     other {{from} - {to} of {count} Hosts}}

--- a/translations/ja-jp.yaml
+++ b/translations/ja-jp.yaml
@@ -453,7 +453,7 @@ authPage:
       li2:
         text: 'フォーム記入:'
         ul:
-          li1: '<b>名前:</b> <span class="text-muted">自由記載, e.g. My {appName}</span>'
+          li1: '<b>名前:</b> <span class="text-muted">自由記載, e.g. My Pipeline</span>'
           li2: リダイレクトURI
       li3:
         text: '"アプリケーションを保存" をクリック '
@@ -473,7 +473,7 @@ authPage:
     ul:
       li2:
         ul:
-          li1: '<b>名前:</b> <span class="text-muted">自由記載, e.g. My {appName}</span>'
+          li1: '<b>名前:</b> <span class="text-muted">自由記載, e.g. My Pipeline</span>'
           li2: コールバックURL
     form:
       clientId:
@@ -491,7 +491,7 @@ authPage:
       li2:
         text: '新しいアプリケーションリンクを作成:'
         ul:
-          li2: '<b>アプリケーション名:</b> <span class="text-muted">自由記載, e.g. My {appName}</span>'
+          li2: '<b>アプリケーション名:</b> <span class="text-muted">自由記載, e.g. My Pipeline</span>'
     form:
       hostname:
         placeholder: '例: example.com'
@@ -4858,7 +4858,7 @@ modalProcessError:
   none: N/A
   stackTrace: "スタックトレース:"
   close: 閉じる
-modalDrainNode:
+drainNode:
   gracePeriod:
     placeholder: '例: 60'
   timeout:

--- a/translations/uk-ua.yaml
+++ b/translations/uk-ua.yaml
@@ -4985,7 +4985,7 @@ modalProcessError:
   none: Н/Д
   stackTrace: "Трасування Стека:"
   close: Закрити
-modalDrainNode:
+drainNode:
   mode: Режим
   gracePeriod:
     placeholder: напр. 30

--- a/translations/zh-hans.yaml
+++ b/translations/zh-hans.yaml
@@ -4253,7 +4253,6 @@ clusterNew:
       text: 编辑主机选项将更新主机注册命令
     command:
       instructions: '复制以下命令在主机的 SSH 终端运行。'
-      winInstructions: '在一台或者多台运行了受支持的 Docker 版本的主机上运行<code>CMD</code>命令，并且 windows server 版本大于<code class="code-version">{version}</code>.'
     auth:
       label: 认证提供者
       x509: x509
@@ -5659,7 +5658,6 @@ validationsList:
 dangerZone:
   header: 高级设置
   subtext: "通常情况下用户不需要修改以下设置。请谨慎操作，不正确的值可能导致 {appName} 无法正常运行。修改默认设置后将以<b>粗体</b>显示配置名。"
-  showLabel: 我已确认修改高级设置可能导致 {appName} 出问题。
   show: 显示
   hide: 隐藏
   description:

--- a/translations/zh-hant-tw.yaml
+++ b/translations/zh-hant-tw.yaml
@@ -3997,7 +3997,6 @@ clusterNew:
       text: 編輯主機選項將更新主機註冊命令
     command:
       instructions: '複製以下命令在主機的SSH終端運行。'
-      winInstructions: '在一台或者多台運行了受支持的Docker版本的主機上運行<code>CMD</code>命令，並且windows server版本大於<code class="code-version">{version}</code>.'
     auth:
       label: 認證提供者
       x509: x509
@@ -5384,7 +5383,6 @@ validationsList:
 dangerZone:
   header: 高級設置
   subtext: "通常情況下用戶不需要修改以下設置。請謹慎操作，不正確的值可能導致{appName}無法正常運行。修改默認設置後將以<b>粗體</b>顯示設定名。"
-  showLabel: 我已確認修改高級設置可能導致{appName}出問題。
   show: 顯示
   hide: 隱藏
   description:
@@ -7504,7 +7502,7 @@ modalProcessError:
   stackTrace: "堆疊跟蹤:"
   close: 關閉
 
-modalDrainNode:
+drainNode:
   titleOne: '驅散節點: "{name}"'
   titleMultiple: '驅散{count}個節點'
   action: 驅散
@@ -7546,9 +7544,9 @@ modalRestoreBackup:
   type:
     label: 恢復類型
     etcd: Restore etcd
-    k8sVersion: "恢復Kubernetes版本 - {version}"
+    k8sVersion: "恢復Kubernetes版本"
     versionUnknown: '未知'
-    etcdAndK8sVersion: "恢復etcd和Kubernetes版本 - {version}"
+    etcdAndK8sVersion: "恢復etcd和Kubernetes版本"
     k8sVersionUnknown: 我們無法還原此快照的kubernetes版本，因為該版本未知。
 
 modalRotateCertificates:

--- a/translations/zh-hant.yaml
+++ b/translations/zh-hant.yaml
@@ -2267,7 +2267,6 @@ clusterNew:
       text: 編輯主機選項將更新主機註冊命令
     command:
       instructions: '複製以下命令在主機的SSH終端運行。'
-      winInstructions: '在一台或者多台運行了受支持的Docker版本的主機上運行<code>CMD</code>命令，並且windows server版本大於<code class="code-version">{version}</code>.'
     auth:
       label: 認證提供者
       x509: x509
@@ -4851,7 +4850,7 @@ modalProcessError:
   stackTrace: "堆棧跟蹤:"
   close: 關閉
 
-modalDrainNode:
+drainNode:
   titleOne: '驅散節點: "{name}"'
   titleMultiple: '驅散{count}個節點'
   action: 驅散


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/9361

The assorted "ICU argument missing..." errors shown when running the UI locally are mostly a result of translation strings in en-us being updated to no longer reference arguments still present in other l18n files. This seems to throw errors even if the arguments are still be provided in template files.  Some translation strings have drifted so much in en-us that it was unclear to me how to rewrite the corresponding translations to remove arguments in other files, so I wound up removing them entirely.

Other things going on:

- A bunch of shibboleth translations still referenced in templates were removed from en-us, maybe unintentionally? https://github.com/rancher/ui/pull/3721/files#diff-93bba6cdcf2bf03eb02ffd57e800a775e4b3879683bad0d0f4f3f7508fa92fd7L721

- `modalDrainNode` was renamed to `drainNode` in en-us - this PR updates other l18n files accordingly