### PR TITLE
Set creator principal id annotation when creating clusters

### DIFF
--- a/lib/shared/addon/components/cru-cluster/component.js
+++ b/lib/shared/addon/components/cru-cluster/component.js
@@ -11,6 +11,7 @@ import ChildHook from 'shared/mixins/child-hook';
 import ViewNewEdit from 'shared/mixins/view-new-edit';
 import { loadStylesheet, proxifyUrl } from 'shared/utils/load-script';
 import layout from './template';
+import C from '../../utils/constants';
 
 const MEMBER_CONFIG = { type: 'clusterRoleTemplateBinding', };
 const BUILD_IN_UI = ['tencentkubernetesengine', 'huaweicontainercloudengine', 'oraclecontainerengine', 'linodekubernetesengine'];
@@ -67,6 +68,11 @@ export default Component.extend(ViewNewEdit, ChildHook, {
 
     if ( isEmpty(get(this, 'cluster.id')) ){
       set(this, 'newCluster', true);
+      const principal = get(this, 'access.principal')
+
+      if (principal?.provider !== 'local'){
+        set(this.cluster, 'annotations', { [C.LABEL.CREATOR_PRINCIPAL_ID]: principal.id })
+      }
     }
 
     this.router.on('routeWillChange', (/* transition */) => {

--- a/lib/shared/addon/utils/constants.js
+++ b/lib/shared/addon/utils/constants.js
@@ -164,8 +164,9 @@ var C = {
 
     DEPLOYMENT_REVISION: 'deployment.kubernetes.io/revision',
 
-    CREATOR_ID: 'field.cattle.io/creatorId',
-    TIMESTAMP:  'cattle.io/timestamp',
+    CREATOR_ID:           'field.cattle.io/creatorId',
+    TIMESTAMP:            'cattle.io/timestamp',
+    CREATOR_PRINCIPAL_ID: 'field.cattle.io/creator-principal-name',
 
     // EKS Cluster session token
     EKS_SESSION_TOKEN: 'clusterstatus.management.cattle.io/temporary-security-credentials',


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/11852
This PR adds an annotation when creating rke1 clusters and importing aks/eks/gke clusters. See the dashboard side https://github.com/rancher/dashboard/pull/12233 for more details
