### PR TITLE
Deprecate ember-based UI Plugins

### DIFF
--- a/app/authenticated/cluster/edit/template.hbs
+++ b/app/authenticated/cluster/edit/template.hbs
@@ -7,7 +7,7 @@
 <BannerMessage
   @color="bg-warning"
   @icon="icon-alert"
-  @message={{t "clustersPage.rke1DeprecationMessage" htmlSafe=true}}
+  @message={{t "clustersPage.emberDeprecationMessage" htmlSafe=true}}
 />
 
 <CruCluster

--- a/lib/global-admin/addon/clusters/new/route.js
+++ b/lib/global-admin/addon/clusters/new/route.js
@@ -11,6 +11,7 @@ import { get, set } from '@ember/object';
 
 export default Route.extend({
   globalStore: service(),
+  intl:        service(),
 
   model() {
     const gs = this.globalStore;
@@ -33,7 +34,7 @@ export default Route.extend({
 
   afterModel(model) {
     // load the css/js url here, if the url loads fail we should error the driver out
-    // show the driver in the ui, greyed out, and possibly add error text "can not load comonent from url [put url here]"
+    // show the driver in the ui, greyed out, and possibly add error text "can not load component from url [put url here]"
     let { kontainerDrivers } = model;
     let externalDrivers      = kontainerDrivers.filter( (d) => d.uiUrl !== '' && d.state === 'active');
     let promises = {};
@@ -59,6 +60,12 @@ export default Route.extend({
             let match = kontainerDrivers.findBy('id', tmp);
 
             console.log('Error Loading External Component for: ', match);
+
+            // Try and find by name if we could not find by id
+            if (!match) {
+              match = kontainerDrivers.findBy('name', tmp);
+            }
+
             if (match && get(match, 'scriptError') !== true) {
               set(match, 'scriptError', get(this, 'intl').t('clusterNew.externalError'));
             }

--- a/lib/global-admin/addon/clusters/new/template.hbs
+++ b/lib/global-admin/addon/clusters/new/template.hbs
@@ -23,7 +23,7 @@
   <BannerMessage
     @color="bg-warning"
     @icon="icon-alert"
-    @message={{t "clustersPage.rke1DeprecationMessage" htmlSafe=true}}
+    @message={{t "clustersPage.emberDeprecationMessage" htmlSafe=true}}
   />
   {{outlet}}
 </section>

--- a/lib/shared/addon/components/cru-cluster/component.js
+++ b/lib/shared/addon/components/cru-cluster/component.js
@@ -468,6 +468,24 @@ export default Component.extend(ViewNewEdit, ChildHook, {
     return true;
   }),
 
+  hasDriverComponentError: computed('showDriverComponent', function() {
+    const {
+      provider,
+      kontainerDrivers,
+    } = this;
+
+    if (kontainerDrivers?.custom) {
+      const driver = kontainerDrivers.custom.find((d) => d.id === provider || d.name === provider);
+
+      if (driver) {
+        // Return whether the driver has a script error
+        return !!driver.scriptError;
+      }
+    }
+
+    return false;
+  }),
+
   doSave(opt) {
     opt = opt || {};
     opt.qp = { '_replace': 'true' };

--- a/lib/shared/addon/components/cru-cluster/template.hbs
+++ b/lib/shared/addon/components/cru-cluster/template.hbs
@@ -1,177 +1,184 @@
-{{#if (eq step 1)}}
-  <form onsubmit={{action "clickNext"}}>
-    {{form-name-description
-      model=model.cluster
-      editing=(not isEksClusterPending)
-      nameRequired=true
-      rowClass="row mb-20"
-      colClass="col span-12 mb-0"
-      nameLabel="clusterNew.name.label"
-      namePlaceholder="clusterNew.name.placeholder"
-      descriptionPlaceholder="clusterNew.description.placeholder"
-    }}
-  </form>
-{{/if}}
-
-{{#if (eq driverInfo.name "amazoneks")}}
+{{#if (and showDriverComponent hasDriverComponentError) }}
   {{banner-message
-    color="bg-warning"
-    message=(t "clusterNew.amazoneks.ingressWarning")
+    color="bg-error"
+    message=(t "clusterNew.driverError")
   }}
-{{else if (eq driverInfo.name "azureaks")}}
-  {{banner-message
-    color="bg-warning"
-    message=(t "clusterNew.azureaks.ingressWarning")
-  }}
-{{/if}}
+{{else}}
+  {{#if (eq step 1)}}
+    <form onsubmit={{action "clickNext"}}>
+      {{form-name-description
+        model=model.cluster
+        editing=(not isEksClusterPending)
+        nameRequired=true
+        rowClass="row mb-20"
+        colClass="col span-12 mb-0"
+        nameLabel="clusterNew.name.label"
+        namePlaceholder="clusterNew.name.placeholder"
+        descriptionPlaceholder="clusterNew.description.placeholder"
+      }}
+    </form>
+  {{/if}}
 
-{{#if (and driverInfo.nodePool (not isCustom))}}
-  <section class="mb-40 mt-40">
-    <CruNodePools
-      @mode={{mode}}
-      @cluster={{cluster}}
-      @driver={{driverInfo.nodeWhich}}
-      @nodeTemplates={{model.nodeTemplates}}
-      @registerHook={{action "registerHook"}}
-      @setNodePoolErrors={{action "setNodePoolErrors"}}
-      @model={{model}}
-    />
-  </section>
-{{/if}}
-
-{{#if (eq step 1)}}
-  {{#accordion-list showExpandAll=false as |al expandFn|}}
-    {{#accordion-list-item
-       title=(t "clusterNew.members.label")
-       detail=(t "clusterNew.members.detail")
-       expandAll=al.expandAll
-       everExpanded=true
-       expanded=expanded
-       expand=(action expandFn)
-       componentId="cru-cluster__members"
+  {{#if (eq driverInfo.name "amazoneks")}}
+    {{banner-message
+      color="bg-warning"
+      message=(t "clusterNew.amazoneks.ingressWarning")
     }}
-      {{#if model.cluster.internal}}
-        <BannerMessage
-          @icon="icon-alert"
-          @color="bg-error mt-0 mb-10"
-          @message={{t "clusterPage.internal" appName=settings.appName htmlSafe=true}}
-        />
-      {{/if}}
+  {{else if (eq driverInfo.name "azureaks")}}
+    {{banner-message
+      color="bg-warning"
+      message=(t "clusterNew.azureaks.ingressWarning")
+    }}
+  {{/if}}
 
-      {{#if isEdit}}
-        <BannerMessage
-          @icon="icon-info"
-          @color="bg-info mt-0 mb-10"
-          @message={{t "clusterPage.removeMemberNote"}}
-        />
-      {{/if}}
-      <FormMembers
-        @creator={{model.me}}
-        @editing={{and (and notView) (not isEksClusterPending)}}
-        @expanded={{expanded}}
-        @isNew={{newCluster}}
-        @memberConfig={{memberConfig}}
-        @errors={{memberErrors}}
-        @primaryResource={{cluster}}
+  {{#if (and driverInfo.nodePool (not isCustom))}}
+    <section class="mb-40 mt-40">
+      <CruNodePools
+        @mode={{mode}}
+        @cluster={{cluster}}
+        @driver={{driverInfo.nodeWhich}}
+        @nodeTemplates={{model.nodeTemplates}}
         @registerHook={{action "registerHook"}}
-        @roles={{model.roleTemplates}}
-        @type="cluster"
-        @users={{model.users}}
-        data-testid="cru-cluster__members__form"
+        @setNodePoolErrors={{action "setNodePoolErrors"}}
+        @model={{model}}
       />
-    {{/accordion-list-item}}
+    </section>
+  {{/if}}
 
-    {{form-labels-annotations
-      classNames="accordion-wrapper"
-      detailKey="clusterPage.annotationsDetail"
-      expandAll=al.expandAll
-      expandFn=expandFn
-      initialLabels=model.cluster.labels
-      model=model.cluster
-      readonlyLabels=readonlyLabels
-      editing=(and (and notView (not isRke2Cluster)) (not isEksClusterPending))
-    }}
-  {{/accordion-list}}
-  {{#if isImportedOther}}
+  {{#if (eq step 1)}}
     {{#accordion-list showExpandAll=false as |al expandFn|}}
       {{#accordion-list-item
-        title=(t "clusterNew.rke.advanced.label")
-        detail=(t "clusterNew.rke.advanced.detail")
+        title=(t "clusterNew.members.label")
+        detail=(t "clusterNew.members.detail")
         expandAll=al.expandAll
         everExpanded=true
+        expanded=expanded
         expand=(action expandFn)
+        componentId="cru-cluster__members"
       }}
-      <div class="row">
-        <div class="col span-6">
-          <label class="acc-label">
-            {{t "generic.networking"}}
-          </label>
-          <div class="checkbox">
-            <label>
-              {{input type="checkbox" checked=cluster.enableNetworkPolicy}}
-              {{t "clusterNew.rke.networkPolicy.label"}}
+        {{#if model.cluster.internal}}
+          <BannerMessage
+            @icon="icon-alert"
+            @color="bg-error mt-0 mb-10"
+            @message={{t "clusterPage.internal" appName=settings.appName htmlSafe=true}}
+          />
+        {{/if}}
+
+        {{#if isEdit}}
+          <BannerMessage
+            @icon="icon-info"
+            @color="bg-info mt-0 mb-10"
+            @message={{t "clusterPage.removeMemberNote"}}
+          />
+        {{/if}}
+        <FormMembers
+          @creator={{model.me}}
+          @editing={{and (and notView) (not isEksClusterPending)}}
+          @expanded={{expanded}}
+          @isNew={{newCluster}}
+          @memberConfig={{memberConfig}}
+          @errors={{memberErrors}}
+          @primaryResource={{cluster}}
+          @registerHook={{action "registerHook"}}
+          @roles={{model.roleTemplates}}
+          @type="cluster"
+          @users={{model.users}}
+          data-testid="cru-cluster__members__form"
+        />
+      {{/accordion-list-item}}
+
+      {{form-labels-annotations
+        classNames="accordion-wrapper"
+        detailKey="clusterPage.annotationsDetail"
+        expandAll=al.expandAll
+        expandFn=expandFn
+        initialLabels=model.cluster.labels
+        model=model.cluster
+        readonlyLabels=readonlyLabels
+        editing=(and (and notView (not isRke2Cluster)) (not isEksClusterPending))
+      }}
+    {{/accordion-list}}
+    {{#if isImportedOther}}
+      {{#accordion-list showExpandAll=false as |al expandFn|}}
+        {{#accordion-list-item
+          title=(t "clusterNew.rke.advanced.label")
+          detail=(t "clusterNew.rke.advanced.detail")
+          expandAll=al.expandAll
+          everExpanded=true
+          expand=(action expandFn)
+        }}
+        <div class="row">
+          <div class="col span-6">
+            <label class="acc-label">
+              {{t "generic.networking"}}
             </label>
+            <div class="checkbox">
+              <label>
+                {{input type="checkbox" checked=cluster.enableNetworkPolicy}}
+                {{t "clusterNew.rke.networkPolicy.label"}}
+              </label>
+            </div>
+          </div>
+          <div class="col span-6">
+            {{#if cluster.enableNetworkPolicy}}
+              <BannerMessage
+                @icon="icon-alert"
+                @color="bg-warning mt-0"
+                @message={{t "clusterNew.import.clusterOptions.warning"}}
+              />
+            {{/if}}
           </div>
         </div>
-        <div class="col span-6">
-          {{#if cluster.enableNetworkPolicy}}
-            <BannerMessage
-              @icon="icon-alert"
-              @color="bg-warning mt-0"
-              @message={{t "clusterNew.import.clusterOptions.warning"}}
+        <div class="row">
+          <div class="col span-6">
+            <label class="acc-label">
+              {{t "clusterNew.rke.agentEnvVars.label"}}
+            </label>
+            <FormAgentEnvVar
+              @editable={{notView}}
+              @value={{mut agentEnvVars}}
             />
-          {{/if}}
+          </div>
         </div>
-      </div>
-      <div class="row">
-        <div class="col span-6">
-          <label class="acc-label">
-            {{t "clusterNew.rke.agentEnvVars.label"}}
-          </label>
-          <FormAgentEnvVar
-            @editable={{notView}}
-            @value={{mut agentEnvVars}}
-          />
-        </div>
-      </div>
-      {{/accordion-list-item}}
-    {{/accordion-list}}
+        {{/accordion-list-item}}
+      {{/accordion-list}}
+    {{/if}}
   {{/if}}
-{{/if}}
 
-{{#if showDriverComponent}}
-  {{component driverInfo.driverComponent
-    applyClusterTemplate=applyClusterTemplate
-    clusterTemplateQuestions=model.clusterTemplateRevision.questions
-    clusterTemplateRevisionId=clusterTemplateRevisionId
-    clusterErrors=errors
-    mode=mode
-    model=model
-    nodePoolErrors=nodePoolErrors
-    nodeWhich=driverInfo.nodeWhich
-    originalCluster=originalCluster
-    otherErrors=memberErrors
-    isEditCluster=isEdit
-    isPostSave=isPostSave
-    save=(action "save")
-    close=(action "close")
-    registerHook=(action "registerHook")
-    updateFromYaml=(action "updateFromYaml")
-  }}
-{{/if}}
+  {{#if showDriverComponent}}
+    {{component driverInfo.driverComponent
+      applyClusterTemplate=applyClusterTemplate
+      clusterTemplateQuestions=model.clusterTemplateRevision.questions
+      clusterTemplateRevisionId=clusterTemplateRevisionId
+      clusterErrors=errors
+      mode=mode
+      model=model
+      nodePoolErrors=nodePoolErrors
+      nodeWhich=driverInfo.nodeWhich
+      originalCluster=originalCluster
+      otherErrors=memberErrors
+      isEditCluster=isEdit
+      isPostSave=isPostSave
+      save=(action "save")
+      close=(action "close")
+      registerHook=(action "registerHook")
+      updateFromYaml=(action "updateFromYaml")
+    }}
+  {{/if}}
 
-{{!-- otherwise save is handled by the cluster driver component --}}
-{{#if (and isEdit (not provider))}}
-  {{top-errors errors=errors}}
-  {{save-cancel
-    editing=isEdit
-    save=(action "save" )
-    cancel=(action "close")
-  }}
-{{else if (not showDriverComponent)}}
-  {{!-- something is super wrong because your not import or custom or any driver in general so we're not letting you save --}}
-  {{save-cancel
-    saveDisabled=true
-    cancel=(action "close")
-  }}
+  {{!-- otherwise save is handled by the cluster driver component --}}
+  {{#if (and isEdit (not provider))}}
+    {{top-errors errors=errors}}
+    {{save-cancel
+      editing=isEdit
+      save=(action "save" )
+      cancel=(action "close")
+    }}
+  {{else if (not showDriverComponent)}}
+    {{!-- something is super wrong because your not import or custom or any driver in general so we're not letting you save --}}
+    {{save-cancel
+      saveDisabled=true
+      cancel=(action "close")
+    }}
+  {{/if}}
 {{/if}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1426,7 +1426,7 @@ clustersPage:
       label: "Add Cluster - Select Cluster Type"
     template:
       label: "Add Cluster - Select RKE Template"
-  rke1DeprecationMessage: 'Rancher Kubernetes Engine (RKE / RKE1) will reach end of life on July 31, 2025. Rancher 2.12.0 and later will no longer support provisioning or managing downstream RKE1 clusters. We recommend replatforming RKE1 clusters to RKE2 to ensure continued support and security updates. Learn more about the transition <a href="https://www.suse.com/support/kb/doc/?id=000021518" target="_blank" rel="noopener noreferrer nofollow">here</a>.'
+  emberDeprecationMessage: 'Support for UI Plugins (based on Ember) for cluster and node drivers was deprecated in Rancher 2.11.0 and will be removed in a future release. These need to be migrated to the new <a href="https://extensions.rancher.io" target="_blank" rel="noopener noreferrer nofollow">UI Extensions framework</a>.'
 
 clusterRibbonNav:
   title: Recent Clusters
@@ -3831,6 +3831,7 @@ clusterNew:
     noCloud: There are no cluster drivers enabled.
     noInfra: There are no node drivers enabled.
   externalError: Component could not be loaded. Check URL.
+  driverError: An error occurred loading the UI for this custom driver - please check driver configuration
 
   googlegke:
     access:


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/14286

This PR changes re-uses the RKE1 deprecation banner for deprecation of Ember-based UI plugins.

It also fixes a bug with the code that handles error loading custom javascript for a plugin and now correctly handles this and shows an error on the creation screen when this happens - previously users get a partially-rendered page.

To test:

- Enable a cluster driver from the Drivers page - suggested one is `Open Telekom Cloud CCE`

Go to create and choose this driver.

Check that the page shows the new deprecation banner:

![image](https://github.com/user-attachments/assets/33526ae5-9ead-4755-9949-e903b828f9e8)

Go the Drivers and edit the for the drvier  - add some junk to the end of the URL, eg:

![image](https://github.com/user-attachments/assets/cf58c000-bab2-46a8-92c8-abc038c06d7f)

Reload the UI (since the plugin is cached and we need to reload to remove it)

Go to the cluster create again and verify that the page shows the new error message and not a partially-rendered form:

![image](https://github.com/user-attachments/assets/1f5da219-50e0-4b41-8c33-1bfca1d69025)
