### PR TITLE
[2.9] Add docker install URL for 27.3 and 27.4

### DIFF
--- a/lib/shared/addon/components/form-engine-opts/component.js
+++ b/lib/shared/addon/components/form-engine-opts/component.js
@@ -48,6 +48,14 @@ export default Component.extend({
 
     let out           = [
       {
+        label: 'v27.4.x',
+        value: 'https://releases.rancher.com/install-docker/27.4.sh'
+      },
+      {
+        label: 'v27.3.x',
+        value: 'https://releases.rancher.com/install-docker/27.3.sh'
+      },
+      {
         label: 'v27.2.x',
         value: 'https://releases.rancher.com/install-docker/27.2.sh'
       },


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/12912 and https://github.com/rancher/dashboard/issues/12913

This PR adds the requested docker install URLs.