### PR TITLE
Remove Ember deprecation banner

### DIFF
--- a/app/authenticated/cluster/edit/template.hbs
+++ b/app/authenticated/cluster/edit/template.hbs
@@ -4,12 +4,6 @@
   </h1>
 </section>
 
-<BannerMessage
-  @color="bg-warning"
-  @icon="icon-alert"
-  @message={{t "clustersPage.emberDeprecationMessage" htmlSafe=true}}
-/>
-
 <CruCluster
   @applyClusterTemplate={{not (is-empty clusterTemplateRevision)}}
   @clusterTemplateRevisionId={{mut clusterTemplateRevision}}

--- a/lib/global-admin/addon/clusters/new/template.hbs
+++ b/lib/global-admin/addon/clusters/new/template.hbs
@@ -20,10 +20,5 @@
   </h1>
 </section>
 <section class="cluster-launch">
-  <BannerMessage
-    @color="bg-warning"
-    @icon="icon-alert"
-    @message={{t "clustersPage.emberDeprecationMessage" htmlSafe=true}}
-  />
   {{outlet}}
 </section>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1426,7 +1426,6 @@ clustersPage:
       label: "Add Cluster - Select Cluster Type"
     template:
       label: "Add Cluster - Select RKE Template"
-  emberDeprecationMessage: 'Support for UI Plugins (based on Ember) for cluster and node drivers was deprecated in Rancher 2.11.0 and will be removed in a future release. These need to be migrated to the new <a href="https://extensions.rancher.io" target="_blank" rel="noopener noreferrer nofollow">UI Extensions framework</a>.'
 
 clusterRibbonNav:
   title: Recent Clusters


### PR DESCRIPTION
Addresses: https://github.com/rancher/dashboard/issues/15257

This PR removes the Ember deprecation banner.

The banner will be moved to the Cluster Drivers page in the dashboard UI.

This PR removes the banner from the Edit and Create cluster pages:

<img width="994" height="408" alt="image" src="https://github.com/user-attachments/assets/4294e868-f4b8-4537-b0d3-1aa1b59e925c" />

<img width="994" height="408" alt="image" src="https://github.com/user-attachments/assets/e4ff1259-e5f1-4b37-b04a-98e72d1ca0e4" />

 