### PR TITLE
BP: Add docker install URL for 27.0 and 27.1

### DIFF
--- a/lib/shared/addon/components/form-engine-opts/component.js
+++ b/lib/shared/addon/components/form-engine-opts/component.js
@@ -48,6 +48,14 @@ export default Component.extend({
 
     let out           = [
       {
+        label: 'v27.1.x',
+        value: 'https://releases.rancher.com/install-docker/27.1.sh'
+      },
+      {
+        label: 'v27.0.x',
+        value: 'https://releases.rancher.com/install-docker/27.0.sh'
+      },
+      {
         label: 'v26.1.x',
         value: 'https://releases.rancher.com/install-docker/26.1.sh'
       },


### PR DESCRIPTION
Backport - Addresses https://github.com/rancher/dashboard/issues/11530

Adds Docker Install URL 27.0 and 27.1

<img width="1546" alt="Screenshot 2024-08-01 at 12 32 26" src="https://github.com/user-attachments/assets/7b7ec0bd-acc9-4d44-94dd-789d3b0ded94">
<img width="1546" alt="Screenshot 2024-08-01 at 12 32 28" src="https://github.com/user-attachments/assets/410a2552-b154-4366-a4d8-487e7ce054c5">
<img width="1546" alt="Screenshot 2024-08-01 at 12 32 32" src="https://github.com/user-attachments/assets/11094f0f-a45d-440f-a6fa-3989818eb571">
