### PR TITLE
Fix logging error in console when redirecting

### DIFF
--- a/app/authenticated/cluster/index/route.js
+++ b/app/authenticated/cluster/index/route.js
@@ -1,7 +1,4 @@
 import Route from '@ember/routing/route';
 
 export default Route.extend({
-  redirect() {
-    this.replaceWith('authenticated.cluster.monitoring.index');
-  },
 });


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/12291

Removes the redirect logic in `app/authenticated/cluster/index/route.js` that basically is responsible to render monitoring in the cluster's page. We don't support that page anymore and users can access that info from the explorer pages.

This is not removing the whole deprecated code, just the part that causes the console error.