### PR TITLE
remove requests to load nodeTemplates during kontainer cluster provisioning

### DIFF
--- a/app/authenticated/cluster/edit/route.js
+++ b/app/authenticated/cluster/edit/route.js
@@ -28,7 +28,6 @@ export default Route.extend({
       cluster:                    cluster.clone(),
       cloudCredentials:           globalStore.findAll('cloudcredential'),
       kontainerDrivers:           globalStore.findAll('kontainerDriver'),
-      nodeTemplates:              globalStore.findAll('nodeTemplate'),
       nodeDrivers:                globalStore.findAll('nodeDriver'),
       psacs:                      globalStore.findAll('podSecurityAdmissionConfigurationTemplate'),
       roleTemplates:              this.roleTemplateService.get('allFilteredRoleTemplates'),

--- a/app/authenticated/route.js
+++ b/app/authenticated/route.js
@@ -103,7 +103,6 @@ export default Route.extend(Preload, {
           list.addObjects([
             this.preload('node', 'globalStore', { url: 'nodes' }),
             this.preload('nodePool', 'globalStore', { url: 'nodePools' }),
-            this.preload('noedTemplates', 'globalStore', { url: 'nodeTemplates' }),
             this.preload('roleTemplate', 'globalStore', {
               url:    'roleTemplates',
               filter: {

--- a/app/models/cloudcredential.js
+++ b/app/models/cloudcredential.js
@@ -9,6 +9,7 @@ const cloudCredential = Resource.extend({
   globalStore:    service(),
   nodeTemplates: hasMany('id', 'nodetemplate', 'cloudCredentialId', 'globalStore'),
 
+
   type: 'cloudCredential',
 
   canClone: false,

--- a/lib/global-admin/addon/clusters/new/launch/route.js
+++ b/lib/global-admin/addon/clusters/new/launch/route.js
@@ -92,7 +92,6 @@ export default Route.extend({
       me:                         get(this, 'access.principal'),
       cloudCredentials:           gs.findAll('cloudcredential'),
       clusterRoleTemplateBinding: gs.findAll('clusterRoleTemplateBinding'),
-      nodeTemplates:              gs.findAll('nodeTemplate'),
       psacs:                      gs.findAll('podSecurityAdmissionConfigurationTemplate'),
       users:                      gs.findAll('user'),
       clusterTemplates,


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/14753


The network tab showed additional 404's, but removing these requests to fetch node templates appears to be sufficient.