### PR TITLE
Add `--frozen-lockfile` to `yarn install` commands

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -9,7 +9,7 @@ else
   cd `dirname $CWD`
 fi
 
-yarn --pure-lockfile --non-interactive install
+yarn --frozen-lockfile --non-interactive install
 git submodule init
 git submodule update
 git status

--- a/scripts/patch-docker
+++ b/scripts/patch-docker
@@ -60,7 +60,7 @@ fi
 
 if [ ! -d node_modules ]; then
   echo -e "${YELLOW}node_modules folder does not exist - running yarn install${RESET}"
-  yarn install
+  yarn install --frozen-lockfile
   echo -e "${CYAN}Building production build of the UI${RESET}"
 fi
 

--- a/scripts/update-dependencies
+++ b/scripts/update-dependencies
@@ -17,7 +17,7 @@ git submodule update
 echo "Done"
 
 echo -n "Installing Yarn packages..."
-yarn install
+yarn install --frozen-lockfile
 echo "Done"
 
 echo "Done"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates yarn install usage to enforce `--frozen-lockfile` across all `yarn` and `yarn install` commands.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add `--frozen-lockfile` to yarn install commands

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

`--frozen-lockfile` makes installs deterministic by ensuring that yarn installs the exact dependency versions already defined in `yarn.lock`. If the lockfile is out of sync with `package.json`, the install fails immediately instead of silently re-resolving dependencies or mutating the lockfile. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

CI should pass without failure.

### Related work

- https://github.com/rancher/dashboard/pull/17101
