### PR TITLE
update ec2 instances list in amazon.js

### DIFF
--- a/lib/shared/addon/utils/amazon.js
+++ b/lib/shared/addon/utils/amazon.js
@@ -87,6 +87,207 @@ export const INSTANCE_TYPES = [
   },
 
   {
+    group: 'M7i-flex - General Purpose',
+    name:  'm7i-flex.large'
+  },
+  {
+    group: 'M7i-flex - General Purpose',
+    name:  'm7i-flex.xlarge'
+  },
+  {
+    group: 'M7i-flex - General Purpose',
+    name:  'm7i-flex.2xlarge'
+  },
+  {
+    group: 'M7i-flex - General Purpose',
+    name:  'm7i-flex.4xlarge'
+  },
+  {
+    group: 'M7i-flex - General Purpose',
+    name:  'm7i-flex.8xlarge'
+  },
+
+  {
+    group: 'M7i - General Purpose',
+    name:  'm7i.large'
+  },
+  {
+    group: 'M7i - General Purpose',
+    name:  'm7i.xlarge'
+  },
+  {
+    group: 'M7i - General Purpose',
+    name:  'm7i.2xlarge'
+  },
+  {
+    group: 'M7i - General Purpose',
+    name:  'm7i.4xlarge'
+  },
+  {
+    group: 'M7i - General Purpose',
+    name:  'm7i.8xlarge'
+  },
+  {
+    group: 'M7i - General Purpose',
+    name:  'm7i.12xlarge'
+  },
+  {
+    group: 'M7i - General Purpose',
+    name:  'm7i.16xlarge'
+  },
+  {
+    group: 'M7i - General Purpose',
+    name:  'm7i.24xlarge'
+  },
+  {
+    group: 'M7i - General Purpose',
+    name:  'm7i.48xlarge'
+  },
+  {
+    group: 'M7i - General Purpose',
+    name:  'm7i.metal-24xl'
+  },
+  {
+    group: 'M7i - General Purpose',
+    name:  'm7i.metal-48xl'
+  },
+
+  {
+    group: 'M7a - General Purpose',
+    name:  'm7a.medium'
+  },
+  {
+    group: 'M7a - General Purpose',
+    name:  'm7a.large'
+  },
+  {
+    group: 'M7a - General Purpose',
+    name:  'm7a.xlarge'
+  },
+  {
+    group: 'M7a - General Purpose',
+    name:  'm7a.2xlarge'
+  },
+  {
+    group: 'M7a - General Purpose',
+    name:  'm7a.4xlarge'
+  },
+  {
+    group: 'M7a - General Purpose',
+    name:  'm7a.8xlarge'
+  },
+  {
+    group: 'M7a - General Purpose',
+    name:  'm7a.12xlarge'
+  },
+  {
+    group: 'M7a - General Purpose',
+    name:  'm7a.16xlarge'
+  },
+  {
+    group: 'M7a - General Purpose',
+    name:  'm7a.24xlarge'
+  },
+  {
+    group: 'M7a - General Purpose',
+    name:  'm7a.32xlarge'
+  },
+  {
+    group: 'M7a - General Purpose',
+    name:  'm7a.48xlarge'
+  },
+  {
+    group: 'M7a - General Purpose',
+    name:  'm7a.metal-48xl'
+  },
+
+  {
+    group: 'M6i - General Purpose',
+    name:  'm6i.large'
+  },
+  {
+    group: 'M6i - General Purpose',
+    name:  'm6i.xlarge'
+  },
+  {
+    group: 'M6i - General Purpose',
+    name:  'm6i.2xlarge'
+  },
+  {
+    group: 'M6i - General Purpose',
+    name:  'm6i.4xlarge'
+  },
+  {
+    group: 'M6i - General Purpose',
+    name:  'm6i.8xlarge'
+  },
+  {
+    group: 'M6i - General Purpose',
+    name:  'm6i.12xlarge'
+  },
+  {
+    group: 'M6i - General Purpose',
+    name:  'm6i.16xlarge'
+  },
+  {
+    group: 'M6i - General Purpose',
+    name:  'm6i.24xlarge'
+  },
+  {
+    group: 'M6i - General Purpose',
+    name:  'm6i.32xlarge'
+  },
+  {
+    group: 'M6i - General Purpose',
+    name:  'm6i.metal'
+  },
+
+  {
+    group: 'M6a - General Purpose',
+    name:  'm6a.large'
+  },
+  {
+    group: 'M6a - General Purpose',
+    name:  'm6a.xlarge'
+  },
+  {
+    group: 'M6a - General Purpose',
+    name:  'm6a.2xlarge'
+  },
+  {
+    group: 'M6a - General Purpose',
+    name:  'm6a.4xlarge'
+  },
+  {
+    group: 'M6a - General Purpose',
+    name:  'm6a.8xlarge'
+  },
+  {
+    group: 'M6a - General Purpose',
+    name:  'm6a.12xlarge'
+  },
+  {
+    group: 'M6a - General Purpose',
+    name:  'm6a.16xlarge'
+  },
+  {
+    group: 'M6a - General Purpose',
+    name:  'm6a.24xlarge'
+  },
+  {
+    group: 'M6a - General Purpose',
+    name:  'm6a.32xlarge'
+  },
+  {
+    group: 'M6a - General Purpose',
+    name:  'm6a.48xlarge'
+  },
+  {
+    group: 'M6a - General Purpose',
+    name:  'm6a.metal'
+  },
+
+  {
     group: 'M5 - General Purpose',
     name:  'm5.large'
   },
@@ -259,6 +460,207 @@ export const INSTANCE_TYPES = [
   },
 
   {
+    group: 'C7i-flex - High CPU',
+    name:  'c7i-flex.large'
+  },
+  {
+    group: 'C7i-flex - High CPU',
+    name:  'c7i-flex.xlarge'
+  },
+  {
+    group: 'C7i-flex - High CPU',
+    name:  'c7i-flex.2xlarge'
+  },
+  {
+    group: 'C7i-flex - High CPU',
+    name:  'c7i-flex.4xlarge'
+  },
+  {
+    group: 'C7i-flex - High CPU',
+    name:  'c7i-flex.8xlarge'
+  },
+
+  {
+    group: 'C7i - High CPU',
+    name:  'c7i.large'
+  },
+  {
+    group: 'C7i - High CPU',
+    name:  'c7i.xlarge'
+  },
+  {
+    group: 'C7i - High CPU',
+    name:  'c7i.2xlarge'
+  },
+  {
+    group: 'C7i - High CPU',
+    name:  'c7i.4xlarge'
+  },
+  {
+    group: 'C7i - High CPU',
+    name:  'c7i.8xlarge'
+  },
+  {
+    group: 'C7i - High CPU',
+    name:  'c7i.12xlarge'
+  },
+  {
+    group: 'C7i - High CPU',
+    name:  'c7i.16xlarge'
+  },
+  {
+    group: 'C7i - High CPU',
+    name:  'c7i.24xlarge'
+  },
+  {
+    group: 'C7i - High CPU',
+    name:  'c7i.48xlarge'
+  },
+  {
+    group: 'C7i - High CPU',
+    name:  'c7i.metal-24xl'
+  },
+  {
+    group: 'C7i - High CPU',
+    name:  'c7i.metal-48xl'
+  },
+
+  {
+    group: 'C7a - High CPU',
+    name:  'c7a.medium'
+  },
+  {
+    group: 'C7a - High CPU',
+    name:  'c7a.large'
+  },
+  {
+    group: 'C7a - High CPU',
+    name:  'c7a.xlarge'
+  },
+  {
+    group: 'C7a - High CPU',
+    name:  'c7a.2xlarge'
+  },
+  {
+    group: 'C7a - High CPU',
+    name:  'c7a.4xlarge'
+  },
+  {
+    group: 'C7a - High CPU',
+    name:  'c7a.8xlarge'
+  },
+  {
+    group: 'C7a - High CPU',
+    name:  'c7a.12xlarge'
+  },
+  {
+    group: 'C7a - High CPU',
+    name:  'c7a.16xlarge'
+  },
+  {
+    group: 'C7a - High CPU',
+    name:  'c7a.24xlarge'
+  },
+  {
+    group: 'C7a - High CPU',
+    name:  'c7a.32xlarge'
+  },
+  {
+    group: 'C7a - High CPU',
+    name:  'c7a.48xlarge'
+  },
+  {
+    group: 'C7a - High CPU',
+    name:  'c7a.metal-48xl'
+  },
+
+  {
+    group: 'C6i - High CPU',
+    name:  'c6i.large'
+  },
+  {
+    group: 'C6i - High CPU',
+    name:  'c6i.xlarge'
+  },
+  {
+    group: 'C6i - High CPU',
+    name:  'c6i.2xlarge'
+  },
+  {
+    group: 'C6i - High CPU',
+    name:  'c6i.4xlarge'
+  },
+  {
+    group: 'C6i - High CPU',
+    name:  'c6i.8xlarge'
+  },
+  {
+    group: 'C6i - High CPU',
+    name:  'c6i.12xlarge'
+  },
+  {
+    group: 'C6i - High CPU',
+    name:  'c6i.16xlarge'
+  },
+  {
+    group: 'C6i - High CPU',
+    name:  'c6i.24xlarge'
+  },
+  {
+    group: 'C6i - High CPU',
+    name:  'c6i.32xlarge'
+  },
+  {
+    group: 'C6i - High CPU',
+    name:  'c6i.metal'
+  },
+
+  {
+    group: 'C6a - High CPU',
+    name:  'c6a.large'
+  },
+  {
+    group: 'C6a - High CPU',
+    name:  'c6a.xlarge'
+  },
+  {
+    group: 'C6a - High CPU',
+    name:  'c6a.2xlarge'
+  },
+  {
+    group: 'C6a - High CPU',
+    name:  'c6a.4xlarge'
+  },
+  {
+    group: 'C6a - High CPU',
+    name:  'c6a.8xlarge'
+  },
+  {
+    group: 'C6a - High CPU',
+    name:  'c6a.12xlarge'
+  },
+  {
+    group: 'C6a - High CPU',
+    name:  'c6a.16xlarge'
+  },
+  {
+    group: 'C6a - High CPU',
+    name:  'c6a.24xlarge'
+  },
+  {
+    group: 'C6a - High CPU',
+    name:  'c6a.32xlarge'
+  },
+  {
+    group: 'C6a - High CPU',
+    name:  'c6a.48xlarge'
+  },
+  {
+    group: 'C6a - High CPU',
+    name:  'c6a.metal'
+  },
+
+  {
     group: 'C5 - High CPU',
     name:  'c5.large'
   },
@@ -329,31 +731,6 @@ export const INSTANCE_TYPES = [
   },
 
   {
-    group: 'C5D - High CPU',
-    name:  'c5d.large'
-  },
-  {
-    group: 'C5D - High CPU',
-    name:  'c5d.xlarge'
-  },
-  {
-    group: 'C5D - High CPU',
-    name:  'c5d.2xlarge'
-  },
-  {
-    group: 'C5D - High CPU',
-    name:  'c5d.4xlarge'
-  },
-  {
-    group: 'C5D - High CPU',
-    name:  'c5d.9xlarge'
-  },
-  {
-    group: 'C5D - High CPU',
-    name:  'c5d.18xlarge'
-  },
-
-  {
     group: 'C4 - High CPU',
     name:  'c4.large'
   },
@@ -396,49 +773,183 @@ export const INSTANCE_TYPES = [
   },
 
   {
-    group: 'R3 - High Memory',
-    name:  'r3.large'
+    group: 'R7i - High Memory Optimized',
+    name:  'r7i.large'
   },
   {
-    group: 'R3 - High Memory',
-    name:  'r3.xlarge'
+    group: 'R7i - High Memory Optimized',
+    name:  'r7i.xlarge'
   },
   {
-    group: 'R3 - High Memory',
-    name:  'r3.2xlarge'
+    group: 'R7i - High Memory Optimized',
+    name:  'r7i.2xlarge'
   },
   {
-    group: 'R3 - High Memory',
-    name:  'r3.4xlarge'
+    group: 'R7i - High Memory Optimized',
+    name:  'r7i.4xlarge'
   },
   {
-    group: 'R3 - High Memory',
-    name:  'r3.8xlarge'
+    group: 'R7i - High Memory Optimized',
+    name:  'r7i.8xlarge'
+  },
+  {
+    group: 'R7i - High Memory Optimized',
+    name:  'r7i.12xlarge'
+  },
+  {
+    group: 'R7i - High Memory Optimized',
+    name:  'r7i.16xlarge'
+  },
+  {
+    group: 'R7i - High Memory Optimized',
+    name:  'r7i.24xlarge'
+  },
+  {
+    group: 'R7i - High Memory Optimized',
+    name:  'r7i.48xlarge'
+  },
+  {
+    group: 'R7i - High Memory Optimized',
+    name:  'r7i.metal-24xl'
+  },
+  {
+    group: 'R7i - High Memory Optimized',
+    name:  'r7i.metal-48xl'
   },
 
   {
-    group: 'R4 - High Memory',
-    name:  'r4.large'
+    group: 'R7a - High Memory Optimized',
+    name:  'r7a.medium'
   },
   {
-    group: 'R4 - High Memory',
-    name:  'r4.xlarge'
+    group: 'R7a - High Memory Optimized',
+    name:  'r7a.large'
   },
   {
-    group: 'R4 - High Memory',
-    name:  'r4.2xlarge'
+    group: 'R7a - High Memory Optimized',
+    name:  'r7a.xlarge'
   },
   {
-    group: 'R4 - High Memory',
-    name:  'r4.4xlarge'
+    group: 'R7a - High Memory Optimized',
+    name:  'r7a.2xlarge'
   },
   {
-    group: 'R4 - High Memory',
-    name:  'r4.8xlarge'
+    group: 'R7a - High Memory Optimized',
+    name:  'r7a.4xlarge'
   },
   {
-    group: 'R4 - High Memory',
-    name:  'r4.16xlarge'
+    group: 'R7a - High Memory Optimized',
+    name:  'r7a.8xlarge'
+  },
+  {
+    group: 'R7a - High Memory Optimized',
+    name:  'r7a.12xlarge'
+  },
+  {
+    group: 'R7a - High Memory Optimized',
+    name:  'r7a.16xlarge'
+  },
+  {
+    group: 'R7a - High Memory Optimized',
+    name:  'r7a.24xlarge'
+  },
+  {
+    group: 'R7a - High Memory Optimized',
+    name:  'r7a.32xlarge'
+  },
+  {
+    group: 'R7a - High Memory Optimized',
+    name:  'r7a.48xlarge'
+  },
+  {
+    group: 'R7a - High Memory Optimized',
+    name:  'r7a.metal-48xl'
+  },
+
+  {
+    group: 'R6i - High Memory Optimized',
+    name:  'r6i.large'
+  },
+  {
+    group: 'R6i - High Memory Optimized',
+    name:  'r6i.xlarge'
+  },
+  {
+    group: 'R6i - High Memory Optimized',
+    name:  'r6i.2xlarge'
+  },
+  {
+    group: 'R6i - High Memory Optimized',
+    name:  'r6i.4xlarge'
+  },
+  {
+    group: 'R6i - High Memory Optimized',
+    name:  'r6i.8xlarge'
+  },
+  {
+    group: 'R6i - High Memory Optimized',
+    name:  'r6i.12xlarge'
+  },
+  {
+    group: 'R6i - High Memory Optimized',
+    name:  'r6i.16xlarge'
+  },
+  {
+    group: 'R6i - High Memory Optimized',
+    name:  'r6i.24xlarge'
+  },
+  {
+    group: 'R6i - High Memory Optimized',
+    name:  'r6i.32xlarge'
+  },
+  {
+    group: 'R6i - High Memory Optimized',
+    name:  'r6i.metal'
+  },
+
+  {
+    group: 'R6a - High Memory Optimized',
+    name:  'r6a.large'
+  },
+  {
+    group: 'R6a - High Memory Optimized',
+    name:  'r6a.xlarge'
+  },
+  {
+    group: 'R6a - High Memory Optimized',
+    name:  'r6a.2xlarge'
+  },
+  {
+    group: 'R6a - High Memory Optimized',
+    name:  'r6a.4xlarge'
+  },
+  {
+    group: 'R6a - High Memory Optimized',
+    name:  'r6a.8xlarge'
+  },
+  {
+    group: 'R6a - High Memory Optimized',
+    name:  'r6a.12xlarge'
+  },
+  {
+    group: 'R6a - High Memory Optimized',
+    name:  'r6a.16xlarge'
+  },
+  {
+    group: 'R6a - High Memory Optimized',
+    name:  'r6a.24xlarge'
+  },
+  {
+    group: 'R6a - High Memory Optimized',
+    name:  'r6a.32xlarge'
+  },
+  {
+    group: 'R6a - High Memory Optimized',
+    name:  'r6a.48xlarge'
+  },
+  {
+    group: 'R6a - High Memory Optimized',
+    name:  'r6a.metal'
   },
 
   {
@@ -492,6 +1003,52 @@ export const INSTANCE_TYPES = [
   },
 
   {
+    group: 'R4 - High Memory',
+    name:  'r4.large'
+  },
+  {
+    group: 'R4 - High Memory',
+    name:  'r4.xlarge'
+  },
+  {
+    group: 'R4 - High Memory',
+    name:  'r4.2xlarge'
+  },
+  {
+    group: 'R4 - High Memory',
+    name:  'r4.4xlarge'
+  },
+  {
+    group: 'R4 - High Memory',
+    name:  'r4.8xlarge'
+  },
+  {
+    group: 'R4 - High Memory',
+    name:  'r4.16xlarge'
+  },
+
+  {
+    group: 'R3 - High Memory',
+    name:  'r3.large'
+  },
+  {
+    group: 'R3 - High Memory',
+    name:  'r3.xlarge'
+  },
+  {
+    group: 'R3 - High Memory',
+    name:  'r3.2xlarge'
+  },
+  {
+    group: 'R3 - High Memory',
+    name:  'r3.4xlarge'
+  },
+  {
+    group: 'R3 - High Memory',
+    name:  'r3.8xlarge'
+  },
+
+  {
     group: 'D2 - High Density Storage',
     name:  'd2.xlarge'
   },
@@ -534,8 +1091,53 @@ export const INSTANCE_TYPES = [
   },
 
   {
+    group: 'I4 - High I/O Storage',
+    name:  'i4i.large'
+  },
+  {
+    group: 'I4 - High I/O Storage',
+    name:  'i4i.xlarge'
+  },
+  {
+    group: 'I4 - High I/O Storage',
+    name:  'i4i.2xlarge'
+  },
+  {
+    group: 'I4 - High I/O Storage',
+    name:  'i4i.4xlarge'
+  },
+  {
+    group: 'I4 - High I/O Storage',
+    name:  'i4i.8xlarge'
+  },
+  {
+    group: 'I4 - High I/O Storage',
+    name:  'i4i.12xlarge'
+  },
+  {
+    group: 'I4 - High I/O Storage',
+    name:  'i4i.16xlarge'
+  },
+  {
+    group: 'I4 - High I/O Storage',
+    name:  'i4i.24xlarge'
+  },
+  {
+    group: 'I4 - High I/O Storage',
+    name:  'i4i.32xlarge'
+  },
+  {
+    group: 'I4 - High I/O Storage',
+    name:  'i4i.metal'
+  },
+
+  {
     group: 'F1 - FPGA',
     name:  'f1.2xlarge'
+  },
+  {
+    group: 'F1 - FPGA',
+    name:  'f1.4xlarge'
   },
   {
     group: 'F1 - FPGA',
@@ -585,6 +1187,114 @@ export const INSTANCE_TYPES = [
   },
 
   {
+    group: 'G5 - GPU',
+    name:  'g5.xlarge'
+  },
+  {
+    group: 'G5 - GPU',
+    name:  'g5.2xlarge'
+  },
+  {
+    group: 'G5 - GPU',
+    name:  'g5.4xlarge'
+  },
+  {
+    group: 'G5 - GPU',
+    name:  'g5.8xlarge'
+  },
+  {
+    group: 'G5 - GPU',
+    name:  'g5.16xlarge'
+  },
+  {
+    group: 'G5 - GPU',
+    name:  'g5.12xlarge'
+  },
+  {
+    group: 'G5 - GPU',
+    name:  'g5.24xlarge'
+  },
+  {
+    group: 'G5 - GPU',
+    name:  'g5.48xlarge'
+  },
+
+  {
+    group: 'G6 - GPU',
+    name:  'g6.xlarge'
+  },
+  {
+    group: 'G6 - GPU',
+    name:  'g6.2xlarge'
+  },
+  {
+    group: 'G6 - GPU',
+    name:  'g6.4xlarge'
+  },
+  {
+    group: 'G6 - GPU',
+    name:  'g6.8xlarge'
+  },
+  {
+    group: 'G6 - GPU',
+    name:  'g6.16xlarge'
+  },
+  {
+    group: 'G6 - GPU',
+    name:  'g6.12xlarge'
+  },
+  {
+    group: 'G6 - GPU',
+    name:  'g6.24xlarge'
+  },
+  {
+    group: 'G6 - GPU',
+    name:  'g6.48xlarge'
+  },
+
+  {
+    group: 'GR6 - GPU High Memory',
+    name:  'gr6.4xlarge'
+  },
+  {
+    group: 'GR6 - GPU High Memory',
+    name:  'gr6.8xlarge'
+  },
+
+  {
+    group: 'G6E - GPU',
+    name:  'g6e.xlarge'
+  },
+  {
+    group: 'G6E - GPU',
+    name:  'g6e.2xlarge'
+  },
+  {
+    group: 'G6E - GPU',
+    name:  'g6e.4xlarge'
+  },
+  {
+    group: 'G6E - GPU',
+    name:  'g6e.8xlarge'
+  },
+  {
+    group: 'G6E - GPU',
+    name:  'g6e.16xlarge'
+  },
+  {
+    group: 'G6E - GPU',
+    name:  'g6e.12xlarge'
+  },
+  {
+    group: 'G6E - GPU',
+    name:  'g6e.24xlarge'
+  },
+  {
+    group: 'G6E - GPU',
+    name:  'g6e.48xlarge'
+  },
+
+  {
     group: 'P2 - GPU',
     name:  'p2.xlarge'
   },
@@ -615,12 +1325,43 @@ export const INSTANCE_TYPES = [
   },
 
   {
+    group: 'P4 - GPU',
+    name:  'p4d.24xlarge'
+  },
+
+  {
+    group: 'P5 - GPU',
+    name:  'p5.48xlarge'
+  },
+  {
+    group: 'P5 - GPU',
+    name:  'p5e.48xlarge'
+  },
+
+  {
     group: 'X1 - Really High Memory',
     name:  'x1.16xlarge'
   },
   {
     group: 'X1 - Really High Memory',
     name:  'x1.32xlarge'
+  },
+
+  {
+    group: 'X2IDN - Really High Memory',
+    name:  'x2idn.16xlarge'
+  },
+  {
+    group: 'X2IDN - Really High Memory',
+    name:  'x2idn.24xlarge'
+  },
+  {
+    group: 'X2IDN - Really High Memory',
+    name:  'x2idn.32xlarge'
+  },
+  {
+    group: 'X2IDN - Really High Memory',
+    name:  'x2idn.metal'
   },
 ];
 


### PR DESCRIPTION
It looks like the included AWS EC2 instance list in Rancher is a bit stale.  I've attempted to update the existing instance types with the latest Intel/AMD versions excluding some of the fancier EC2 types for networking/storage .  Graviton instances look like they're still marked as "experimental" for use in Rancher so those have been excluded too.

