### PR TITLE
Remove use of JsZip

### DIFF
--- a/app/authenticated/cluster/cis/scan/controller.js
+++ b/app/authenticated/cluster/cis/scan/controller.js
@@ -1,6 +1,5 @@
 import { filterBy, alias } from '@ember/object/computed';
 import Controller from '@ember/controller';
-import { downloadFile, generateZip } from 'shared/utils/download-files';
 import { get, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 
@@ -79,13 +78,8 @@ export default Controller.extend({
   },
   bulkActionHandler: computed(function() {
     return {
-      download: async(scans) => {
-        const asyncFiles = scans
-          .map((scan) => get(scan, 'csvFile'))
-        const files = await Promise.all(asyncFiles);
-        const zip = await generateZip(files);
-
-        await downloadFile(`cis-scans.zip`, zip, get(zip, 'type'));
+      download: () => {
+        console.error('CIS Scan Downloads is no longer available');
       },
       promptDelete: async(scans) => {
         this.modalService.toggleModal('confirm-delete', {

--- a/lib/pipeline/addon/components/edit-pipeline-config/component.js
+++ b/lib/pipeline/addon/components/edit-pipeline-config/component.js
@@ -3,7 +3,6 @@ import { inject as service } from '@ember/service';
 import { set, get, observer, setProperties } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { next } from '@ember/runloop';
-import { downloadFile, generateZip } from 'shared/utils/download-files';
 
 export default Component.extend({
   growl:        service(),
@@ -199,35 +198,9 @@ export default Component.extend({
   },
 
   download(pipeline, success) {
-    const unSyncConfigs = get(pipeline, 'unSyncConfigs');
+    console.error('Pipeline download no longer supported');
 
-    get(this, 'store').rawRequest({
-      url:    `${ get(pipeline, 'links.yaml') }?configs=${ JSON.stringify(unSyncConfigs) }`,
-      method: 'GET',
-    }).then((res) => {
-      const data = JSON.parse(res.body);
-      const files = [];
-
-      Object.keys(data).forEach((key) => {
-        files.push({
-          name: `${ key }.yml`,
-          file: data[key]
-        });
-      });
-
-      if ( files.length > 1 ) {
-        generateZip(files).then((zip) => {
-          downloadFile(`rancher-pipeline.zip`, zip, get(zip, 'type'));
-        });
-      } else {
-        downloadFile(`.rancher-pipeline.yml`, get(files, 'firstObject.file'));
-      }
-
-      success(true);
-      get(this, 'router').transitionTo('authenticated.project.pipeline.pipelines');
-    }).catch(() => {
-      success(false);
-    });
+    success(false);
   },
 
   submit(pipeline, success, pushToRepo = false) {

--- a/lib/shared/addon/bulk-action-handler/service.js
+++ b/lib/shared/addon/bulk-action-handler/service.js
@@ -1,5 +1,4 @@
 import Service, { inject as service } from '@ember/service';
-import { downloadResourceYaml } from 'shared/utils/download-files';
 
 export default Service.extend({
   modalService: service('modal'),
@@ -28,8 +27,4 @@ export default Service.extend({
   move(nodes) {
     this.get('modalService').toggleModal('modal-move-namespace', nodes);
   },
-
-  downloadYaml(nodes){
-    downloadResourceYaml(nodes);
-  }
 });

--- a/lib/shared/addon/mixins/cattle-transitioning-resource.js
+++ b/lib/shared/addon/mixins/cattle-transitioning-resource.js
@@ -5,7 +5,6 @@ import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
 import { ucFirst, sortableNumericSuffix } from 'ui/utils/util';
 import C from 'ui/utils/constants';
-import { downloadResourceYaml } from 'shared/utils/download-files';
 
 function terminatedIcon(inst) {
   if ( get(inst, 'exitCode') === 0 ) {
@@ -344,15 +343,16 @@ export default Mixin.create({
       enabled: get(this, 'canViewYaml'),
     });
 
-    out.push({
-      sort:     97,
-      label:    'action.downloadYaml',
-      icon:     'icon icon-download',
-      action:   'downloadYaml',
-      bulkable: true,
-      single:   false,
-      enabled:  get(this, 'canDownloadYaml'),
-    });
+    // Backend API For YAML Download does not work
+    // out.push({
+    //   sort:     97,
+    //   label:    'action.downloadYaml',
+    //   icon:     'icon icon-download',
+    //   action:   'downloadYaml',
+    //   bulkable: false,
+    //   single:   true,
+    //   enabled:  get(this, 'canDownloadYaml'),
+    // });
 
     out.push({
       sort:    98,
@@ -429,10 +429,6 @@ export default Mixin.create({
 
     delete() {
       return this.delete();
-    },
-
-    downloadYaml() {
-      downloadResourceYaml([this]);
     },
 
     editYaml(){

--- a/lib/shared/addon/utils/download-files.js
+++ b/lib/shared/addon/utils/download-files.js
@@ -1,28 +1,12 @@
 import fetchYaml from 'shared/utils/fetch-yaml';
 import { all } from 'rsvp';
 import { addQueryParam } from 'shared/utils/util';
-import JSZip from 'jszip';
 import { saveAs } from 'file-saver';
 
 export function downloadFile(fileName, content, contentType = 'text/plain;charset=utf-8') {
   const blob = new Blob([content], { type: contentType });
 
   saveAs(blob, fileName);
-}
-
-// [{name: 'file1', file: 'data'}, {name: 'file2', file: 'data2'}]
-export function generateZip(files) {
-  const zip = new JSZip();
-
-  for ( let i = 0 ; i < files.length ; i++ ) {
-    let file = files[i];
-
-    zip.file(file.name, file.file);
-  }
-
-  return zip.generateAsync({ type: 'blob' }).then((contents) => {
-    return contents;
-  });
 }
 
 export function downloadResourceYaml(resources){

--- a/lib/shared/addon/utils/download-files.js
+++ b/lib/shared/addon/utils/download-files.js
@@ -1,5 +1,3 @@
-import fetchYaml from 'shared/utils/fetch-yaml';
-import { addQueryParam } from 'shared/utils/util';
 import { saveAs } from 'file-saver';
 
 export function downloadFile(fileName, content, contentType = 'text/plain;charset=utf-8') {

--- a/lib/shared/addon/utils/download-files.js
+++ b/lib/shared/addon/utils/download-files.js
@@ -1,5 +1,4 @@
 import fetchYaml from 'shared/utils/fetch-yaml';
-import { all } from 'rsvp';
 import { addQueryParam } from 'shared/utils/util';
 import { saveAs } from 'file-saver';
 
@@ -7,48 +6,4 @@ export function downloadFile(fileName, content, contentType = 'text/plain;charse
   const blob = new Blob([content], { type: contentType });
 
   saveAs(blob, fileName);
-}
-
-export function downloadResourceYaml(resources){
-  if ( !resources.length ) {
-    return;
-  }
-
-  if ( resources.length <= 1 ) {
-    let resource = resources[0];
-
-    let yamlLink = resource.links.yaml;
-
-    if ( yamlLink ) {
-      yamlLink = addQueryParam(yamlLink, 'export', 'true');
-      fetchYaml(yamlLink).then((yaml) => {
-        downloadFile(`${ resource.name  }.yaml`, yaml);
-      });
-    }
-  } else {
-    let hashRequest = [];
-
-    for ( let i = 0; i < resources.length; i++ ) {
-      let resource = resources[i];
-      let yamlLink = resource.links.yaml;
-
-      if ( yamlLink ) {
-        yamlLink = addQueryParam(yamlLink, 'export', 'true');
-        hashRequest.push(fetchYaml(yamlLink));
-      }
-    }
-
-    all(hashRequest).then((data) => {
-      let files = data.map((ele, index) => {
-        return {
-          name: `${ resources[index].name  }.yaml`,
-          file: ele
-        };
-      });
-
-      generateZip(files).then((zip) => {
-        downloadFile(`${ resources[0].type  }.zip`, zip, zip.type);
-      });
-    });
-  }
 }

--- a/lib/shared/package.json
+++ b/lib/shared/package.json
@@ -26,7 +26,6 @@
     "jgrowl": "*",
     "json2yaml": "*",
     "jsyaml": "*",
-    "jszip": "*",
     "liquid-fire": "*",
     "marked": "*",
     "prettycron": "*",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "js-yaml": "3.14.0",
     "json2yaml": "^1.1.0",
     "jsondiffpatch": "^0.4.1",
-    "jszip": "^3.8.0",
     "linkifyjs": "^2.1.9",
     "loader.js": "^4.7.0",
     "marked": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9502,11 +9502,6 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immediate@~3.0.5:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
-  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
-
 import-fresh@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.1.0.tgz#6d33fa1dcef6df930fae003446f33415af905118"
@@ -10346,16 +10341,6 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jszip@^3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.8.0.tgz#a2ac3c33fe96a76489765168213655850254d51b"
-  integrity sha512-cnpQrXvFSLdsR9KR5/x7zdf6c3m8IhZfZzSblFEHSqBaVwD2nvJ4CuCKLyvKvwBgZm08CgfSoiTBQLm5WW9hGw==
-  dependencies:
-    lie "~3.3.0"
-    pako "~1.0.2"
-    readable-stream "~2.3.6"
-    set-immediate-shim "~1.0.1"
-
 kind-of@^3.0.2, kind-of@^3.0.3:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -10433,13 +10418,6 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
-
-lie@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
-  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
-  dependencies:
-    immediate "~3.0.5"
 
 line-column@^1.0.2:
   version "1.0.2"
@@ -11815,7 +11793,7 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-pako@~1.0.2, pako@~1.0.5:
+pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
@@ -13060,11 +13038,6 @@ set-cookie-parser@^2.4.6:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.4.6.tgz#43bdea028b9e6f176474ee5298e758b4a44799c3"
   integrity sha512-mNCnTUF0OYPwYzSHbdRdCfNNHqrne+HS5tS5xNb6yJbdP9wInV0q5xPLE0EyfV/Q3tImo3y/OXpD8Jn0Jtnjrg==
-
-set-immediate-shim@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
-  integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
This PR removes the JsZip library.

This was only being used in 2 parts of the codebase - cis scans and pipelines - both of these are no longer shown in the UI.

For simplicity, the code has been removed and errors are logged - these code paths should not be reachable in the UI - we will prune this code in the future as part of a larger tidy-up effort.