### PR TITLE
Update azure cloud provider option based on k8s version support

### DIFF
--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -183,8 +183,8 @@ export default Component.extend({
       set(configAnswersOut, answer.key, answer.value);
     });
 
-    // Avoid setting cloud provider specific configs if its path doesn't exist
-    if (!this.pathForSet) {
+    // Avoid setting cloud provider-specific configs in edit mode if the path doesn't exist (caused issues with Azure)
+    if (!this.pathForSet && this.mode === 'edit') {
       return;
     }
 

--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -16,6 +16,8 @@ const azureDefaults = C.AZURE_DEFAULTS;
 const GENERIC_PATH  = 'cluster.rancherKubernetesEngineConfig.cloudProvider.cloudConfig';
 const AWS_PATH      = 'cluster.rancherKubernetesEngineConfig.cloudProvider.awsCloudProvider';
 const AZURE_PATH    = 'cluster.rancherKubernetesEngineConfig.cloudProvider.azureCloudProvider';
+const AZURE_IN_TREE_MINIMUM_VERSION = 'v1.27.0';
+const AZURE_IN_TREE_DEPRICATE_VERSION = 'v1.30.0';
 
 export default Component.extend({
   globalStore:                 service(),
@@ -39,6 +41,7 @@ export default Component.extend({
   // track the original configuration to revert the switch to 'external' when the selected provider is not supported
   initialCloudProvider:        null,
   initialConfigAnswers:        null,
+  showChangedToExternal:       false,
 
   configName: alias('cluster.rancherKubernetesEngineConfig.cloudProvider.name'),
 
@@ -60,11 +63,14 @@ export default Component.extend({
 
       this.setCpFields(`azureCloudProvider`, reorderedAnswers);
 
+      const shouldAllowEditingCloudProvider = this.mode === 'edit' && this.isAzureInTreeSupported;
+
       setProperties(this, {
-        selectedCloudProvider: 'azure',
-        configAnswers:         reorderedAnswers,
-        initialCloudProvider:  'azure',
-        initialConfigAnswers:  reorderedAnswers
+        selectedCloudProvider:       'azure',
+        configAnswers:               reorderedAnswers,
+        initialCloudProvider:        'azure',
+        initialConfigAnswers:        reorderedAnswers,
+        unsupportedProviderSelected: shouldAllowEditingCloudProvider
       });
     } else if ( !cloudProviderName ) {
       set(this, 'selectedCloudProvider', 'none');
@@ -84,6 +90,7 @@ export default Component.extend({
 
   modeChanged: observer('selectedCloudProvider', function() {
     let selectedCloudProvider = get(this, 'selectedCloudProvider');
+    const showChangedToExternal = get(this, 'showChangedToExternal');
 
     if ( selectedCloudProvider !== 'none' ) {
       this.constructConfig();
@@ -93,6 +100,11 @@ export default Component.extend({
       if (config && get(config, 'cloudProvider')) {
         delete config.cloudProvider;
       }
+    }
+
+    // remove azure warning banner when selection changes
+    if (selectedCloudProvider !== 'external' && showChangedToExternal) {
+      set(this, 'showChangedToExternal', false);
     }
   }),
 
@@ -104,13 +116,34 @@ export default Component.extend({
 
   k8sVersionDidChange: observer( 'cluster.rancherKubernetesEngineConfig.kubernetesVersion', function(){
     const kubernetesVersion = get(this, 'cluster.rancherKubernetesEngineConfig.kubernetesVersion')
-    const initialCloudProvider = get(this, 'initialCloudProvider')
+    const initialCloudProvider = get(this, 'initialCloudProvider');
+    const selectedCloudProvider = get(this, 'selectedCloudProvider');
+    const isAzureCurrentlySelected = selectedCloudProvider === 'azure';
+    const isAzureInTreeSupported = get(this, 'isAzureInTreeSupported');
+    const showChangedToExternal = get(this, 'showChangedToExternal');
 
     if (initialCloudProvider === 'amazonec2' && Semver.gte(Semver.coerce(kubernetesVersion), '1.27.0')){
       set(this, 'unsupportedProviderSelected', true);
       set(this, 'selectedCloudProvider', 'external-aws');
       set(this, 'showChangedToAmazonExternal', true);
-      this.constructConfig()
+      this.constructConfig();
+    } else if (initialCloudProvider === 'azure') { // Edit mode for Azure
+      if (!isAzureInTreeSupported && isAzureCurrentlySelected) {
+        set(this, 'unsupportedProviderSelected', true);
+        set(this, 'selectedCloudProvider', 'external');
+        set(this, 'showChangedToExternal', true);
+        this.constructConfig();
+      } else if (showChangedToExternal) {
+        set(this, 'showChangedToExternal', false);
+      }
+    } else if (isAzureCurrentlySelected) { // Create mode for Azure
+      if (!isAzureInTreeSupported){
+        set(this, 'selectedCloudProvider', 'external');
+        set(this, 'showChangedToExternal', true);
+        this.constructConfig()
+      } else if (showChangedToExternal) {
+        set(this, 'showChangedToExternal', false);
+      }
     } else if (get(this, 'unsupportedProviderSelected')){
       setProperties(this, {
         unsupportedProviderSelected: false,
@@ -118,6 +151,8 @@ export default Component.extend({
         selectedCloudProvider:       get(this, 'initialCloudProvider'),
         configAnswers:               get(this, 'initialConfigAnswers')
       })
+    } else if (showChangedToExternal) { // Remove azure warning
+      set(this, 'showChangedToExternal', false);
     }
   }),
 
@@ -191,6 +226,12 @@ export default Component.extend({
     } else {
       return true;
     }
+  }),
+
+  isAzureInTreeSupported: computed('cluster.rancherKubernetesEngineConfig.kubernetesVersion', function() {
+    const kubernetesVersion = get(this, 'cluster.rancherKubernetesEngineConfig.kubernetesVersion');
+
+    return Semver.satisfies(Semver.coerce(kubernetesVersion), `>=${ AZURE_IN_TREE_MINIMUM_VERSION } <${ AZURE_IN_TREE_DEPRICATE_VERSION }`);
   }),
 
   mappedConfigAnswers: computed('configAnswers', function() {

--- a/lib/shared/addon/components/cru-cloud-provider/component.js
+++ b/lib/shared/addon/components/cru-cloud-provider/component.js
@@ -183,6 +183,11 @@ export default Component.extend({
       set(configAnswersOut, answer.key, answer.value);
     });
 
+    // Avoid setting cloud provider specific configs if its path doesn't exist
+    if (!this.pathForSet) {
+      return;
+    }
+
     set(this, pathForSet, configAnswersOut);
   }),
 

--- a/lib/shared/addon/components/cru-cloud-provider/template.hbs
+++ b/lib/shared/addon/components/cru-cloud-provider/template.hbs
@@ -258,9 +258,11 @@
             />
           {{/if}}
         </label>
-        <p class="help-block mt-0">
-          {{t (get (get azureDescriptions answer.key) "description") htmlSafe=true}}
-        </p>
+        {{#if (get azureDescriptions answer.key)}}
+          <p class="help-block mt-0">
+            {{t (get (get azureDescriptions answer.key) "description") htmlSafe=true}}
+          </p>
+        {{/if}}
       </div>
       <div class="col span-6">
         <CheckOverrideAllowed

--- a/lib/shared/addon/components/cru-cloud-provider/template.hbs
+++ b/lib/shared/addon/components/cru-cloud-provider/template.hbs
@@ -39,6 +39,16 @@
     @isCreateClusterOrClusterTemplate={{isCreateClusterOrClusterTemplate}}
     @computedState={{not (eq selectedCloudProvider "none")}}
   >
+    {{#if showChangedToExternal}}
+      <div class="col span-12">
+        <BannerMessage
+          @color="bg-warning mt-0 mb-0"
+          @icon="icon-alert"
+          @message={{t "cloudProvider.azureUnsupported" htmlSafe=true}}
+        />
+      </div>
+    {{/if}}
+  
     {{#input-or-display
        editable=(or (and (eq mode "new") (or (not applyClusterTemplate) (and (eq mode "new") selectedCloudProviderOverrideAvailable))) canEditProvider)
        value=selectedCloudProvider
@@ -89,7 +99,7 @@
                 {{t "cloudProvider.azure"}}
               </label>
             </div>
-          {{else if isCreateClusterOrClusterTemplate}}
+          {{else if (and isCreateClusterOrClusterTemplate isAzureInTreeSupported)}}
             <div class="radio">
               <label>
                 {{radio-button

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -3161,6 +3161,7 @@ cloudProvider:
     label: External Amazon (Out-Of-Tree) 
     helpText: External Amazon enables use of useInstanceMetadataHostname. When useInstanceMetadataHostname is enabled, RKE will configure node name from ec2 metadata service. Configuring a Cloud Provider in your cluster without configuring the prerequisites will cause your cluster to not provision correctly. Prerequisites needed for supported cloud providers can be found in the documentation.
   azure: Azure (In-Tree)
+  azureUnsupported: 'Azure (In-Tree) is not supported by this version of Kubernetes. The Cloud Provider has been changed to External. Please use the <a href="https://ranchermanager.docs.rancher.com/v2.9/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/azure#cloud-provider-configuration" target="_blank" rel="nofollow noopener noreferrer">Cloud Provider Config</a> to supply an out-of-tree configuration as needed.'
   external:
     label: External (Out-Of-Tree)
     helpText: 'Please edit the YAML to specify the required addon for cloud controller manager.'


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/11520

## Occurred changes

- Azure is removed from the list of cloud providers when k8s version is `>= 1.30`
- When selected k8s version is  `>=1.27 or < 1.30` the Azure option will be displayed
- While the supported version is selected If you change that to an unsupported version `External` option automatically gets selected and a warning banner will be displayed that includes a documentation link
- By switching to a different cloud provider or a supported k8s version the warning banner will disappear

https://github.com/user-attachments/assets/dbf8fe0e-9fea-4a55-8f1c-58f4124d62de


## What should be tested

- Watch the video and test the same scenarios
- Also try to finish creating an Azure RKE1 cluster, I did not test that in my video, and there was an issue that got fixed later