### PR TITLE
Remove standalone access to the legacy UI

### DIFF
--- a/app/authenticated/route.js
+++ b/app/authenticated/route.js
@@ -352,6 +352,18 @@ export default Route.extend(Preload, {
   },
 
   testAuthToken() {
+    // If not embedded and not dev mode, then direct access is disabled
+    const isDev = get(this, 'app.environment') === 'development';
+    const noDirectAccess = !isDev && !isEmbedded();
+
+    if (noDirectAccess) {
+      return Promise.reject({
+        status:          410,
+        useVueDashboard: true,
+        dashboardLink:   get(this, 'scope.dashboardBase')
+      });
+    }
+
     return this.access.testAuth()
       .catch(() => {
         set(this, `session.${ C.SESSION.BACK_TO }`, window.location.href);

--- a/app/fail-whale/controller.js
+++ b/app/fail-whale/controller.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  actions: {
+    gotoDashboard() {
+      const url = this.get('model.dashboardLink') || '/';
+
+      window.location.href = url;
+    },
+  },
+});

--- a/app/fail-whale/template.hbs
+++ b/app/fail-whale/template.hbs
@@ -1,15 +1,27 @@
 <section class="fail-whale">
-  <div class="error">
-    <h2 class="bg-error">{{t 'failWhalePage.header'}}</h2>
-    <div class="p-20">
-      <h4 class="mt-20">{{model.code}} {{#if model.status}}({{model.status}}){{/if}}</h4>
-      <p>{{model.message}}</p>
-      <p class="small">{{model.detail}}</p>
-      <div class="mt-20">
-        {{t 'failWhalePage.reloadButton' htmlSafe=true}} <a class="hand" {{action "logout"}}>{{t 'failWhalePage.logoutButton'}}</a>
+  {{#if model.useVueDashboard }}
+    <div class="error">
+      <h2 class="bg-error">{{t 'legacyRemoved.title'}}</h2>
+      <div class="p-20">
+        <h4 class="">{{t 'legacyRemoved.message'}}</h4>
+        <button class="btn bg-primary btn-sm mt-20" type="button" {{action "gotoDashboard"}}>
+          {{t 'legacyRemoved.action'}}
+        </button>
       </div>
     </div>
-  </div>
+  {{else}}
+    <div class="error">
+      <h2 class="bg-error">{{t 'failWhalePage.header'}}</h2>
+      <div class="p-20">
+        <h4 class="mt-20">{{model.code}} {{#if model.status}}({{model.status}}){{/if}}</h4>
+        <p>{{model.message}}</p>
+        <p class="small">{{model.detail}}</p>
+        <div class="mt-20">
+          {{t 'failWhalePage.reloadButton' htmlSafe=true}} <a class="hand" {{action "logout"}}>{{t 'failWhalePage.logoutButton'}}</a>
+        </div>
+      </div>
+    </div>
+  {{/if}}
 
   {{#if settings.isRancher}}
     <div class="failplane">

--- a/scripts/patch-docker
+++ b/scripts/patch-docker
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+DIR=$(cd $(dirname $0)/..; pwd)
+
+CYAN="\033[96m"
+YELLOW="\033[93m"
+RESET="\033[0m"
+BOLD="\033[1m"
+
+echo -e "${CYAN}${BOLD}==================================================${RESET}"
+echo -e "${CYAN}${BOLD}Patch running Rancher Docker container with dev UI${RESET}"
+echo -e "${CYAN}${BOLD}==================================================${RESET}"
+echo ""
+echo "This script will build the UI and copy the built UI into the specified running Rancher container"
+echo ""
+
+if [ -z "$1" ]; then
+  echo -e "${YELLOW}Need ID of Rancher container to patch${RESET}"
+  exit 1
+fi
+
+DOCKER=$(docker version > /dev/null)
+if [ $? -ne 0 ]; then
+  echo -e "${YELLOW}Can not run Docker commands - is Docker running?${RESET}"
+  exit 1
+fi
+
+CONTAINER=$1
+
+SKIP_BUILD="false"
+
+if [ "$2" == "-s" ]; then
+  echo "Skipping build"
+  SKIP_BUILD="true"
+fi
+
+# Check container exists and looks like a Rancher container
+VERSION=$(docker exec ${CONTAINER} /bin/bash -c "printenv CATTLE_UI_VERSION")
+
+if [ $? -ne 0 ]; then
+  echo -e "${YELLOW}Could not get version env var from container - check the container ID${RESET}"
+  exit 1
+fi
+
+echo "UI version from existing container: ${VERSION}"
+
+# Check we have node and yarn installed
+
+node --version > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  echo -e "${YELLOW}node does not appear to be installed - this is required to build the UI${RESET}"
+  exit 1
+fi
+
+yarn --version > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  echo -e "${YELLOW}yarn does not appear to be installed - this is required to build the UI${RESET}"
+  exit 1
+fi
+
+if [ ! -d node_modules ]; then
+  echo -e "${YELLOW}node_modules folder does not exist - running yarn install${RESET}"
+  yarn installecho -e "${CYAN}Building production build of the UI${RESET}"
+
+rm -rf ${DIR}/dist
+mkdir -p ${DIR}/dist
+
+UI_MODE="" RANCHER="" CATALOG="" ${DIR}/node_modules/.bin/ember build --environment=production --output-path=${DIR}/dist
+
+  mkdir -p ${DIR}/dist
+
+  UI_MODE="" RANCHER="" CATALOG="" ${DIR}/node_modules/.bin/ember build --environment=production --output-path=${DIR}/dist
+fi
+
+rm -f dist.tar
+tar -cvf dist.tar dist/
+
+docker exec -it ${CONTAINER} bash -c "cd /usr/share/rancher/ui; rm -rf *"
+docker cp dist.tar ${CONTAINER}:/usr/share/rancher/ui
+rm -f dist.tar
+
+docker exec -it ${CONTAINER} bash -c "cd /usr/share/rancher/ui; tar -xvf dist.tar --strip-components=1"
+
+echo ""
+echo "All done"
+echo -e "${YELLOW}Note: It is recommended to set the Rancher 'ui-offline-preferred' setting to 'Local' to ensure the embedded UI is always used${RESET}"
+echo ""
+
+

--- a/scripts/patch-docker
+++ b/scripts/patch-docker
@@ -60,17 +60,14 @@ fi
 
 if [ ! -d node_modules ]; then
   echo -e "${YELLOW}node_modules folder does not exist - running yarn install${RESET}"
-  yarn installecho -e "${CYAN}Building production build of the UI${RESET}"
+  yarn install
+  echo -e "${CYAN}Building production build of the UI${RESET}"
+fi
 
 rm -rf ${DIR}/dist
 mkdir -p ${DIR}/dist
 
 UI_MODE="" RANCHER="" CATALOG="" ${DIR}/node_modules/.bin/ember build --environment=production --output-path=${DIR}/dist
-
-  mkdir -p ${DIR}/dist
-
-  UI_MODE="" RANCHER="" CATALOG="" ${DIR}/node_modules/.bin/ember build --environment=production --output-path=${DIR}/dist
-fi
 
 rm -f dist.tar
 tar -cvf dist.tar dist/
@@ -85,5 +82,3 @@ echo ""
 echo "All done"
 echo -e "${YELLOW}Note: It is recommended to set the Rancher 'ui-offline-preferred' setting to 'Local' to ensure the embedded UI is always used${RESET}"
 echo ""
-
-

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -169,6 +169,13 @@ realmNames:
   euWest: EU West
   euEast: EU East
 
+
+## Error page for UI access removed ##
+legacyRemoved:
+  title: The Legacy UI has been removed
+  message: Please use the new Rancher Dashboard UI
+  action: Goto Dashboard
+
 ##############################
 # Routes
 ##############################


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/11371

If the UI is not running in development mode and not embedded, then send the user to the error page.

Only the pages embedded in the new dashboard UI are supported - this PR adds a check to see if the old UI is being accessed standalone and shows an error message if so.

Access to `/g` should show the new error page:

![image](https://github.com/user-attachments/assets/2063a810-ab09-4352-b99b-b26c8d30cce0)

This PR:

- Updates the fail page to include support for showing a specific message related to removing standalone access
- Update authentication guard to check access and throw an error if being accessed standalone, which causes the fail page to be shown
- Added translations as needed
- Adds a script to help with testing - it builds the static UI assets and copies them into a running Rancher container, allowing testing in a simulated production build

Note: This PR is layered on top of the Docker URL PR