### PR TITLE
Remove express dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "eslint": "^7.17.0",
     "eslint-plugin-ember": "^10.1.1",
     "eslint-plugin-node": "^11.1.0",
-    "express": "^4.8.5",
     "file-saver": "^2.0.2",
     "glob": "^7.1.2",
     "http-proxy": "^1.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8231,7 +8231,7 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-express@^4.10.7, express@^4.17.1, express@^4.8.5:
+express@^4.10.7, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
   integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==


### PR DESCRIPTION
This PR removes the `express` dependency we have in our `package.json` file.

There are no references in the codebase that I could find. The only place I believed it might be used is for the development server that is run with `yarn start` - but this does not seem to require it (I think Ember brings it in as a dependency itself).